### PR TITLE
feat: add repo name and link in branch section

### DIFF
--- a/server/api/filetree.go
+++ b/server/api/filetree.go
@@ -229,6 +229,8 @@ func gitListFiles(cwd string) ([]string, error) {
 
 type gitSummaryInfo struct {
 	Branch    string `json:"branch"`
+	RepoName  string `json:"repo_name,omitempty"`
+	RepoURL   string `json:"repo_url,omitempty"`
 	Modified  int    `json:"modified"`
 	Added     int    `json:"added"`
 	Deleted   int    `json:"deleted"`
@@ -246,6 +248,14 @@ func gitSummary(cwd string) gitSummaryInfo {
 	cmd.Dir = cwd
 	if out, err := cmd.Output(); err == nil {
 		info.Branch = strings.TrimSpace(string(out))
+	}
+
+	// Get remote URL and derive repo name + browsable URL
+	cmdRemote := exec.Command("git", "remote", "get-url", "origin")
+	cmdRemote.Dir = cwd
+	if out, err := cmdRemote.Output(); err == nil {
+		rawURL := strings.TrimSpace(string(out))
+		info.RepoName, info.RepoURL = parseGitRemoteURL(rawURL)
 	}
 
 	// Get ahead/behind from tracking branch
@@ -302,6 +312,38 @@ func parseInt(s string) (int, error) {
 		n = n*10 + int(c-'0')
 	}
 	return n, nil
+}
+
+// parseGitRemoteURL converts a git remote URL (SSH or HTTPS) into a
+// human-readable repo name (owner/repo) and a browsable HTTPS URL.
+func parseGitRemoteURL(rawURL string) (name, browseURL string) {
+	// SSH format: git@github.com:owner/repo.git
+	if strings.HasPrefix(rawURL, "git@") {
+		// git@github.com:owner/repo.git -> github.com/owner/repo
+		trimmed := strings.TrimPrefix(rawURL, "git@")
+		trimmed = strings.TrimSuffix(trimmed, ".git")
+		trimmed = strings.Replace(trimmed, ":", "/", 1)
+		parts := strings.SplitN(trimmed, "/", 3)
+		if len(parts) == 3 {
+			name = parts[1] + "/" + parts[2]
+			browseURL = "https://" + trimmed
+		}
+		return
+	}
+
+	// HTTPS format: https://github.com/owner/repo.git
+	if strings.HasPrefix(rawURL, "https://") || strings.HasPrefix(rawURL, "http://") {
+		trimmed := strings.TrimSuffix(rawURL, ".git")
+		// Extract owner/repo from URL path
+		parts := strings.Split(trimmed, "/")
+		if len(parts) >= 5 {
+			name = parts[len(parts)-2] + "/" + parts[len(parts)-1]
+		}
+		browseURL = trimmed
+		return
+	}
+
+	return "", ""
 }
 
 // gitStatus returns a map of relative path -> status code

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -266,6 +266,12 @@
           </template>
         </div>
         <div class="git-status-bar" x-show="gitInfo">
+          <div class="git-repo-row" x-show="gitInfo?.repo_name" style="display:flex; align-items:center; gap:4px; margin-bottom:2px; font-size:11px; opacity:0.7;">
+            <a :href="gitInfo?.repo_url" target="_blank" rel="noopener" x-text="gitInfo?.repo_name"
+               style="color:var(--text-secondary); text-decoration:none; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"
+               @mouseenter="$el.style.color='var(--accent-color)'; $el.style.textDecoration='underline'"
+               @mouseleave="$el.style.color='var(--text-secondary)'; $el.style.textDecoration='none'"></a>
+          </div>
           <div class="git-branch-row">
             <span class="git-branch-icon">⎇</span>
             <span class="git-branch-name" x-text="gitInfo?.branch || 'detached'"></span>


### PR DESCRIPTION
## Summary
- Parses the git remote URL (SSH and HTTPS formats) to extract owner/repo name and browsable HTTPS URL
- Displays the repo name as a clickable link above the branch name in the file tree sidebar
- Hover highlights with accent color for discoverability

## Changes
- `server/api/filetree.go`: Added `repo_name` and `repo_url` fields to `gitSummaryInfo`, new `parseGitRemoteURL()` helper, and `git remote get-url origin` call in `gitSummary()`
- `server/web/static/index.html`: Added repo link row above the branch row in the git status bar

Closes #15

## Test plan
- [ ] Verify repo link appears for repos with SSH remotes (`git@github.com:...`)
- [ ] Verify repo link appears for repos with HTTPS remotes (`https://github.com/...`)
- [ ] Verify link opens correct GitHub repo page in new tab
- [ ] Verify no link shown when no remote is configured
- [ ] Verify hover styling highlights the link