### PR TITLE
feat: git diff viewer and file tree refresh

### DIFF
--- a/server/api/filetree.go
+++ b/server/api/filetree.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -98,6 +99,88 @@ func (s *Server) handleFileTree(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"files": entries,
 		"cwd":   cwd,
+	})
+}
+
+func (s *Server) handleFileDiff(w http.ResponseWriter, r *http.Request) {
+	filePath := r.URL.Query().Get("path")
+	sessionID := r.URL.Query().Get("session_id")
+	if filePath == "" || sessionID == "" {
+		http.Error(w, `{"error":"path and session_id required"}`, http.StatusBadRequest)
+		return
+	}
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		return
+	}
+
+	cwd := sess.CWD
+	if cwd == "" {
+		cwd = sess.ProjectPath
+	}
+	if cwd == "" {
+		http.Error(w, `{"error":"session has no working directory"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Ensure the file is within the session's working directory
+	absPath, err := filepath.Abs(filePath)
+	if err != nil || !strings.HasPrefix(absPath, cwd) {
+		http.Error(w, `{"error":"file outside session directory"}`, http.StatusForbidden)
+		return
+	}
+
+	relPath, err := filepath.Rel(cwd, absPath)
+	if err != nil {
+		http.Error(w, `{"error":"failed to resolve path"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Try staged + unstaged diff first, then check for untracked files
+	cmd := exec.Command("git", "diff", "HEAD", "--", relPath)
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		// Might be an untracked file or only staged changes — try just `git diff`
+		cmd2 := exec.Command("git", "diff", "--", relPath)
+		cmd2.Dir = cwd
+		out2, _ := cmd2.Output()
+		if len(out2) > 0 {
+			out = out2
+		}
+	}
+
+	// If still no diff, check if it's a new untracked file — show full content as added
+	if len(out) == 0 {
+		cmd3 := exec.Command("git", "status", "--porcelain", "--", relPath)
+		cmd3.Dir = cwd
+		statusOut, _ := cmd3.Output()
+		statusLine := strings.TrimSpace(string(statusOut))
+		if strings.HasPrefix(statusLine, "??") || strings.HasPrefix(statusLine, "A") {
+			// Untracked or newly added — read file and format as "all new"
+			content, readErr := os.ReadFile(absPath)
+			if readErr == nil && len(content) > 0 {
+				// Cap at 1MB
+				if len(content) > 1024*1024 {
+					content = content[:1024*1024]
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"diff":    "",
+					"content": string(content),
+					"status":  "new",
+				})
+				return
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"diff":   string(out),
+		"status": "modified",
 	})
 }
 

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -58,6 +58,7 @@ func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager) http.Handle
 	apiMux.HandleFunc("GET /api/sessions/{id}/files", s.handleListSessionFiles)
 	apiMux.HandleFunc("GET /api/sessions/{id}/filetree", s.handleFileTree)
 	apiMux.HandleFunc("GET /api/files/content", s.handleGetFileContent)
