### PR TITLE
feat: improve chat UI input, message persistence, and markdown

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -701,7 +701,7 @@ document.addEventListener('alpine:init', () => {
         if (!res.ok) return;
         const msgs = await res.json();
         this.chatMessages = (msgs || [])
-          .filter(m => m.role === 'assistant' || (m.role === 'system' && m.content && m.content.includes('"error"')))
+          .filter(m => m.role === 'user' || m.role === 'assistant' || (m.role === 'system' && m.content && m.content.includes('"error"')))
           .map(m => ({
             role: m.role,
             content: m.content,
@@ -852,6 +852,10 @@ document.addEventListener('alpine:init', () => {
       const time = `<span class="bubble-time">${esc(this.timeAgo(msg.timestamp))}</span>`;
 
       if (msg.msg_type === 'text') {
+        if (msg.role === 'assistant' && typeof marked !== 'undefined') {
+          const html = marked.parse(msg.content || '', { breaks: true });
+          return `<div class="markdown-content">${html}</div>${time}`;
+        }
         return `${esc(msg.content)}${time}`;
       }
       if (msg.msg_type === 'edit') {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Claude Controller</title>
   <link rel="stylesheet" href="/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script defer src="/app.js"></script>
   <script defer src="/alpine.min.js"></script>
 </head>
@@ -140,15 +141,17 @@
 
             <!-- Input bar (managed mode messages OR hook-mode instructions) -->
             <div class="instruction-bar" x-show="selectedSessionId && !currentPendingPrompt">
-              <input type="text" x-model="inputText"
+              <textarea x-model="inputText" rows="1"
                      :placeholder="currentSession?.mode === 'managed' ? 'Send a message... (type /resume to continue a previous session)' : 'Send instruction (delivered on next stop)...'"
-                     @keydown.enter="handleInput()"
-                     :disabled="inputSending">
+                     @keydown="if(($event.metaKey || $event.ctrlKey) && $event.key === 'Enter') { $event.preventDefault(); handleInput(); }"
+                     @input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 150) + 'px'"
+                     :disabled="inputSending"></textarea>
               <button class="btn btn-primary btn-sm" :disabled="!inputText.trim() || inputSending"
                       @click="handleInput()" style="width:auto">
                 <span x-show="!inputSuccess">Send</span>
                 <span x-show="inputSuccess" style="color:#16a34a">Sent!</span>
               </button>
+              <span class="input-hint">⌘↵ to send</span>
             </div>
           </div>
 

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -390,11 +390,11 @@ body {
   border-top: 1px solid var(--border);
   display: flex;
   gap: 0.5rem;
-  align-items: center;
+  align-items: flex-end;
   background: var(--bg-secondary);
   font-size: 0.8125rem;
 }
-.instruction-bar input {
+.instruction-bar textarea {
   flex: 1;
   padding: 0.375rem 0.625rem;
   border: 1px solid var(--border);
@@ -402,8 +402,19 @@ body {
   background: var(--bg);
   color: var(--text);
   font-size: 0.8125rem;
+  font-family: inherit;
+  resize: none;
+  overflow-y: auto;
+  min-height: 1.75rem;
+  max-height: 150px;
+  line-height: 1.4;
 }
-.instruction-bar input:focus { outline: 2px solid var(--accent); border-color: transparent; }
+.instruction-bar textarea:focus { outline: 2px solid var(--accent); border-color: transparent; }
+.instruction-bar .input-hint {
+  font-size: 0.625rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
 .instruction-bar .helper { font-size: 0.6875rem; color: var(--text-muted); }
 
 /* Connection banner */
@@ -536,6 +547,36 @@ body {
 .full-file-content { margin: 0; white-space: pre-wrap; word-break: break-word; }
 .viewer-loading, .viewer-binary, .viewer-truncated { color: var(--text-muted); padding: 8px 0; }
 .viewer-truncated { border-top: 1px solid var(--border); margin-top: 12px; padding-top: 12px; font-size: 11px; }
+
+/* Markdown content in assistant bubbles */
+.chat-bubble.assistant { white-space: normal; }
+.chat-bubble.user { white-space: pre-wrap; }
+.markdown-content { overflow-wrap: break-word; }
+.markdown-content p { margin: 0.25em 0; }
+.markdown-content p:first-child { margin-top: 0; }
+.markdown-content p:last-child { margin-bottom: 0; }
+.markdown-content pre {
+  background: rgba(0,0,0,0.25); padding: 0.5em 0.75em; border-radius: 6px;
+  overflow-x: auto; font-size: 0.8em; margin: 0.5em 0; line-height: 1.4;
+}
+.markdown-content code {
+  background: rgba(0,0,0,0.15); padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.85em;
+}
+.markdown-content pre code { background: none; padding: 0; font-size: inherit; }
+.markdown-content ul, .markdown-content ol { margin: 0.25em 0; padding-left: 1.5em; }
+.markdown-content li { margin: 0.15em 0; }
+.markdown-content h1, .markdown-content h2, .markdown-content h3 {
+  margin: 0.5em 0 0.25em; font-size: 1em; font-weight: 600;
+}
+.markdown-content blockquote {
+  border-left: 3px solid var(--border); margin: 0.5em 0; padding: 0.25em 0.75em;
+  color: var(--text-muted);
+}
+.markdown-content a { color: inherit; text-decoration: underline; }
+.markdown-content table { border-collapse: collapse; margin: 0.5em 0; font-size: 0.85em; }
+.markdown-content th, .markdown-content td {
+  border: 1px solid var(--border); padding: 0.25em 0.5em;
+}
 
 @media (max-width: 768px) {
   .sidebar { display: none; }


### PR DESCRIPTION
## Summary
- **Multiline input**: Changed chat input from `<input>` to auto-growing `<textarea>`. Enter creates newlines; Cmd/Ctrl+Enter sends. Includes "⌘↵ to send" hint.
- **User message persistence**: Fixed `fetchManagedMessages()` filtering out user messages, causing them to disappear on session switch or page refresh.
- **Markdown rendering**: Assistant messages now render markdown (code blocks, lists, tables, headings, etc.) via `marked.js`. User messages remain plain text.

## Test plan
- [ ] Open a managed session, send a message, switch sessions, switch back — user message should still be visible
- [ ] Refresh the page — user messages should persist
- [ ] Type multiline text in the input bar using Enter, then send with Cmd+Enter
- [ ] Verify assistant responses render markdown (code blocks, bold, lists, etc.)
- [ ] Verify user messages do NOT render markdown (plain text only)