### PR TITLE
feat: add git status bar to file tree sidebar

### DIFF
--- a/server/api/filetree.go
+++ b/server/api/filetree.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -95,10 +96,14 @@ func (s *Server) handleFileTree(w http.ResponseWriter, r *http.Request) {
 		entries = []fileTreeEntry{}
 	}
 
+	// Get git branch and summary info
+	gitInfo := gitSummary(cwd)
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"files": entries,
 		"cwd":   cwd,
+		"git":   gitInfo,
 	})
 }
 
@@ -220,6 +225,83 @@ func gitListFiles(cwd string) ([]string, error) {
 	}
 
 	return files, nil
+}
+
+type gitSummaryInfo struct {
+	Branch    string `json:"branch"`
+	Modified  int    `json:"modified"`
+	Added     int    `json:"added"`
+	Deleted   int    `json:"deleted"`
+	Untracked int    `json:"untracked"`
+	Staged    int    `json:"staged"`
+	Ahead     int    `json:"ahead"`
+	Behind    int    `json:"behind"`
+}
+
+func gitSummary(cwd string) gitSummaryInfo {
+	info := gitSummaryInfo{}
+
+	// Get branch name
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = cwd
+	if out, err := cmd.Output(); err == nil {
+		info.Branch = strings.TrimSpace(string(out))
+	}
+
+	// Get ahead/behind from tracking branch
+	cmd2 := exec.Command("git", "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
+	cmd2.Dir = cwd
+	if out, err := cmd2.Output(); err == nil {
+		parts := strings.Fields(strings.TrimSpace(string(out)))
+		if len(parts) == 2 {
+			if n, err := parseInt(parts[0]); err == nil {
+				info.Behind = n
+			}
+			if n, err := parseInt(parts[1]); err == nil {
+				info.Ahead = n
+			}
+		}
+	}
+
+	// Parse porcelain status for file counts
+	cmd3 := exec.Command("git", "status", "--porcelain")
+	cmd3.Dir = cwd
+	if out, err := cmd3.Output(); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if len(line) < 3 {
+				continue
+			}
+			x, y := line[0], line[1]
+			// Staged changes (index column)
+			if x == 'M' || x == 'A' || x == 'D' || x == 'R' {
+				info.Staged++
+			}
+			// Working tree changes
+			switch {
+			case x == '?' && y == '?':
+				info.Untracked++
+			case y == 'M':
+				info.Modified++
+			case y == 'D':
+				info.Deleted++
+			case y == 'A':
+				info.Added++
+			}
+		}
+	}
+
+	return info
+}
+
+func parseInt(s string) (int, error) {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a number")
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, nil
 }
 
 // gitStatus returns a map of relative path -> status code

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -45,6 +45,7 @@ document.addEventListener('alpine:init', () => {
     // File browser state
     sessionFiles: [],
     fileTreeData: [],
+    gitInfo: null,
     viewerFile: null,
     viewerMode: 'diff',
     viewerDiffs: [],
@@ -730,7 +731,7 @@ document.addEventListener('alpine:init', () => {
     // File browser methods
     async loadSessionFiles(sessionId) {
       this.renderedContentCache = {};
-      if (!sessionId) { this.sessionFiles = []; this.fileTreeData = []; return; }
+      if (!sessionId) { this.sessionFiles = []; this.fileTreeData = []; this.gitInfo = null; return; }
       try {
         const resp = await fetch(`/api/sessions/${sessionId}/filetree`, {
           headers: { 'Authorization': 'Bearer ' + this.apiKey }
@@ -740,18 +741,21 @@ document.addEventListener('alpine:init', () => {
           const fallback = await fetch(`/api/sessions/${sessionId}/files`, {
             headers: { 'Authorization': 'Bearer ' + this.apiKey }
           });
-          if (!fallback.ok) { this.sessionFiles = []; this.fileTreeData = []; return; }
+          if (!fallback.ok) { this.sessionFiles = []; this.fileTreeData = []; this.gitInfo = null; return; }
           const data = await fallback.json();
           this.sessionFiles = data.files || [];
           this.fileTreeData = this.buildFileTree(this.sessionFiles);
+          this.gitInfo = null;
           return;
         }
         const data = await resp.json();
         this.sessionFiles = data.files || [];
         this.fileTreeData = this.buildFileTree(this.sessionFiles);
+        this.gitInfo = data.git || null;
       } catch (e) {
         this.sessionFiles = [];
         this.fileTreeData = [];
+        this.gitInfo = null;
       }
     },
 

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -214,6 +214,24 @@
             </div>
           </template>
         </div>
+        <div class="git-status-bar" x-show="gitInfo">
+          <div class="git-branch-row">
+            <span class="git-branch-icon">⎇</span>
+            <span class="git-branch-name" x-text="gitInfo?.branch || 'detached'"></span>
+            <span class="git-ahead" x-show="gitInfo?.ahead > 0" x-text="'↑' + gitInfo?.ahead" title="Commits ahead of remote"></span>
+            <span class="git-behind" x-show="gitInfo?.behind > 0" x-text="'↓' + gitInfo?.behind" title="Commits behind remote"></span>
+          </div>
+          <div class="git-file-counts" x-show="gitInfo?.modified || gitInfo?.added || gitInfo?.deleted || gitInfo?.untracked || gitInfo?.staged">
+            <span class="git-stat git-stat-staged" x-show="gitInfo?.staged > 0" x-text="gitInfo?.staged + ' staged'" title="Staged changes"></span>
+            <span class="git-stat git-stat-modified" x-show="gitInfo?.modified > 0" x-text="gitInfo?.modified + ' modified'" title="Modified files"></span>
+            <span class="git-stat git-stat-added" x-show="gitInfo?.added > 0" x-text="gitInfo?.added + ' added'" title="Added files"></span>
+            <span class="git-stat git-stat-deleted" x-show="gitInfo?.deleted > 0" x-text="gitInfo?.deleted + ' deleted'" title="Deleted files"></span>
+            <span class="git-stat git-stat-untracked" x-show="gitInfo?.untracked > 0" x-text="gitInfo?.untracked + ' untracked'" title="Untracked files"></span>
+          </div>
+          <div class="git-clean" x-show="!gitInfo?.modified && !gitInfo?.added && !gitInfo?.deleted && !gitInfo?.untracked && !gitInfo?.staged">
+            <span class="git-clean-text">Working tree clean</span>
+          </div>
+        </div>
       </div>
     </div>
   </template>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -528,6 +528,30 @@ body {
 .file-tree-action.action-write { color: var(--green); }
 .file-tree-action.action-read { color: var(--text-muted); }
 
+/* Git Status Bar */
+.git-status-bar {
+  border-top: 1px solid var(--border); padding: 10px 12px;
+  font-size: 12px; background: var(--bg-secondary); flex-shrink: 0;
+}
+.git-branch-row {
+  display: flex; align-items: center; gap: 6px; font-weight: 600; margin-bottom: 4px;
+}
+.git-branch-icon { font-size: 14px; color: var(--text-muted); }
+.git-branch-name { color: var(--accent); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.git-ahead { color: var(--green); font-size: 11px; font-weight: 500; }
+.git-behind { color: var(--yellow); font-size: 11px; font-weight: 500; }
+.git-file-counts {
+  display: flex; flex-wrap: wrap; gap: 4px 8px; color: var(--text-muted); font-size: 11px;
+}
+.git-stat { white-space: nowrap; }
+.git-stat-staged { color: var(--green); }
+.git-stat-modified { color: var(--yellow); }
+.git-stat-added { color: var(--green); }
+.git-stat-deleted { color: var(--red); }
+.git-stat-untracked { color: var(--text-muted); }
+.git-clean { color: var(--text-muted); font-size: 11px; }
+.git-clean-text { font-style: italic; }
+
 /* Main content split */
 .main-content-split { display: flex; flex: 1; overflow: hidden; }
 .chat-column { display: flex; flex-direction: column; flex: 1; min-width: 0; overflow: hidden; }


### PR DESCRIPTION
## Summary
- Adds a git status bar at the bottom of the file tree sidebar showing branch name, ahead/behind indicators, and working tree file counts
- New `gitSummary()` backend function returns branch, ahead/behind, and categorized file status counts (modified, staged, added, deleted, untracked)
- Color-coded display: green for staged/added, yellow for modified/behind, red for deleted, muted for untracked
- Shows "Working tree clean" when there are no uncommitted changes

## Test plan
- [ ] Open a session with a git repo — verify branch name displays correctly
- [ ] Make local changes — verify modified/untracked counts update on refresh
- [ ] Stage files — verify staged count appears
- [ ] Push commits — verify ahead/behind indicators work
- [ ] Check clean repo — verify "Working tree clean" message shows