### PR TITLE
fix: open markdown links in new tab

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -963,7 +963,15 @@ document.addEventListener('alpine:init', () => {
 
       if (msg.msg_type === 'text') {
         if (msg.role === 'assistant' && typeof marked !== 'undefined') {
-          const html = marked.parse(msg.content || '', { breaks: true });
+          const r = new marked.Renderer();
+          r.link = function(href, title, text) {
+            const h = typeof href === 'object' ? href.href : href;
+            const t = typeof href === 'object' ? href.title : title;
+            const tx = typeof href === 'object' ? href.text : text;
+            const titleAttr = t ? ` title="${t}"` : '';
+            return `<a href="${h}" target="_blank" rel="noopener noreferrer"${titleAttr}>${tx}</a>`;
+          };
+          const html = marked.parse(msg.content || '', { renderer: r, breaks: true });
           return `<div class="markdown-content">${html}</div>${time}`;
         }
         return `${esc(msg.content)}${time}`;
@@ -1129,6 +1137,13 @@ document.addEventListener('alpine:init', () => {
 
       const renderer = new marked.Renderer();
       const self = this;
+      renderer.link = function(href, title, text) {
+        const h = typeof href === 'object' ? href.href : href;
+        const t = typeof href === 'object' ? href.title : title;
+        const tx = typeof href === 'object' ? href.text : text;
+        const titleAttr = t ? ` title="${self.escapeHtml(t)}"` : '';
+        return `<a href="${self.escapeHtml(h)}" target="_blank" rel="noopener noreferrer"${titleAttr}>${tx}</a>`;
+      };
       renderer.code = function(code, language) {
         const text = typeof code === 'object' ? code.text : code;
         const lang = typeof code === 'object' ? code.lang : language;


### PR DESCRIPTION
## Summary
- Links in chat messages and the markdown file viewer were replacing the current tab when clicked
- Added target=_blank rel=noopener noreferrer to all anchor tags rendered by marked.js
- Applies to both chat bubble rendering and the file viewer markdown renderer

## Test plan
- [ ] Send a message from Claude that contains a URL and verify clicking it opens in a new tab
- [ ] Open a markdown file in the file viewer that contains links, verify they open in new tabs