+	apiMux.HandleFunc("GET /api/files/diff", s.handleFileDiff)
 
 	rl := NewRateLimiter(60, 10)
 	authedAPI := rl.Middleware(AuthMiddleware(apiKey, rl, apiMux))

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -48,6 +48,7 @@ document.addEventListener('alpine:init', () => {
     viewerFile: null,
     viewerMode: 'diff',
     viewerDiffs: [],
+    viewerDiffHtml: '',
     viewerContent: '',
     viewerLoading: false,
     viewerBinary: false,
@@ -808,17 +809,31 @@ document.addEventListener('alpine:init', () => {
 
     toggleDir(node) { node.open = !node.open; },
 
-    openFileViewer(filePath) {
+    async openFileViewer(filePath) {
       if (this.viewerFile === filePath) { this.closeFileViewer(); return; }
       this.viewerFile = filePath;
       this.viewerMode = 'diff';
       this.viewerContent = '';
-      this.viewerLoading = false;
+      this.viewerLoading = true;
       this.viewerBinary = false;
       this.viewerTruncated = false;
-      this.viewerDiffs = this.chatMessages
-        .filter(m => m.file_path === filePath && (m.msg_type === 'edit' || m.msg_type === 'write'))
-        .map(m => ({ old_string: m.old_string || '', new_string: m.new_string || '', content: m.content || '', type: m.msg_type }));
+      this.viewerDiffs = [];
+      this.viewerDiffHtml = '';
+
+      // Fetch git diff for this file
+      try {
+        const params = new URLSearchParams({ path: filePath, session_id: this.selectedSessionId });
+        const resp = await fetch('/api/files/diff?' + params, {
+          headers: { 'Authorization': 'Bearer ' + this.apiKey }
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          this.viewerDiffHtml = this.renderDiffHtml(data);
+        }
+      } catch (e) {
+        // Ignore — will show empty diff
+      }
+      this.viewerLoading = false;
     },
 
     async switchToFullView() {
@@ -852,9 +867,32 @@ document.addEventListener('alpine:init', () => {
       }
     },
 
+    renderDiffHtml(data) {
+      const esc = s => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      if (data.status === 'new' && data.content) {
+        return '<pre class="git-diff-content">' +
+          data.content.split('\n').map(l => '<span class="diff-line diff-add">' + esc('+ ' + l) + '</span>').join('\n') +
+          '</pre>';
+      }
+      if (data.diff) {
+        return '<pre class="git-diff-content">' +
+          data.diff.split('\n').map(l => {
+            let cls = '';
+            if (l.startsWith('+') && !l.startsWith('+++')) cls = 'diff-add';
+            else if (l.startsWith('-') && !l.startsWith('---')) cls = 'diff-remove';
+            else if (l.startsWith('@@')) cls = 'diff-hunk';
+            else if (l.startsWith('diff ') || l.startsWith('index ') || l.startsWith('---') || l.startsWith('+++')) cls = 'diff-meta';
+            return '<span class="diff-line' + (cls ? ' ' + cls : '') + '">' + esc(l) + '</span>';
+          }).join('\n') +
+          '</pre>';
+      }
+      return '';
+    },
+
     closeFileViewer() {
       this.viewerFile = null;
       this.viewerDiffs = [];
+      this.viewerDiffHtml = '';
       this.viewerContent = '';
     },
 

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -164,15 +164,9 @@
             </div>
             <div class="file-viewer-body">
               <div x-show="viewerMode === 'diff'" class="diff-view">
-                <template x-if="viewerDiffs.length === 0">
-                  <div class="diff-empty">No edits recorded for this file. Switch to Full view to see content.</div>
-                </template>
-                <template x-for="(diff, i) in viewerDiffs" :key="i">
-                  <div class="diff-block">
-                    <div class="diff-old" x-show="diff.old_string" x-text="diff.old_string"></div>
-                    <div class="diff-new" x-text="diff.new_string || diff.content"></div>
-                  </div>
-                </template>
+                <div x-show="viewerLoading" class="viewer-loading">Loading diff...</div>
+                <div x-show="!viewerLoading && !viewerDiffHtml" class="diff-empty">No changes detected for this file.</div>
+                <div x-show="!viewerLoading && viewerDiffHtml" x-html="viewerDiffHtml"></div>
               </div>
               <div x-show="viewerMode === 'full'" class="full-view">
                 <div x-show="viewerLoading" class="viewer-loading">Loading...</div>
@@ -190,6 +184,7 @@
         <div class="file-tree-header">
           <span>Files</span>
           <span class="file-count-badge" x-show="sessionFiles.length > 0" x-text="sessionFiles.length"></span>
+          <button class="file-tree-refresh" @click="loadSessionFiles(selectedSessionId)" title="Refresh files">↻</button>
         </div>
         <div class="file-tree-list">
           <template x-if="visibleFileNodes.length === 0">

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -486,6 +486,11 @@ body {
   background: var(--bg-secondary); color: var(--text-muted); font-size: 11px;
   padding: 2px 6px; border-radius: 8px; font-weight: 500;
 }
+.file-tree-refresh {
+  margin-left: auto; background: none; border: none; color: var(--text-muted);
+  cursor: pointer; font-size: 16px; padding: 2px 6px; border-radius: 4px; line-height: 1;
+}
+.file-tree-refresh:hover { color: var(--text-primary); background: var(--bg-secondary); }
 .file-tree-list { overflow-y: auto; flex: 1; padding: 4px 0; }
 .file-tree-empty { color: var(--text-muted); font-size: 13px; padding: 16px; text-align: center; }
 .file-tree-item {
@@ -542,6 +547,12 @@ body {
 .file-viewer-body .diff-old { background: color-mix(in srgb, var(--red) 12%, var(--bg)); padding: 8px 12px; white-space: pre-wrap; word-break: break-word; border-left: 3px solid var(--red); }
 .file-viewer-body .diff-new { background: color-mix(in srgb, var(--green) 12%, var(--bg)); padding: 8px 12px; white-space: pre-wrap; word-break: break-word; border-left: 3px solid var(--green); }
 .diff-empty { color: var(--text-muted); padding: 24px; text-align: center; }
+.git-diff-content { margin: 0; font-family: monospace; font-size: 12px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+.git-diff-content .diff-line { display: block; padding: 0 12px; }
+.git-diff-content .diff-add { background: color-mix(in srgb, var(--green) 12%, var(--bg)); color: var(--green); }
+.git-diff-content .diff-remove { background: color-mix(in srgb, var(--red) 12%, var(--bg)); color: var(--red); }
+.git-diff-content .diff-hunk { color: var(--accent); font-weight: 600; margin-top: 8px; }
+.git-diff-content .diff-meta { color: var(--text-muted); }
 .full-file-content { margin: 0; white-space: pre-wrap; word-break: break-word; }
 .viewer-loading, .viewer-binary, .viewer-truncated { color: var(--text-muted); padding: 8px 0; }
 .viewer-truncated { border-top: 1px solid var(--border); margin-top: 12px; padding-top: 12px; font-size: 11px; }


### PR DESCRIPTION
## Summary
- **Git diff endpoint**: New `GET /api/files/diff` endpoint that runs `git diff HEAD` for any file in a session working directory. Handles staged, unstaged, and untracked/new files.
- **Real diffs in file viewer**: Clicking any file with changes now fetches and displays the actual git diff with syntax-colored lines (additions, removals, hunks, metadata) instead of only showing edits from chat message history.
- **Refresh button**: Added a refresh button to the file tree sidebar header so users can reload the file list on-demand, without waiting for a Claude response.

## Test plan
- [ ] Click a file with M git status - verify unified diff is shown with colored add/remove lines
- [ ] Click an untracked file (?) - verify full content shown as additions
- [ ] Click a file with no changes - verify No changes detected message
- [ ] Click the refresh button - verify file tree reloads
- [ ] Verify `go build ./...` passes