### PR TITLE
feat: GitHub issue picker in web UI

### DIFF
--- a/docs/superpowers/plans/2026-03-22-issue-picker.md
+++ b/docs/superpowers/plans/2026-03-22-issue-picker.md
@@ -1,0 +1,911 @@
+# Issue Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub issue picker to the web UI's right sidebar that lets users browse, search, and select issues, then generate a structured prompt for Claude to work on.
+
+**Architecture:** New Go handler file (`github.go`) shells out to the `gh` CLI in the session's CWD. Frontend adds an issues section below the git branch info in the right sidebar using Alpine.js state management. "Generate Prompt" populates the existing chat textarea.
+
+**Tech Stack:** Go (backend handlers, `exec.Command` for `gh` CLI), Alpine.js (frontend state), HTML/CSS (UI), marked.js (markdown rendering, already loaded).
+
+**Spec:** `docs/superpowers/specs/2026-03-22-issue-picker-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `server/api/github.go` | Create | GitHub issue list/detail handlers, `gh` CLI interaction, response structs |
+| `server/api/github_test.go` | Create | Tests for GitHub handlers (mocked `gh` CLI output) |
+| `server/api/router.go` | Modify (lines 57-61) | Register two new routes |
+| `server/web/static/index.html` | Modify (after line 248) | Issues section HTML in right sidebar |
+| `server/web/static/app.js` | Modify | Alpine.js state, fetch methods, prompt generation |
+| `server/web/static/style.css` | Modify | CSS for issues section, rows, detail panel |
+
+---
+
+### Task 1: Backend — GitHub Issue List Handler
+
+**Files:**
+- Create: `server/api/github.go`
+- Create: `server/api/github_test.go`
+
+- [ ] **Step 1: Write the test for listing issues**
+
+```go
+// server/api/github_test.go
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListGithubIssuesRequiresManagedSession(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+
+	// Register a hook-mode session (no CWD)
+	store.RegisterSession("hook-session", "host1", "/some/path")
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/hook-session/github/issues", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for hook session, got %d", resp.StatusCode)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./api/ -v -run TestListGithubIssuesRequiresManagedSession`
+Expected: FAIL — `handleListGithubIssues` does not exist yet
+
+- [ ] **Step 3: Create `github.go` with structs and list handler**
+
+```go
+// server/api/github.go
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+// Raw structs matching gh CLI JSON output
+type ghAuthor struct {
+	Login string `json:"login"`
+}
+
+type ghLabel struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type ghIssue struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"createdAt"`
+	Author    ghAuthor  `json:"author"`
+	Labels    []ghLabel `json:"labels"`
+	Body      string    `json:"body,omitempty"`
+}
+
+// Response structs (reshaped for frontend)
+type issueLabel struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type issueResponse struct {
+	Number    int          `json:"number"`
+	Title     string       `json:"title"`
+	State     string       `json:"state"`
+	CreatedAt time.Time    `json:"created_at"`
+	Author    string       `json:"author"`
+	Labels    []issueLabel `json:"labels"`
+	Body      string       `json:"body,omitempty"`
+}
+
+type issueListResponse struct {
+	Repo    string          `json:"repo"`
+	Issues  []issueResponse `json:"issues"`
+	HasMore bool            `json:"has_more"`
+}
+
+func reshapeIssue(gh ghIssue) issueResponse {
+	labels := make([]issueLabel, len(gh.Labels))
+	for i, l := range gh.Labels {
+		labels[i] = issueLabel{Name: l.Name, Color: l.Color}
+	}
+	if labels == nil {
+		labels = []issueLabel{}
+	}
+	return issueResponse{
+		Number:    gh.Number,
+		Title:     gh.Title,
+		State:     gh.State,
+		CreatedAt: gh.CreatedAt,
+		Author:    gh.Author.Login,
+		Labels:    labels,
+		Body:      gh.Body,
+	}
+}
+
+func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		return
+	}
+
+	// Only managed sessions have a CWD
+	if sess.Mode != "managed" || sess.CWD == "" {
+		http.Error(w, `{"error":"issue picker requires a managed session with a working directory"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Parse query params
+	state := r.URL.Query().Get("state")
+	if state == "" {
+		state = "open"
+	}
+	if state != "open" && state != "closed" {
+		http.Error(w, `{"error":"state must be open or closed"}`, http.StatusBadRequest)
+		return
+	}
+
+	search := r.URL.Query().Get("search")
+
+	limitStr := r.URL.Query().Get("limit")
+	limit := 10
+	if limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 && l <= 100 {
+			limit = l
+		}
+	}
+
+	// Detect repo name
+	repoCmd := exec.Command("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+	repoCmd.Dir = sess.CWD
+	repoOut, err := repoCmd.Output()
+	if err != nil {
+		http.Error(w, `{"error":"failed to detect GitHub repo — is gh CLI installed and authenticated?"}`, http.StatusInternalServerError)
+		return
+	}
+	repo := strings.TrimSpace(string(repoOut))
+
+	// Build gh issue list command
+	// Fetch limit+1 to determine has_more
+	args := []string{"issue", "list", "--state", state, "--limit", strconv.Itoa(limit + 1), "--json", "number,title,state,createdAt,author,labels"}
+	if search != "" {
+		args = append(args, "--search", search)
+	}
+
+	cmd := exec.Command("gh", args...)
+	cmd.Dir = sess.CWD
+	out, err := cmd.Output()
+	if err != nil {
+		http.Error(w, `{"error":"failed to list issues — check gh CLI auth"}`, http.StatusInternalServerError)
+		return
+	}
+
+	var ghIssues []ghIssue
+	if err := json.Unmarshal(out, &ghIssues); err != nil {
+		http.Error(w, `{"error":"failed to parse gh output"}`, http.StatusInternalServerError)
+		return
+	}
+
+	hasMore := len(ghIssues) > limit
+	if hasMore {
+		ghIssues = ghIssues[:limit]
+	}
+
+	issues := make([]issueResponse, len(ghIssues))
+	for i, gh := range ghIssues {
+		issues[i] = reshapeIssue(gh)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(issueListResponse{
+		Repo:    repo,
+		Issues:  issues,
+		HasMore: hasMore,
+	})
+}
+```
+
+Note: Add `"strings"` to the import block (already shown in the import list above).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && go test ./api/ -v -run TestListGithubIssuesRequiresManagedSession`
+Expected: PASS
+
+- [ ] **Step 5: Register route in router.go**
+
+Add after line 61 in `server/api/router.go` (after the file browser endpoints):
+
+```go
+	// GitHub issue endpoints
+	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues", s.handleListGithubIssues)
+```
+
+- [ ] **Step 6: Run all tests to verify nothing is broken**
+
+Run: `cd server && go test ./api/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/api/github.go server/api/github_test.go server/api/router.go
+git commit -m "feat: add GitHub issue list API endpoint"
+```
+
+---
+
+### Task 2: Backend — GitHub Issue Detail Handler
+
+**Files:**
+- Modify: `server/api/github.go`
+- Modify: `server/api/github_test.go`
+- Modify: `server/api/router.go`
+
+- [ ] **Step 1: Write the test for issue detail**
+
+Append to `server/api/github_test.go`:
+
+```go
+func TestGetGithubIssueRequiresManagedSession(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+
+	store.RegisterSession("hook-session", "host1", "/some/path")
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/hook-session/github/issues/1", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for hook session, got %d", resp.StatusCode)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./api/ -v -run TestGetGithubIssueRequiresManagedSession`
+Expected: FAIL — `handleGetGithubIssue` does not exist yet
+
+- [ ] **Step 3: Add detail handler to `github.go`**
+
+Append to `server/api/github.go`:
+
+```go
+func (s *Server) handleGetGithubIssue(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	number := r.PathValue("number")
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		return
+	}
+
+	if sess.Mode != "managed" || sess.CWD == "" {
+		http.Error(w, `{"error":"issue picker requires a managed session with a working directory"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Validate number is numeric
+	if _, err := strconv.Atoi(number); err != nil {
+		http.Error(w, `{"error":"invalid issue number"}`, http.StatusBadRequest)
+		return
+	}
+
+	cmd := exec.Command("gh", "issue", "view", number, "--json", "number,title,state,body,createdAt,author,labels")
+	cmd.Dir = sess.CWD
+	out, err := cmd.Output()
+	if err != nil {
+		http.Error(w, `{"error":"failed to fetch issue"}`, http.StatusInternalServerError)
+		return
+	}
+
+	var gh ghIssue
+	if err := json.Unmarshal(out, &gh); err != nil {
+		http.Error(w, `{"error":"failed to parse gh output"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reshapeIssue(gh))
+}
+```
+
+- [ ] **Step 4: Register the route in router.go**
+
+Add after the issues list route:
+
+```go
+	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues/{number}", s.handleGetGithubIssue)
+```
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cd server && go test ./api/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Build to verify compilation**
+
+Run: `cd server && go build -o claude-controller .`
+Expected: Compiles successfully
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/api/github.go server/api/github_test.go server/api/router.go
+git commit -m "feat: add GitHub issue detail API endpoint"
+```
+
+---
+
+### Task 3: Frontend — CSS Styles for Issues Section
+
+**Files:**
+- Modify: `server/web/static/style.css` (append after the git status bar styles around line 553)
+
+- [ ] **Step 1: Add CSS for the issues section**
+
+Append after the `.git-clean` block (around line 553) in `style.css`:
+
+```css
+/* GitHub Issues Section */
+.issues-section {
+    padding: 8px 12px;
+    border-top: 1px solid var(--border);
+}
+
+.issues-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.issues-title {
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text);
+}
+
+.issue-state-toggles {
+    display: flex;
+    gap: 4px;
+}
+
+.issue-state-toggle {
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 10px;
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    transition: all 0.15s;
+}
+
+.issue-state-toggle.active-open {
+    background: #238636;
+    border-color: #238636;
+    color: #fff;
+}
+
+.issue-state-toggle.active-closed {
+    background: #8957e5;
+    border-color: #8957e5;
+    color: #fff;
+}
+
+.issues-search {
+    width: 100%;
+    box-sizing: border-box;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 5px 8px;
+    color: var(--text);
+    font-size: 11px;
+    margin-bottom: 8px;
+}
+
+.issues-search::placeholder {
+    color: var(--text-muted);
+}
+
+.issue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.issue-row {
+    padding: 6px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    display: flex;
+    gap: 6px;
+    align-items: flex-start;
+    transition: background 0.1s;
+}
+
+.issue-row:hover {
+    background: var(--bg-secondary);
+}
+
+.issue-dot {
+    font-size: 14px;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.issue-dot.open { color: #238636; }
+.issue-dot.closed { color: #8957e5; }
+
+.issue-row-title {
+    font-size: 11px;
+    line-height: 1.3;
+    color: var(--text);
+}
+
+.issue-row-meta {
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.issues-show-more {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 8px;
+    cursor: pointer;
+}
+
+.issues-show-more:hover {
+    color: var(--accent);
+}
+
+.issues-loading, .issues-error, .issues-empty {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 12px 0;
+}
+
+.issues-error {
+    color: var(--danger, #c05050);
+}
+
+/* Issue Detail Panel */
+.issue-detail {
+    padding: 4px 0;
+}
+
+.issue-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 8px;
+}
+
+.issue-detail-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.3;
+}
+
+.issue-detail-meta {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.issue-detail-close {
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 4px;
+}
+
+.issue-detail-close:hover {
+    color: var(--text);
+}
+
+.issue-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 10px;
+}
+
+.issue-label {
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-weight: 500;
+}
+
+.issue-body {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text);
+    max-height: 200px;
+    overflow-y: auto;
+    margin-bottom: 12px;
+}
+
+.issue-body p { margin: 0 0 8px 0; }
+.issue-body p:last-child { margin-bottom: 0; }
+.issue-body code { background: var(--bg); padding: 1px 4px; border-radius: 3px; font-size: 11px; }
+.issue-body pre { background: var(--bg); padding: 8px; border-radius: 4px; overflow-x: auto; }
+
+.generate-prompt-btn {
+    width: 100%;
+    background: #238636;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.generate-prompt-btn:hover {
+    background: #2ea043;
+}
+
+.generate-prompt-hint {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-align: center;
+    margin-top: 4px;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/web/static/style.css
+git commit -m "feat: add CSS styles for GitHub issues section"
+```
+
+---
+
+### Task 4: Frontend — Alpine.js State and Methods
+
+**Files:**
+- Modify: `server/web/static/app.js`
+
+- [ ] **Step 1: Add state properties**
+
+Add these properties to the Alpine.js `data()` return object (around where `gitInfo: null` is defined, near line 48):
+
+```javascript
+githubIssues: [],
+githubIssuesState: 'open',
+githubIssuesSearch: '',
+githubIssuesLimit: 10,
+githubIssuesHasMore: false,
+githubIssuesLoading: false,
+githubIssuesError: null,
+selectedIssue: null,
+selectedIssueLoading: false,
+```
+
+- [ ] **Step 2: Add fetch methods**
+
+Add these methods to the Alpine.js component (near the `loadSessionFiles` method, around line 794):
+
+```javascript
+async fetchGithubIssues(sessionId) {
+  if (!sessionId) return;
+  this.githubIssuesLoading = true;
+  this.githubIssuesError = null;
+  try {
+    const params = new URLSearchParams({
+      state: this.githubIssuesState,
+      limit: this.githubIssuesLimit.toString(),
+    });
+    if (this.githubIssuesSearch) {
+      params.set('search', this.githubIssuesSearch);
+    }
+    const res = await fetch(`/api/sessions/${sessionId}/github/issues?${params}`, {
+      headers: { 'Authorization': 'Bearer ' + this.apiKey }
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      this.githubIssuesError = data.error || 'Failed to load issues';
+      return;
+    }
+    const data = await res.json();
+    this.githubIssues = data.issues || [];
+    this.githubIssuesHasMore = data.has_more || false;
+  } catch (e) {
+    this.githubIssuesError = 'Failed to load issues';
+  } finally {
+    this.githubIssuesLoading = false;
+  }
+},
+
+async fetchIssueDetail(sessionId, number) {
+  this.selectedIssueLoading = true;
+  try {
+    const res = await fetch(`/api/sessions/${sessionId}/github/issues/${number}`, {
+      headers: { 'Authorization': 'Bearer ' + this.apiKey }
+    });
+    if (!res.ok) return;
+    this.selectedIssue = await res.json();
+  } catch (e) {
+    // ignore
+  } finally {
+    this.selectedIssueLoading = false;
+  }
+},
+
+toggleIssueState(state) {
+  this.githubIssuesState = state;
+  this.githubIssuesLimit = 10;
+  this.selectedIssue = null;
+  this.fetchGithubIssues(this.selectedSessionId);
+},
+
+searchIssuesDebounced: null,
+
+searchIssues() {
+  clearTimeout(this.searchIssuesDebounced);
+  this.searchIssuesDebounced = setTimeout(() => {
+    this.githubIssuesLimit = 10;
+    this.selectedIssue = null;
+    this.fetchGithubIssues(this.selectedSessionId);
+  }, 300);
+},
+
+loadMoreIssues() {
+  this.githubIssuesLimit += 10;
+  this.fetchGithubIssues(this.selectedSessionId);
+},
+
+generateIssuePrompt(issue) {
+  const prompt = `Work on GitHub issue #${issue.number}: "${issue.title}"
+
+Requirements:
+${issue.body || '(No description provided)'}
+
+Create a feature branch, implement the solution, and open a draft PR linking to issue #${issue.number}.`;
+  this.inputText = prompt;
+  // Trigger textarea resize
+  this.$nextTick(() => {
+    const ta = this.$el.querySelector('.instruction-bar textarea');
+    if (ta) {
+      ta.style.height = 'auto';
+      ta.style.height = Math.min(ta.scrollHeight, 150) + 'px';
+    }
+  });
+},
+
+issueTimeAgo(dateStr) {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 60) return diffMins + 'm ago';
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return diffHours + 'h ago';
+  const diffDays = Math.floor(diffHours / 24);
+  return diffDays + 'd ago';
+},
+
+issueLabelStyle(label) {
+  if (!label.color) return '';
+  const r = parseInt(label.color.substring(0, 2), 16);
+  const g = parseInt(label.color.substring(2, 4), 16);
+  const b = parseInt(label.color.substring(4, 6), 16);
+  // Use label color at low opacity for background, full for text
+  return `background:rgba(${r},${g},${b},0.2);color:#${label.color};border:1px solid rgba(${r},${g},${b},0.4)`;
+},
+```
+
+- [ ] **Step 3: Trigger issue loading on session select**
+
+In the `selectSession` method (around line 366), add after `this.loadSessionFiles(this.selectedSessionId);`:
+
+```javascript
+// Load GitHub issues for managed sessions
+if (sess && sess.mode === 'managed') {
+  this.githubIssues = [];
+  this.githubIssuesState = 'open';
+  this.githubIssuesSearch = '';
+  this.githubIssuesLimit = 10;
+  this.selectedIssue = null;
+  this.githubIssuesError = null;
+  this.fetchGithubIssues(this.selectedSessionId);
+}
+```
+
+- [ ] **Step 4: Verify the app loads without errors**
+
+Run: `cd server && go build -o claude-controller . && ./claude-controller`
+Expected: Server starts, web UI loads without JS console errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/web/static/app.js
+git commit -m "feat: add Alpine.js state and methods for GitHub issues"
+```
+
+---
+
+### Task 5: Frontend — HTML Issues Section
+
+**Files:**
+- Modify: `server/web/static/index.html` (insert after line 248, before the closing `</div>` of the sidebar)
+
+- [ ] **Step 1: Add the issues section HTML**
+
+Insert after line 248 (after the `git-status-bar` div closing tag) and before line 249 (`</div>` sidebar close):
+
+```html
+        <!-- GitHub Issues Section -->
+        <div class="issues-section" x-show="gitInfo && currentSession?.mode === 'managed'">
+          <template x-if="!selectedIssue">
+            <div>
+              <div class="issues-header">
+                <span class="issues-title">Issues</span>
+                <div class="issue-state-toggles">
+                  <span class="issue-state-toggle" :class="githubIssuesState === 'open' ? 'active-open' : ''"
+                        @click="toggleIssueState('open')">Open</span>
+                  <span class="issue-state-toggle" :class="githubIssuesState === 'closed' ? 'active-closed' : ''"
+                        @click="toggleIssueState('closed')">Closed</span>
+                </div>
+              </div>
+              <input class="issues-search" type="text" placeholder="Search issues..."
+                     x-model="githubIssuesSearch" @input="searchIssues()">
+              <div x-show="githubIssuesLoading" class="issues-loading">Loading issues...</div>
+              <div x-show="githubIssuesError && !githubIssuesLoading" class="issues-error">
+                <span x-text="githubIssuesError"></span>
+                <span style="cursor:pointer;text-decoration:underline;margin-left:4px"
+                      @click="fetchGithubIssues(selectedSessionId)">Retry</span>
+              </div>
+              <div x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length === 0" class="issues-empty">
+                No issues found
+              </div>
+              <div class="issue-list" x-show="!githubIssuesLoading && !githubIssuesError">
+                <template x-for="issue in githubIssues" :key="issue.number">
+                  <div class="issue-row" @click="fetchIssueDetail(selectedSessionId, issue.number)">
+                    <span class="issue-dot" :class="issue.state === 'OPEN' ? 'open' : 'closed'"
+                          x-text="issue.state === 'OPEN' ? '●' : '●'"></span>
+                    <div>
+                      <div class="issue-row-title" x-text="issue.title"></div>
+                      <div class="issue-row-meta">
+                        <span x-text="'#' + issue.number"></span> ·
+                        <span x-text="issueTimeAgo(issue.created_at)"></span>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+              </div>
+              <div class="issues-show-more" x-show="githubIssuesHasMore && !githubIssuesLoading"
+                   @click="loadMoreIssues()">Show more ↓</div>
+            </div>
+          </template>
+          <template x-if="selectedIssue">
+            <div class="issue-detail">
+              <div class="issue-detail-header">
+                <div>
+                  <div class="issue-detail-title" x-text="selectedIssue.title"></div>
+                  <div class="issue-detail-meta">
+                    <span x-text="'#' + selectedIssue.number"></span> ·
+                    opened by <span x-text="selectedIssue.author"></span> ·
+                    <span x-text="issueTimeAgo(selectedIssue.created_at)"></span>
+                  </div>
+                </div>
+                <span class="issue-detail-close" @click="selectedIssue = null">✕</span>
+              </div>
+              <div class="issue-labels" x-show="selectedIssue.labels && selectedIssue.labels.length > 0">
+                <template x-for="label in selectedIssue.labels" :key="label.name">
+                  <span class="issue-label" :style="issueLabelStyle(label)" x-text="label.name"></span>
+                </template>
+              </div>
+              <div class="issue-body" x-html="marked.parse(selectedIssue.body || '*No description*')"></div>
+              <button class="generate-prompt-btn" @click="generateIssuePrompt(selectedIssue)">
+                Generate Prompt →
+              </button>
+              <div class="generate-prompt-hint">Pastes into the message input below</div>
+            </div>
+          </template>
+          <div x-show="selectedIssueLoading" class="issues-loading">Loading issue...</div>
+        </div>
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd server && go build -o claude-controller .`
+Expected: Compiles successfully (Go embeds static files)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/web/static/index.html
+git commit -m "feat: add GitHub issues section HTML to right sidebar"
+```
+
+---
+
+### Task 6: Integration Test and Polish
+
+**Files:**
+- All files from previous tasks
+
+- [ ] **Step 1: Run all Go tests**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Build the server**
+
+Run: `cd server && go build -o claude-controller .`
+Expected: Compiles successfully
+
+- [ ] **Step 3: Manual smoke test**
+
+Start the server, open the web UI, select a managed session that points to a repo with GitHub issues.
+
+Verify:
+1. Issues section appears below the git branch info
+2. Open issues listed by default
+3. Clicking "Closed" toggle switches to closed issues
+4. Search box filters issues
+5. Clicking an issue shows the detail view with title, labels, body
+6. Clicking "Generate Prompt" populates the chat textarea
+7. Clicking ✕ returns to the issue list
+8. "Show more" loads additional issues (if the repo has >10)
+9. Hook-mode sessions do NOT show the issues section
+
+- [ ] **Step 4: Final commit if any polish needed**
+
+```bash
+git add -A
+git commit -m "feat: issue picker polish and fixes"
+```

--- a/docs/superpowers/specs/2026-03-22-issue-picker-design.md
+++ b/docs/superpowers/specs/2026-03-22-issue-picker-design.md
@@ -41,15 +41,22 @@ The server detects the GitHub repo from the managed session's CWD by running `gh
 
 All endpoints shell out to the `gh` CLI in the session's CWD directory, reusing the user's existing `gh` auth. No API tokens to manage.
 
+**Session mode guard:** These endpoints only work for managed sessions (which have a CWD). Hook-mode sessions return 400. The frontend hides the issues section for hook-mode sessions.
+
+**Safety:** All `gh` CLI arguments are passed as separate args to `exec.Command()` (never interpolated into a shell string) to prevent injection.
+
 #### `GET /api/sessions/{id}/github/issues`
 
 Query params:
 - `state` — `open` (default) or `closed`
 - `search` — search string (optional)
 - `limit` — number of issues to return (default 10)
-- `page` — page number for pagination (default 1)
 
 Implementation: Shells out to `gh issue list --state {state} --search {search} --limit {limit} --json number,title,state,createdAt,author,labels` in the session's CWD.
+
+The `gh` CLI returns `author` as an object (`{"login": "..."}`) and `labels` as an array of objects (`[{"name": "...", "color": "..."}]`). The Go handler defines structs to deserialize the raw output and reshapes it into the simplified response below, extracting `author.login` as a string and mapping labels to `[{"name": "...", "color": "..."}]`.
+
+**Pagination:** The `gh` CLI has no offset/page support. "Show more" works by incrementing the `limit` param (e.g., first load fetches 10, "Show more" fetches 20). The frontend replaces the full list on each fetch. If the number of results returned is less than the requested limit, there are no more results (used to hide the "Show more" link). No `total_count` field.
 
 Response:
 ```json
@@ -62,16 +69,16 @@ Response:
       "state": "OPEN",
       "created_at": "2026-03-22T02:42:03Z",
       "author": "lankeami",
-      "labels": ["enhancement"]
+      "labels": [{"name": "enhancement", "color": "a2eeef"}]
     }
   ],
-  "total_count": 8
+  "has_more": false
 }
 ```
 
 #### `GET /api/sessions/{id}/github/issues/{number}`
 
-Implementation: Shells out to `gh issue view {number} --json number,title,state,body,createdAt,author,labels,comments` in the session's CWD.
+Implementation: Shells out to `gh issue view {number} --json number,title,state,body,createdAt,author,labels` in the session's CWD. Same struct reshaping as the list endpoint.
 
 Response:
 ```json
@@ -82,8 +89,7 @@ Response:
   "body": "As a developer, I'm having fun playing around...",
   "created_at": "2026-03-22T02:42:03Z",
   "author": "lankeami",
-  "labels": ["enhancement"],
-  "comments": []
+  "labels": [{"name": "enhancement", "color": "a2eeef"}]
 }
 ```
 
@@ -93,9 +99,9 @@ New state properties:
 - `githubIssues: []` — cached issue list
 - `githubIssuesState: 'open'` — open/closed filter
 - `githubIssuesSearch: ''` — search query
-- `githubIssuesPage: 1` — current page
+- `githubIssuesLimit: 10` — current fetch limit (increases on "Show more")
+- `githubIssuesHasMore: false` — whether more results exist
 - `githubIssuesLoading: false`
-- `githubIssuesTotal: 0` — total count for pagination
 - `selectedIssue: null` — expanded issue detail
 - `selectedIssueLoading: false`
 
@@ -105,11 +111,13 @@ New methods:
 - `generateIssuePrompt(issue)` — constructs prompt text, sets `this.inputText`, auto-resizes textarea
 - `toggleIssueState(state)` — switches open/closed, re-fetches
 - `searchIssues()` — debounced search, re-fetches
-- `loadMoreIssues()` — increments page, appends results
+- `loadMoreIssues()` — increases limit by 10, re-fetches full list
 
 ### Frontend — HTML Structure
 
-The issues section is added to `index.html` inside the right sidebar's git info area, below the branch name and working tree status. Structure:
+The issues section is added to `index.html` inside the right sidebar (`.file-tree-sidebar`), below the git info block. The entire sidebar already has `overflow-y: auto`, so the issues section scrolls naturally with the file tree — no separate scroll container needed. When the issue detail panel is expanded, it replaces the issue list inline (not a separate panel).
+
+Structure:
 
 ```
 .git-info-section (existing)
@@ -136,8 +144,8 @@ New styles for:
 - `.issues-search` — search input matching existing file tree search style
 - `.issue-row` — clickable issue item with hover state
 - `.issue-detail` — expanded view panel
-- `.issue-labels` — label pill styling
-- `.issue-body` — scrollable markdown content area
+- `.issue-labels` — label pill styling; background color derived from the `color` field returned by `gh` (prefixed with `#`)
+- `.issue-body` — markdown content area, rendered using the existing `marked.parse()` (already loaded in index.html)
 - `.generate-prompt-btn` — green action button
 
 ### Prompt Generation

--- a/docs/superpowers/specs/2026-03-22-issue-picker-design.md
+++ b/docs/superpowers/specs/2026-03-22-issue-picker-design.md
@@ -1,0 +1,171 @@
+# Issue Picker Design Spec
+
+## Overview
+
+Add a GitHub issue picker to the web UI that lets users browse repo issues, view details, and generate a structured prompt for Claude to work on an issue — including creating a feature branch and opening a draft PR.
+
+## User Flow
+
+1. User selects a managed session → right sidebar shows git info (branch, working tree status)
+2. Below the git branch info, an **Issues** section loads automatically, fetching issues from the session's CWD git remote
+3. Issues are shown in a paginated list (~10 at a time) with:
+   - **Open/Closed toggle** (open selected by default)
+   - **Search box** to filter issues
+   - **"Show more"** link for pagination
+4. Each issue row shows: status dot (green=open, purple=closed), title, `#number · opened X ago`
+5. User clicks an issue → **detail view expands inline** showing:
+   - Title, author, timestamp
+   - Labels as colored pills
+   - Scrollable body content (rendered markdown)
+   - Close button (✕) to collapse back to list
+   - **"Generate Prompt"** button
+6. Clicking "Generate Prompt" populates the existing chat input textarea with a structured prompt:
+   ```
+   Work on GitHub issue #19: "Pick from a list of issues to develop against"
+
+   Requirements:
+   As a developer, I'm having fun playing around in claude-control...
+
+   Create a feature branch, implement the solution, and open a draft PR linking to issue #19.
+   ```
+7. User can edit the prompt, then hits Send or ⌘↵
+8. Claude creates a feature branch, develops the solution, and opens a draft PR
+
+## Architecture
+
+### Repo Detection
+
+The server detects the GitHub repo from the managed session's CWD by running `gh repo view --json nameWithOwner` in that directory. This is done once when issues are first fetched for a session and cached.
+
+### Backend — New API Endpoints
+
+All endpoints shell out to the `gh` CLI in the session's CWD directory, reusing the user's existing `gh` auth. No API tokens to manage.
+
+#### `GET /api/sessions/{id}/github/issues`
+
+Query params:
+- `state` — `open` (default) or `closed`
+- `search` — search string (optional)
+- `limit` — number of issues to return (default 10)
+- `page` — page number for pagination (default 1)
+
+Implementation: Shells out to `gh issue list --state {state} --search {search} --limit {limit} --json number,title,state,createdAt,author,labels` in the session's CWD.
+
+Response:
+```json
+{
+  "repo": "lankeami/claude-control",
+  "issues": [
+    {
+      "number": 19,
+      "title": "Pick from a list of issues to develop against",
+      "state": "OPEN",
+      "created_at": "2026-03-22T02:42:03Z",
+      "author": "lankeami",
+      "labels": ["enhancement"]
+    }
+  ],
+  "total_count": 8
+}
+```
+
+#### `GET /api/sessions/{id}/github/issues/{number}`
+
+Implementation: Shells out to `gh issue view {number} --json number,title,state,body,createdAt,author,labels,comments` in the session's CWD.
+
+Response:
+```json
+{
+  "number": 19,
+  "title": "Pick from a list of issues to develop against",
+  "state": "OPEN",
+  "body": "As a developer, I'm having fun playing around...",
+  "created_at": "2026-03-22T02:42:03Z",
+  "author": "lankeami",
+  "labels": ["enhancement"],
+  "comments": []
+}
+```
+
+### Frontend — Alpine.js State
+
+New state properties:
+- `githubIssues: []` — cached issue list
+- `githubIssuesState: 'open'` — open/closed filter
+- `githubIssuesSearch: ''` — search query
+- `githubIssuesPage: 1` — current page
+- `githubIssuesLoading: false`
+- `githubIssuesTotal: 0` — total count for pagination
+- `selectedIssue: null` — expanded issue detail
+- `selectedIssueLoading: false`
+
+New methods:
+- `fetchGithubIssues(sessionId)` — calls list endpoint, updates state
+- `fetchIssueDetail(sessionId, number)` — calls detail endpoint, expands view
+- `generateIssuePrompt(issue)` — constructs prompt text, sets `this.inputText`, auto-resizes textarea
+- `toggleIssueState(state)` — switches open/closed, re-fetches
+- `searchIssues()` — debounced search, re-fetches
+- `loadMoreIssues()` — increments page, appends results
+
+### Frontend — HTML Structure
+
+The issues section is added to `index.html` inside the right sidebar's git info area, below the branch name and working tree status. Structure:
+
+```
+.git-info-section (existing)
+  ├── branch name + working tree status (existing)
+  └── .issues-section (NEW)
+      ├── header: "Issues" label + Open/Closed toggle pills
+      ├── search input
+      ├── issue list (scrollable)
+      │   └── issue rows (clickable)
+      ├── "Show more" pagination link
+      └── issue detail panel (when expanded)
+          ├── title, author, timestamp
+          ├── labels
+          ├── body (scrollable, rendered markdown)
+          └── "Generate Prompt" button
+```
+
+### Frontend — CSS
+
+New styles for:
+- `.issues-section` — container below git info
+- `.issues-header` — flex row with title and toggle pills
+- `.issue-state-toggle` — open/closed pill buttons
+- `.issues-search` — search input matching existing file tree search style
+- `.issue-row` — clickable issue item with hover state
+- `.issue-detail` — expanded view panel
+- `.issue-labels` — label pill styling
+- `.issue-body` — scrollable markdown content area
+- `.generate-prompt-btn` — green action button
+
+### Prompt Generation
+
+The generated prompt follows this template:
+
+```
+Work on GitHub issue #{number}: "{title}"
+
+Requirements:
+{body}
+
+Create a feature branch, implement the solution, and open a draft PR linking to issue #{number}.
+```
+
+The prompt is inserted into the existing `inputText` Alpine.js property, which binds to the chat textarea. The textarea auto-resizes to fit the content (existing behavior via the `@input` handler).
+
+## Error Handling
+
+- **No `gh` CLI installed**: Show "GitHub CLI not found" message in issues section
+- **Not a git repo / no remote**: Show "No GitHub remote detected" message
+- **Auth failure**: Show "Run `gh auth login` to authenticate" message
+- **Network errors**: Show inline error with retry button
+- **Empty results**: Show "No issues found" with current filter state
+
+## Non-Goals
+
+- Creating/editing issues from the UI (use GitHub directly)
+- Showing PR status or linking sessions to issues in the database
+- Supporting non-GitHub remotes (GitLab, Bitbucket)
+- Caching issues across sessions or in the database

--- a/server/api/github.go
+++ b/server/api/github.go
@@ -1,11 +1,49 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"os/exec"
 	"strconv"
+	"strings"
 )
+
+// ghError returns a user-friendly error message from a failed gh command.
+func ghError(err error, stderr *bytes.Buffer) string {
+	if stderr != nil && stderr.Len() > 0 {
+		msg := strings.TrimSpace(stderr.String())
+		// Common gh CLI errors → friendly messages
+		if strings.Contains(msg, "not a git repository") {
+			return "This directory is not a git repository"
+		}
+		if strings.Contains(msg, "could not determine repo") || strings.Contains(msg, "no git remotes") {
+			return "No GitHub remote found in this repository"
+		}
+		if strings.Contains(msg, "auth login") || strings.Contains(msg, "authentication") {
+			return "GitHub CLI not authenticated — run 'gh auth login' in your terminal"
+		}
+		if strings.Contains(msg, "not found") || strings.Contains(msg, "Could not resolve") {
+			return "Repository not found on GitHub — check that the remote exists"
+		}
+		if strings.Contains(msg, "gh: command not found") || strings.Contains(msg, "executable file not found") {
+			return "GitHub CLI (gh) is not installed"
+		}
+	}
+	// Fallback: check if gh isn't installed
+	if execErr, ok := err.(*exec.Error); ok {
+		if strings.Contains(execErr.Error(), "not found") {
+			return "GitHub CLI (gh) is not installed"
+		}
+	}
+	return "Could not connect to GitHub — check that 'gh' is installed and authenticated"
+}
+
+func jsonError(w http.ResponseWriter, msg string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
 
 // gh CLI raw output structs
 
@@ -72,40 +110,42 @@ func (s *Server) handleGetGithubIssue(w http.ResponseWriter, r *http.Request) {
 
 	sess, err := s.store.GetSessionByID(sessionID)
 	if err != nil {
-		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		jsonError(w, "Session not found", http.StatusNotFound)
 		return
 	}
 
 	if sess.Mode != "managed" {
-		http.Error(w, `{"error":"github issues only available for managed sessions"}`, http.StatusBadRequest)
+		jsonError(w, "Issues are only available for managed sessions", http.StatusBadRequest)
 		return
 	}
 
 	cwd := sess.CWD
 	if cwd == "" {
-		http.Error(w, `{"error":"session has no working directory"}`, http.StatusBadRequest)
+		jsonError(w, "Session has no working directory", http.StatusBadRequest)
 		return
 	}
 
 	numberStr := r.PathValue("number")
 	number, err := strconv.Atoi(numberStr)
 	if err != nil || number < 1 {
-		http.Error(w, `{"error":"number must be a positive integer"}`, http.StatusBadRequest)
+		jsonError(w, "Invalid issue number", http.StatusBadRequest)
 		return
 	}
 
+	var stderr bytes.Buffer
 	cmd := exec.Command("gh", "issue", "view", strconv.Itoa(number),
 		"--json", "number,title,state,body,createdAt,author,labels")
 	cmd.Dir = cwd
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		http.Error(w, `{"error":"failed to get github issue: `+err.Error()+`"}`, http.StatusInternalServerError)
+		jsonError(w, ghError(err, &stderr), http.StatusInternalServerError)
 		return
 	}
 
 	var raw ghIssue
 	if err := json.Unmarshal(out, &raw); err != nil {
-		http.Error(w, `{"error":"failed to parse gh output: `+err.Error()+`"}`, http.StatusInternalServerError)
+		jsonError(w, "Unexpected response from GitHub CLI", http.StatusInternalServerError)
 		return
 	}
 
@@ -118,18 +158,18 @@ func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) 
 
 	sess, err := s.store.GetSessionByID(sessionID)
 	if err != nil {
-		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		jsonError(w, "Session not found", http.StatusNotFound)
 		return
 	}
 
 	if sess.Mode != "managed" {
-		http.Error(w, `{"error":"github issues only available for managed sessions"}`, http.StatusBadRequest)
+		jsonError(w, "Issues are only available for managed sessions", http.StatusBadRequest)
 		return
 	}
 
 	cwd := sess.CWD
 	if cwd == "" {
-		http.Error(w, `{"error":"session has no working directory"}`, http.StatusBadRequest)
+		jsonError(w, "Session has no working directory", http.StatusBadRequest)
 		return
 	}
 
@@ -141,7 +181,7 @@ func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) 
 		state = "open"
 	}
 	if state != "open" && state != "closed" {
-		http.Error(w, `{"error":"state must be open or closed"}`, http.StatusBadRequest)
+		jsonError(w, "State must be 'open' or 'closed'", http.StatusBadRequest)
 		return
 	}
 
@@ -151,7 +191,7 @@ func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) 
 	if ls := q.Get("limit"); ls != "" {
 		n, err := strconv.Atoi(ls)
 		if err != nil || n < 1 {
-			http.Error(w, `{"error":"limit must be a positive integer"}`, http.StatusBadRequest)
+			jsonError(w, "Limit must be a positive number", http.StatusBadRequest)
 			return
 		}
 		if n > 100 {
@@ -161,18 +201,16 @@ func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Detect repo name
+	var repoStderr bytes.Buffer
 	repoCmd := exec.Command("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
 	repoCmd.Dir = cwd
+	repoCmd.Stderr = &repoStderr
 	repoOut, err := repoCmd.Output()
 	if err != nil {
-		http.Error(w, `{"error":"failed to detect github repo: `+err.Error()+`"}`, http.StatusInternalServerError)
+		jsonError(w, ghError(err, &repoStderr), http.StatusInternalServerError)
 		return
 	}
-	repo := string(repoOut)
-	// trim trailing newline
-	for len(repo) > 0 && (repo[len(repo)-1] == '\n' || repo[len(repo)-1] == '\r') {
-		repo = repo[:len(repo)-1]
-	}
+	repo := strings.TrimSpace(string(repoOut))
 
 	// Build gh issue list args
 	args := []string{
@@ -185,17 +223,19 @@ func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) 
 		args = append(args, "--search", search)
 	}
 
+	var issueStderr bytes.Buffer
 	issueCmd := exec.Command("gh", args...)
 	issueCmd.Dir = cwd
+	issueCmd.Stderr = &issueStderr
 	issueOut, err := issueCmd.Output()
 	if err != nil {
-		http.Error(w, `{"error":"failed to list github issues: `+err.Error()+`"}`, http.StatusInternalServerError)
+		jsonError(w, ghError(err, &issueStderr), http.StatusInternalServerError)
 		return
 	}
 
 	var raw []ghIssue
 	if err := json.Unmarshal(issueOut, &raw); err != nil {
-		http.Error(w, `{"error":"failed to parse gh output: `+err.Error()+`"}`, http.StatusInternalServerError)
+		jsonError(w, "Unexpected response from GitHub CLI", http.StatusInternalServerError)
 		return
 	}
 

--- a/server/api/github.go
+++ b/server/api/github.go
@@ -67,6 +67,52 @@ func reshapeIssue(g ghIssue) issueResponse {
 	}
 }
 
+func (s *Server) handleGetGithubIssue(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		return
+	}
+
+	if sess.Mode != "managed" {
+		http.Error(w, `{"error":"github issues only available for managed sessions"}`, http.StatusBadRequest)
+		return
+	}
+
+	cwd := sess.CWD
+	if cwd == "" {
+		http.Error(w, `{"error":"session has no working directory"}`, http.StatusBadRequest)
+		return
+	}
+
+	numberStr := r.PathValue("number")
+	number, err := strconv.Atoi(numberStr)
+	if err != nil || number < 1 {
+		http.Error(w, `{"error":"number must be a positive integer"}`, http.StatusBadRequest)
+		return
+	}
+
+	cmd := exec.Command("gh", "issue", "view", strconv.Itoa(number),
+		"--json", "number,title,state,body,createdAt,author,labels")
+	cmd.Dir = cwd
+	out, err := cmd.Output()
+	if err != nil {
+		http.Error(w, `{"error":"failed to get github issue: `+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	var raw ghIssue
+	if err := json.Unmarshal(out, &raw); err != nil {
+		http.Error(w, `{"error":"failed to parse gh output: `+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reshapeIssue(raw))
+}
+
 func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 

--- a/server/api/github.go
+++ b/server/api/github.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os/exec"
+	"strconv"
+)
+
+// gh CLI raw output structs
+
+type ghAuthor struct {
+	Login string `json:"login"`
+}
+
+type ghLabel struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type ghIssue struct {
+	Number    int      `json:"number"`
+	Title     string   `json:"title"`
+	State     string   `json:"state"`
+	CreatedAt string   `json:"createdAt"`
+	Author    ghAuthor `json:"author"`
+	Labels    []ghLabel `json:"labels"`
+	Body      string   `json:"body"`
+}
+
+// Response structs
+
+type issueLabel struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type issueResponse struct {
+	Number    int          `json:"number"`
+	Title     string       `json:"title"`
+	State     string       `json:"state"`
+	CreatedAt string       `json:"created_at"`
+	Author    string       `json:"author"`
+	Labels    []issueLabel `json:"labels"`
+	Body      string       `json:"body"`
+}
+
+type issueListResponse struct {
+	Repo    string          `json:"repo"`
+	Issues  []issueResponse `json:"issues"`
+	HasMore bool            `json:"has_more"`
+}
+
+func reshapeIssue(g ghIssue) issueResponse {
+	labels := make([]issueLabel, 0, len(g.Labels))
+	for _, l := range g.Labels {
+		labels = append(labels, issueLabel{Name: l.Name, Color: l.Color})
+	}
+	return issueResponse{
+		Number:    g.Number,
+		Title:     g.Title,
+		State:     g.State,
+		CreatedAt: g.CreatedAt,
+		Author:    g.Author.Login,
+		Labels:    labels,
+		Body:      g.Body,
+	}
+}
+
+func (s *Server) handleListGithubIssues(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
+		return
+	}
+
+	if sess.Mode != "managed" {
+		http.Error(w, `{"error":"github issues only available for managed sessions"}`, http.StatusBadRequest)
+		return
+	}
+
+	cwd := sess.CWD
+	if cwd == "" {
+		http.Error(w, `{"error":"session has no working directory"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Parse query params
+	q := r.URL.Query()
+
+	state := q.Get("state")
+	if state == "" {
+		state = "open"
+	}
+	if state != "open" && state != "closed" {
+		http.Error(w, `{"error":"state must be open or closed"}`, http.StatusBadRequest)
+		return
+	}
+
+	search := q.Get("search")
+
+	limit := 10
+	if ls := q.Get("limit"); ls != "" {
+		n, err := strconv.Atoi(ls)
+		if err != nil || n < 1 {
+			http.Error(w, `{"error":"limit must be a positive integer"}`, http.StatusBadRequest)
+			return
+		}
+		if n > 100 {
+			n = 100
+		}
+		limit = n
+	}
+
+	// Detect repo name
+	repoCmd := exec.Command("gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+	repoCmd.Dir = cwd
+	repoOut, err := repoCmd.Output()
+	if err != nil {
+		http.Error(w, `{"error":"failed to detect github repo: `+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+	repo := string(repoOut)
+	// trim trailing newline
+	for len(repo) > 0 && (repo[len(repo)-1] == '\n' || repo[len(repo)-1] == '\r') {
+		repo = repo[:len(repo)-1]
+	}
+
+	// Build gh issue list args
+	args := []string{
+		"issue", "list",
+		"--state", state,
+		"--limit", strconv.Itoa(limit + 1),
+		"--json", "number,title,state,createdAt,author,labels,body",
+	}
+	if search != "" {
+		args = append(args, "--search", search)
+	}
+
+	issueCmd := exec.Command("gh", args...)
+	issueCmd.Dir = cwd
+	issueOut, err := issueCmd.Output()
+	if err != nil {
+		http.Error(w, `{"error":"failed to list github issues: `+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	var raw []ghIssue
+	if err := json.Unmarshal(issueOut, &raw); err != nil {
+		http.Error(w, `{"error":"failed to parse gh output: `+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	hasMore := len(raw) > limit
+	if hasMore {
+		raw = raw[:limit]
+	}
+
+	issues := make([]issueResponse, 0, len(raw))
+	for _, g := range raw {
+		issues = append(issues, reshapeIssue(g))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(issueListResponse{
+		Repo:    repo,
+		Issues:  issues,
+		HasMore: hasMore,
+	})
+}

--- a/server/api/github_test.go
+++ b/server/api/github_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestListGithubIssues_HookModeReturns400(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	// UpsertSession creates a hook-mode session
+	sess, err := store.UpsertSession("test-computer", "/tmp/hook-test", "")
+	if err != nil {
+		t.Fatalf("UpsertSession: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/github/issues", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestListGithubIssues_SessionNotFound(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/nonexistent-id/github/issues", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestListGithubIssues_ManagedNoCWDReturns400(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	// CreateManagedSession with empty cwd
+	sess, err := store.CreateManagedSession("", `[]`, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/github/issues", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestListGithubIssues_InvalidStateParam(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/github/issues?state=invalid", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestListGithubIssues_DefaultParamsAccepted(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/github/issues", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Valid default params must not produce a 400 (could be 500 if gh is not available)
+	if resp.StatusCode == http.StatusBadRequest {
+		var body map[string]string
+		json.NewDecoder(resp.Body).Decode(&body)
+		t.Fatalf("got 400 with valid default params, body=%v", body)
+	}
+}

--- a/server/api/github_test.go
+++ b/server/api/github_test.go
@@ -99,6 +99,97 @@ func TestListGithubIssues_InvalidStateParam(t *testing.T) {
 	}
 }
 
+func TestGetGithubIssue_HookModeReturns400(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, err := store.UpsertSession("test-computer", "/tmp/hook-test", "")
+	if err != nil {
+		t.Fatalf("UpsertSession: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/github/issues/42", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestGetGithubIssue_SessionNotFound(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/nonexistent-id/github/issues/42", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404", resp.StatusCode)
+	}
+}
+
+func TestGetGithubIssue_InvalidNumberReturns400(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/github/issues/notanumber", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
+func TestGetGithubIssue_ManagedNoCWDReturns400(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, err := store.CreateManagedSession("", `[]`, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession: %v", err)
+	}
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/github/issues/42", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
+	}
+}
+
 func TestListGithubIssues_DefaultParamsAccepted(t *testing.T) {
 	ts, store := setupTestServer(t)
 	defer ts.Close()

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -62,6 +62,7 @@ func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager) http.Handle
 
 	// GitHub endpoints
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues", s.handleListGithubIssues)
+	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues/{number}", s.handleGetGithubIssue)
 
 	rl := NewRateLimiter(60, 10)
 	authedAPI := rl.Middleware(AuthMiddleware(apiKey, rl, apiMux))

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -60,6 +60,9 @@ func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager) http.Handle
 	apiMux.HandleFunc("GET /api/files/content", s.handleGetFileContent)
 	apiMux.HandleFunc("GET /api/files/diff", s.handleFileDiff)
 
+	// GitHub endpoints
+	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues", s.handleListGithubIssues)
+
 	rl := NewRateLimiter(60, 10)
 	authedAPI := rl.Middleware(AuthMiddleware(apiKey, rl, apiMux))
 

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -48,6 +48,7 @@ document.addEventListener('alpine:init', () => {
     gitInfo: null,
 
     // GitHub Issues state
+    githubRepo: null,
     githubIssues: [],
     githubIssuesState: 'open',
     githubIssuesSearch: '',
@@ -837,6 +838,7 @@ document.addEventListener('alpine:init', () => {
         const data = await resp.json();
         this.githubIssues = data.issues || [];
         this.githubIssuesHasMore = data.has_more || false;
+        if (data.repo) this.githubRepo = data.repo;
       } catch (e) {
         this.githubIssuesError = e.message || 'Failed to load issues';
       } finally {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -55,6 +55,7 @@ document.addEventListener('alpine:init', () => {
     githubIssuesHasMore: false,
     githubIssuesLoading: false,
     githubIssuesError: null,
+    issuesExpanded: true,
     selectedIssue: null,
     selectedIssueLoading: false,
     _searchIssuesTimer: null,
@@ -846,6 +847,8 @@ document.addEventListener('alpine:init', () => {
     async fetchIssueDetail(sessionId, number) {
       if (!sessionId) return;
       this.selectedIssueLoading = true;
+      // Close any open file viewer and open issue in viewer panel
+      this.closeFileViewer();
       try {
         const resp = await fetch(`/api/sessions/${sessionId}/github/issues/${number}`, {
           headers: { 'Authorization': 'Bearer ' + this.apiKey }
@@ -858,6 +861,10 @@ document.addEventListener('alpine:init', () => {
       } finally {
         this.selectedIssueLoading = false;
       }
+    },
+
+    closeIssueViewer() {
+      this.selectedIssue = null;
     },
 
     toggleIssueState(state) {
@@ -1010,6 +1017,7 @@ Create a feature branch, implement the solution, and open a draft PR linking to 
 
     async openFileViewer(filePath) {
       if (this.viewerFile === filePath) { this.closeFileViewer(); return; }
+      this.selectedIssue = null; // Close issue viewer if open
       this.viewerFile = filePath;
       this.viewerMode = 'full';
       this.viewerContent = '';

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -46,6 +46,18 @@ document.addEventListener('alpine:init', () => {
     sessionFiles: [],
     fileTreeData: [],
     gitInfo: null,
+
+    // GitHub Issues state
+    githubIssues: [],
+    githubIssuesState: 'open',
+    githubIssuesSearch: '',
+    githubIssuesLimit: 10,
+    githubIssuesHasMore: false,
+    githubIssuesLoading: false,
+    githubIssuesError: null,
+    selectedIssue: null,
+    selectedIssueLoading: false,
+    _searchIssuesTimer: null,
     viewerFile: null,
     viewerMode: 'diff',
     viewerDiffs: [],
@@ -364,6 +376,15 @@ document.addEventListener('alpine:init', () => {
         await this.fetchTranscript(this.selectedSessionId, true);
       }
       this.loadSessionFiles(this.selectedSessionId);
+      if (sess && sess.mode === 'managed') {
+        this.githubIssues = [];
+        this.githubIssuesState = 'open';
+        this.githubIssuesSearch = '';
+        this.githubIssuesLimit = 10;
+        this.selectedIssue = null;
+        this.githubIssuesError = null;
+        this.fetchGithubIssues(this.selectedSessionId);
+      }
     },
 
     async deleteSession(id) {
@@ -788,6 +809,113 @@ document.addEventListener('alpine:init', () => {
         console.error('Failed to fetch messages:', e);
       }
       this.chatLoading = false;
+    },
+
+    // GitHub Issues methods
+    async fetchGithubIssues(sessionId) {
+      if (!sessionId) return;
+      this.githubIssuesLoading = true;
+      this.githubIssuesError = null;
+      try {
+        const params = new URLSearchParams({
+          state: this.githubIssuesState,
+          limit: this.githubIssuesLimit,
+        });
+        if (this.githubIssuesSearch.trim()) {
+          params.set('search', this.githubIssuesSearch.trim());
+        }
+        const resp = await fetch(`/api/sessions/${sessionId}/github/issues?${params}`, {
+          headers: { 'Authorization': 'Bearer ' + this.apiKey }
+        });
+        if (resp.status === 401) { this.disconnect(); return; }
+        if (!resp.ok) {
+          const text = await resp.text();
+          this.githubIssuesError = text || 'Failed to load issues';
+          return;
+        }
+        const data = await resp.json();
+        this.githubIssues = data.issues || [];
+        this.githubIssuesHasMore = data.has_more || false;
+      } catch (e) {
+        this.githubIssuesError = e.message || 'Failed to load issues';
+      } finally {
+        this.githubIssuesLoading = false;
+      }
+    },
+
+    async fetchIssueDetail(sessionId, number) {
+      if (!sessionId) return;
+      this.selectedIssueLoading = true;
+      try {
+        const resp = await fetch(`/api/sessions/${sessionId}/github/issues/${number}`, {
+          headers: { 'Authorization': 'Bearer ' + this.apiKey }
+        });
+        if (resp.status === 401) { this.disconnect(); return; }
+        if (!resp.ok) return;
+        this.selectedIssue = await resp.json();
+      } catch (e) {
+        // Ignore — keep selectedIssue as null
+      } finally {
+        this.selectedIssueLoading = false;
+      }
+    },
+
+    toggleIssueState(state) {
+      this.githubIssuesState = state;
+      this.githubIssuesLimit = 10;
+      this.selectedIssue = null;
+      this.fetchGithubIssues(this.selectedSessionId);
+    },
+
+    searchIssues() {
+      if (this._searchIssuesTimer) clearTimeout(this._searchIssuesTimer);
+      this._searchIssuesTimer = setTimeout(() => {
+        this.githubIssuesLimit = 10;
+        this.fetchGithubIssues(this.selectedSessionId);
+      }, 300);
+    },
+
+    loadMoreIssues() {
+      this.githubIssuesLimit += 10;
+      this.fetchGithubIssues(this.selectedSessionId);
+    },
+
+    generateIssuePrompt(issue) {
+      const prompt = `Work on GitHub issue #${issue.number}: "${issue.title}"
+
+Requirements:
+${issue.body || '(No description provided)'}
+
+Create a feature branch, implement the solution, and open a draft PR linking to issue #${issue.number}.`;
+      this.inputText = prompt;
+      this.$nextTick(() => {
+        const textarea = document.querySelector('.instruction-bar textarea');
+        if (textarea) {
+          textarea.style.height = 'auto';
+          textarea.style.height = Math.min(textarea.scrollHeight, 150) + 'px';
+        }
+      });
+    },
+
+    issueTimeAgo(dateStr) {
+      if (!dateStr) return '';
+      const date = new Date(dateStr);
+      const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+      if (seconds < 60) return 'just now';
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) return `${minutes}m ago`;
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return `${hours}h ago`;
+      return `${Math.floor(hours / 24)}d ago`;
+    },
+
+    issueLabelStyle(label) {
+      if (!label || !label.color) return '';
+      const hex = label.color.replace('#', '');
+      const r = parseInt(hex.substring(0, 2), 16);
+      const g = parseInt(hex.substring(2, 4), 16);
+      const b = parseInt(hex.substring(4, 6), 16);
+      return `background: rgba(${r},${g},${b},0.2); color: rgb(${r},${g},${b}); border-color: rgba(${r},${g},${b},0.4);`;
     },
 
     // File browser methods

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -208,6 +208,8 @@
                   <span class="file-viewer-path" x-text="'Issue #' + selectedIssue.number"></span>
                   <span class="file-type-badge" x-text="selectedIssue.state" :style="selectedIssue.state === 'OPEN' ? 'background:#238636;color:#fff' : 'background:#8957e5;color:#fff'"></span>
                   <div class="file-viewer-controls">
+                    <a class="issue-link-btn" :href="'https://github.com/' + githubRepo + '/issues/' + selectedIssue.number" target="_blank" rel="noopener"
+                       title="Open on GitHub">↗ GitHub</a>
                     <button class="generate-prompt-btn" style="padding:2px 10px;font-size:11px;width:auto;border-radius:4px" @click="generateIssuePrompt(selectedIssue)">Generate Prompt</button>
                     <button class="file-viewer-close" @click="closeIssueViewer()">&times;</button>
                   </div>

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -246,6 +246,69 @@
             <span class="git-clean-text">Working tree clean</span>
           </div>
         </div>
+
+        <!-- GitHub Issues Section -->
+        <div x-show="gitInfo && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+          <div class="issues-section">
+            <!-- List view -->
+            <template x-if="!selectedIssue">
+              <div>
+                <div class="issues-header">
+                  <span class="issues-title">Issues</span>
+                  <div class="issue-state-toggles">
+                    <button class="issue-state-toggle"
+                            :class="{ 'active-open': githubIssuesState === 'open' }"
+                            @click="toggleIssueState('open')">Open</button>
+                    <button class="issue-state-toggle"
+                            :class="{ 'active-closed': githubIssuesState === 'closed' }"
+                            @click="toggleIssueState('closed')">Closed</button>
+                  </div>
+                </div>
+                <input type="text" class="issues-search" placeholder="Search issues..."
+                       x-model="githubIssuesSearch"
+                       @input="searchIssues()">
+                <div x-show="githubIssuesLoading" class="issues-loading">Loading...</div>
+                <div x-show="!githubIssuesLoading && githubIssuesError" class="issues-error" x-text="githubIssuesError"></div>
+                <div x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length === 0" class="issues-empty">No issues found</div>
+                <div class="issue-list" x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length > 0">
+                  <template x-for="issue in githubIssues" :key="issue.number">
+                    <div class="issue-row" @click="fetchIssueDetail(selectedSessionId, issue.number)">
+                      <div class="issue-dot" :class="issue.state"></div>
+                      <div class="issue-row-content">
+                        <div class="issue-row-title" x-text="issue.title"></div>
+                        <div class="issue-row-meta" x-text="'#' + issue.number + ' · ' + issueTimeAgo(issue.updated_at)"></div>
+                      </div>
+                    </div>
+                  </template>
+                </div>
+                <button x-show="githubIssuesHasMore && !githubIssuesLoading"
+                        class="issues-show-more"
+                        @click="loadMoreIssues()">Show more</button>
+              </div>
+            </template>
+
+            <!-- Detail view -->
+            <template x-if="selectedIssue">
+              <div class="issue-detail">
+                <div class="issue-detail-header">
+                  <div class="issue-detail-title" x-text="selectedIssue.title"></div>
+                  <button class="issue-detail-close" @click="selectedIssue = null">&#x2715;</button>
+                </div>
+                <div class="issue-detail-meta"
+                     x-text="'#' + selectedIssue.number + ' · ' + selectedIssue.state + ' · ' + issueTimeAgo(selectedIssue.updated_at)"></div>
+                <div class="issue-labels" x-show="selectedIssue.labels && selectedIssue.labels.length > 0">
+                  <template x-for="label in (selectedIssue.labels || [])" :key="label.name">
+                    <span class="issue-label" :style="issueLabelStyle(label)" x-text="label.name"></span>
+                  </template>
+                </div>
+                <div class="issue-body"
+                     x-html="typeof marked !== 'undefined' ? marked.parse(selectedIssue.body || '') : (selectedIssue.body || '(No description)')"></div>
+                <button class="generate-prompt-btn" @click="generateIssuePrompt(selectedIssue)">Generate Prompt</button>
+                <span class="generate-prompt-hint">Populates the chat input below</span>
+              </div>
+            </template>
+          </div>
+        </div>
       </div>
     </div>
   </template>

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -101,7 +101,7 @@
         </div>
 
         <div class="main-content-split">
-          <div class="chat-column" :class="{ 'has-viewer': viewerFile }">
+          <div class="chat-column" :class="{ 'has-viewer': viewerFile || selectedIssue }">
             <!-- Chat area -->
             <div class="chat-area" id="chat-area">
               <template x-if="!selectedSessionId">
@@ -173,29 +173,64 @@
           </div>
 
           <!-- File Viewer Panel -->
-          <div class="file-viewer-column" x-show="viewerFile" x-cloak>
-            <div class="file-viewer-header">
-              <span class="file-viewer-path" x-text="viewerFileName"></span>
-              <span class="file-type-badge" x-text="viewerFileType" x-show="viewerFileType"></span>
-              <div class="file-viewer-controls">
-                <button :class="{ active: viewerMode === 'diff' }" @click="switchToDiffView()">Diff</button>
-                <button :class="{ active: viewerMode === 'full' }" @click="switchToFullView()">Full</button>
-                <button class="file-viewer-close" @click="closeFileViewer()">&times;</button>
+          <div class="file-viewer-column" x-show="viewerFile || selectedIssue" x-cloak>
+            <!-- File viewer (existing) -->
+            <template x-if="viewerFile && !selectedIssue">
+              <div>
+                <div class="file-viewer-header">
+                  <span class="file-viewer-path" x-text="viewerFileName"></span>
+                  <span class="file-type-badge" x-text="viewerFileType" x-show="viewerFileType"></span>
+                  <div class="file-viewer-controls">
+                    <button :class="{ active: viewerMode === 'diff' }" @click="switchToDiffView()">Diff</button>
+                    <button :class="{ active: viewerMode === 'full' }" @click="switchToFullView()">Full</button>
+                    <button class="file-viewer-close" @click="closeFileViewer()">&times;</button>
+                  </div>
+                </div>
+                <div class="file-viewer-body">
+                  <div x-show="viewerMode === 'diff'" class="diff-view">
+                    <div x-show="viewerLoading" class="viewer-loading">Loading diff...</div>
+                    <div x-show="!viewerLoading && !viewerDiffHtml" class="diff-empty">No changes detected for this file.</div>
+                    <div x-show="!viewerLoading && viewerDiffHtml" x-html="viewerDiffHtml"></div>
+                  </div>
+                  <div x-show="viewerMode === 'full'" class="full-view">
+                    <div x-show="viewerLoading" class="viewer-loading">Loading...</div>
+                    <div x-show="viewerBinary" class="viewer-binary">Binary file — cannot display.</div>
+                    <div x-show="!viewerLoading && !viewerBinary" class="full-file-content" x-html="viewerFullHtml"></div>
+                    <div x-show="viewerTruncated" class="viewer-truncated">File truncated (exceeds 1MB).</div>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div class="file-viewer-body">
-              <div x-show="viewerMode === 'diff'" class="diff-view">
-                <div x-show="viewerLoading" class="viewer-loading">Loading diff...</div>
-                <div x-show="!viewerLoading && !viewerDiffHtml" class="diff-empty">No changes detected for this file.</div>
-                <div x-show="!viewerLoading && viewerDiffHtml" x-html="viewerDiffHtml"></div>
+            </template>
+            <!-- Issue viewer -->
+            <template x-if="selectedIssue">
+              <div>
+                <div class="file-viewer-header">
+                  <span class="file-viewer-path" x-text="'Issue #' + selectedIssue.number"></span>
+                  <span class="file-type-badge" x-text="selectedIssue.state" :style="selectedIssue.state === 'OPEN' ? 'background:#238636;color:#fff' : 'background:#8957e5;color:#fff'"></span>
+                  <div class="file-viewer-controls">
+                    <button class="generate-prompt-btn" style="padding:2px 10px;font-size:11px;width:auto;border-radius:4px" @click="generateIssuePrompt(selectedIssue)">Generate Prompt</button>
+                    <button class="file-viewer-close" @click="closeIssueViewer()">&times;</button>
+                  </div>
+                </div>
+                <div class="file-viewer-body" style="padding:16px">
+                  <div x-show="selectedIssueLoading" class="viewer-loading">Loading issue...</div>
+                  <div x-show="!selectedIssueLoading">
+                    <h3 style="margin:0 0 8px 0;font-size:16px;color:var(--text)" x-text="selectedIssue.title"></h3>
+                    <div style="font-size:11px;color:var(--text-muted);margin-bottom:12px">
+                      opened by <span x-text="selectedIssue.author"></span> ·
+                      <span x-text="issueTimeAgo(selectedIssue.created_at || selectedIssue.updated_at)"></span>
+                    </div>
+                    <div class="issue-labels" x-show="selectedIssue.labels && selectedIssue.labels.length > 0" style="margin-bottom:12px">
+                      <template x-for="label in (selectedIssue.labels || [])" :key="label.name">
+                        <span class="issue-label" :style="issueLabelStyle(label)" x-text="label.name"></span>
+                      </template>
+                    </div>
+                    <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
+                         x-html="typeof marked !== 'undefined' ? marked.parse(selectedIssue.body || '*No description*') : (selectedIssue.body || '(No description)')"></div>
+                  </div>
+                </div>
               </div>
-              <div x-show="viewerMode === 'full'" class="full-view">
-                <div x-show="viewerLoading" class="viewer-loading">Loading...</div>
-                <div x-show="viewerBinary" class="viewer-binary">Binary file — cannot display.</div>
-                <div x-show="!viewerLoading && !viewerBinary" class="full-file-content" x-html="viewerFullHtml"></div>
-                <div x-show="viewerTruncated" class="viewer-truncated">File truncated (exceeds 1MB).</div>
-              </div>
-            </div>
+            </template>
           </div>
         </div>
       </div>
@@ -248,65 +283,43 @@
         </div>
 
         <!-- GitHub Issues Section -->
-        <div x-show="gitInfo && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
-          <div class="issues-section">
-            <!-- List view -->
-            <template x-if="!selectedIssue">
-              <div>
-                <div class="issues-header">
-                  <span class="issues-title">Issues</span>
-                  <div class="issue-state-toggles">
-                    <button class="issue-state-toggle"
-                            :class="{ 'active-open': githubIssuesState === 'open' }"
-                            @click="toggleIssueState('open')">Open</button>
-                    <button class="issue-state-toggle"
-                            :class="{ 'active-closed': githubIssuesState === 'closed' }"
-                            @click="toggleIssueState('closed')">Closed</button>
+        <div class="issues-section" x-show="gitInfo && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+          <div class="issues-header" @click="issuesExpanded = !issuesExpanded" style="cursor:pointer">
+            <span class="issues-title">
+              <span class="issues-toggle" x-text="issuesExpanded ? '▼' : '▶'"></span>
+              Issues
+            </span>
+            <div class="issue-state-toggles" x-show="issuesExpanded" @click.stop>
+              <button class="issue-state-toggle"
+                      :class="{ 'active-open': githubIssuesState === 'open' }"
+                      @click="toggleIssueState('open')">Open</button>
+              <button class="issue-state-toggle"
+                      :class="{ 'active-closed': githubIssuesState === 'closed' }"
+                      @click="toggleIssueState('closed')">Closed</button>
+            </div>
+          </div>
+          <div x-show="issuesExpanded" x-collapse>
+            <input type="text" class="issues-search" placeholder="Search issues..."
+                   x-model="githubIssuesSearch"
+                   @input="searchIssues()">
+            <div x-show="githubIssuesLoading" class="issues-loading">Loading...</div>
+            <div x-show="!githubIssuesLoading && githubIssuesError" class="issues-error" x-text="githubIssuesError"></div>
+            <div x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length === 0" class="issues-empty">No issues found</div>
+            <div class="issue-list" x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length > 0">
+              <template x-for="issue in githubIssues" :key="issue.number">
+                <div class="issue-row" :class="{ 'is-selected': selectedIssue?.number === issue.number }"
+                     @click="fetchIssueDetail(selectedSessionId, issue.number)">
+                  <div class="issue-dot" :class="issue.state"></div>
+                  <div class="issue-row-content">
+                    <div class="issue-row-title" x-text="issue.title"></div>
+                    <div class="issue-row-meta" x-text="'#' + issue.number + ' · ' + issueTimeAgo(issue.updated_at)"></div>
                   </div>
                 </div>
-                <input type="text" class="issues-search" placeholder="Search issues..."
-                       x-model="githubIssuesSearch"
-                       @input="searchIssues()">
-                <div x-show="githubIssuesLoading" class="issues-loading">Loading...</div>
-                <div x-show="!githubIssuesLoading && githubIssuesError" class="issues-error" x-text="githubIssuesError"></div>
-                <div x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length === 0" class="issues-empty">No issues found</div>
-                <div class="issue-list" x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length > 0">
-                  <template x-for="issue in githubIssues" :key="issue.number">
-                    <div class="issue-row" @click="fetchIssueDetail(selectedSessionId, issue.number)">
-                      <div class="issue-dot" :class="issue.state"></div>
-                      <div class="issue-row-content">
-                        <div class="issue-row-title" x-text="issue.title"></div>
-                        <div class="issue-row-meta" x-text="'#' + issue.number + ' · ' + issueTimeAgo(issue.updated_at)"></div>
-                      </div>
-                    </div>
-                  </template>
-                </div>
-                <button x-show="githubIssuesHasMore && !githubIssuesLoading"
-                        class="issues-show-more"
-                        @click="loadMoreIssues()">Show more</button>
-              </div>
-            </template>
-
-            <!-- Detail view -->
-            <template x-if="selectedIssue">
-              <div class="issue-detail">
-                <div class="issue-detail-header">
-                  <div class="issue-detail-title" x-text="selectedIssue.title"></div>
-                  <button class="issue-detail-close" @click="selectedIssue = null">&#x2715;</button>
-                </div>
-                <div class="issue-detail-meta"
-                     x-text="'#' + selectedIssue.number + ' · ' + selectedIssue.state + ' · ' + issueTimeAgo(selectedIssue.updated_at)"></div>
-                <div class="issue-labels" x-show="selectedIssue.labels && selectedIssue.labels.length > 0">
-                  <template x-for="label in (selectedIssue.labels || [])" :key="label.name">
-                    <span class="issue-label" :style="issueLabelStyle(label)" x-text="label.name"></span>
-                  </template>
-                </div>
-                <div class="issue-body"
-                     x-html="typeof marked !== 'undefined' ? marked.parse(selectedIssue.body || '') : (selectedIssue.body || '(No description)')"></div>
-                <button class="generate-prompt-btn" @click="generateIssuePrompt(selectedIssue)">Generate Prompt</button>
-                <span class="generate-prompt-hint">Populates the chat input below</span>
-              </div>
-            </template>
+              </template>
+            </div>
+            <button x-show="githubIssuesHasMore && !githubIssuesLoading"
+                    class="issues-show-more"
+                    @click="loadMoreIssues()">Show more</button>
           </div>
         </div>
       </div>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -830,6 +830,23 @@ body {
   background: #2ea043;
 }
 
+.issue-link-btn {
+  padding: 2px 10px;
+  font-size: 11px;
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.issue-link-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .generate-prompt-hint {
   display: block;
   text-align: center;

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -552,6 +552,278 @@ body {
 .git-clean { color: var(--text-muted); font-size: 11px; }
 .git-clean-text { font-style: italic; }
 
+/* GitHub Issues Section */
+.issues-section {
+  padding: 8px 12px;
+  border-top: 1px solid var(--border);
+}
+
+.issues-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.issues-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+.issue-state-toggles {
+  display: flex;
+  gap: 4px;
+}
+
+.issue-state-toggle {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.issue-state-toggle.active-open {
+  background: #238636;
+  color: #fff;
+  border-color: #238636;
+}
+
+.issue-state-toggle.active-closed {
+  background: #8957e5;
+  color: #fff;
+  border-color: #8957e5;
+}
+
+.issues-search {
+  width: 100%;
+  padding: 5px 8px;
+  font-size: 11px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  margin-bottom: 6px;
+  box-sizing: border-box;
+}
+
+.issues-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.issue-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.issue-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 4px 2px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.issue-row:hover {
+  background: var(--bg-secondary);
+}
+
+.issue-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.issue-dot.open {
+  background: #238636;
+}
+
+.issue-dot.closed {
+  background: #8957e5;
+}
+
+.issue-row-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.issue-row-title {
+  font-size: 11px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.issue-row-meta {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+.issues-show-more {
+  display: block;
+  text-align: center;
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 6px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 2px 0;
+  width: 100%;
+}
+
+.issues-show-more:hover {
+  color: var(--text);
+  text-decoration: underline;
+}
+
+.issues-loading,
+.issues-error,
+.issues-empty {
+  text-align: center;
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 8px 0;
+}
+
+.issues-error {
+  color: var(--red);
+}
+
+/* Issue Detail Panel */
+.issue-detail {
+  padding: 4px 0;
+}
+
+.issue-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.issue-detail-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  flex: 1;
+  min-width: 0;
+  line-height: 1.4;
+}
+
+.issue-detail-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.issue-detail-close {
+  font-size: 14px;
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 2px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.issue-detail-close:hover {
+  color: var(--text);
+}
+
+.issue-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.issue-label {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  border: 1px solid;
+  font-weight: 500;
+}
+
+.issue-body {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  max-height: 200px;
+  overflow-y: auto;
+  font-size: 12px;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+
+.issue-body p { margin: 0.25em 0; }
+.issue-body p:first-child { margin-top: 0; }
+.issue-body p:last-child { margin-bottom: 0; }
+
+.issue-body code {
+  background: rgba(0,0,0,0.1);
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
+.issue-body pre {
+  background: rgba(0,0,0,0.1);
+  padding: 6px 8px;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-size: 0.85em;
+  margin: 0.4em 0;
+}
+
+.issue-body pre code {
+  background: none;
+  padding: 0;
+}
+
+.generate-prompt-btn {
+  width: 100%;
+  padding: 7px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  background: #238636;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-bottom: 4px;
+}
+
+.generate-prompt-btn:hover {
+  background: #2ea043;
+}
+
+.generate-prompt-hint {
+  display: block;
+  text-align: center;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
 /* Main content split */
 .main-content-split { display: flex; flex: 1; overflow: hidden; }
 .chat-column { display: flex; flex-direction: column; flex: 1; min-width: 0; overflow: hidden; }

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -571,6 +571,19 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.issues-toggle {
+  font-size: 8px;
+  color: var(--text-muted);
+}
+
+.issue-row.is-selected {
+  background: var(--bg-secondary);
+  border-left: 2px solid var(--accent);
 }
 
 .issue-state-toggles {


### PR DESCRIPTION
## Summary
- Add GitHub issue browsing to the web UI right sidebar (below git branch info)
- Issues fetched via gh CLI from the session CWD git remote - no API tokens needed
- Collapsible accordion with open/closed toggle, search, and paginated list
- Click an issue to view details in the file viewer panel (title, labels, rendered markdown body)
- Generate Prompt button populates chat textarea with structured prompt for Claude to create a feature branch, implement, and open a draft PR
- GitHub link button opens the issue on GitHub in a new tab
- Human-friendly error messages for common gh CLI failures

Closes #19

## Test plan
- [x] Go tests pass (go test ./...)
- [ ] Create a managed session pointing to a repo with GitHub issues
- [ ] Verify issues load in the sidebar below git branch info
- [ ] Toggle open/closed filter
- [ ] Search for an issue
- [ ] Click an issue - verify it opens in the file viewer panel
- [ ] Click Generate Prompt - verify chat textarea is populated
- [ ] Click GitHub link - verify it opens the issue on GitHub
- [ ] Collapse/expand the issues accordion
- [ ] Verify hook-mode sessions do not show the issues section