### PR TITLE
feat: managed session search and two-step Enter

### DIFF
--- a/server/api/browse.go
+++ b/server/api/browse.go
@@ -66,7 +66,7 @@ func (s *Server) handleBrowse(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sort.Slice(dirs, func(i, j int) bool {
-		return dirs[i].Name < dirs[j].Name
+		return strings.ToLower(dirs[i].Name) < strings.ToLower(dirs[j].Name)
 	})
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -36,6 +36,8 @@ document.addEventListener('alpine:init', () => {
     browsePath: '',
     browseEntries: [],
     browseLoading: false,
+    browseFilter: '',
+    browseConfirmed: false,
 
     // Resume picker state
     showResumePicker: false,
@@ -502,11 +504,15 @@ document.addEventListener('alpine:init', () => {
       this.newSessionCWD = '';
       this.browsePath = '';
       this.browseEntries = [];
+      this.browseFilter = '';
+      this.browseConfirmed = false;
       await this.browseTo('');
     },
 
     async browseTo(path) {
       this.browseLoading = true;
+      this.browseFilter = '';
+      this.browseConfirmed = false;
       try {
         const url = '/api/browse' + (path ? '?path=' + encodeURIComponent(path) : '');
         const res = await fetch(url, {
@@ -540,6 +546,33 @@ document.addEventListener('alpine:init', () => {
       }
       const homeIdx = crumbs.findIndex(c => c.skipPrior);
       return homeIdx >= 0 ? crumbs.slice(homeIdx) : crumbs;
+    },
+
+    get filteredBrowseEntries() {
+      if (!this.browseFilter) return this.browseEntries;
+      const q = this.browseFilter.toLowerCase();
+      return this.browseEntries.filter(e => e.name.toLowerCase().includes(q));
+    },
+
+    handleBrowseInputKeydown(event) {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      const val = this.newSessionCWD.trim();
+      if (!val) return;
+
+      // If the input differs from the browsed path, browse to it first
+      if (val !== this.browsePath) {
+        this.browseConfirmed = false;
+        this.browseTo(val);
+        return;
+      }
+
+      // Same path as browsed — if already confirmed, create the session
+      if (this.browseConfirmed) {
+        this.createManagedSession();
+      } else {
+        this.browseConfirmed = true;
+      }
     },
 
     async createManagedSession() {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -341,12 +341,19 @@
     <div style="background:var(--bg); border-radius:12px; padding:24px; width:500px; max-width:90vw; border:1px solid var(--border); display:flex; flex-direction:column; max-height:70vh;">
       <h3 style="margin-top:0; margin-bottom:12px;">New Managed Session</h3>
 
-      <!-- Manual path input -->
-      <div style="display:flex; gap:8px; margin-bottom:12px;">
+      <!-- Path input with search -->
+      <div style="display:flex; gap:8px; margin-bottom:4px;">
         <input x-model="newSessionCWD" type="text" placeholder="/path/to/project"
                style="flex:1; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;"
-               @keydown.enter="createManagedSession()">
+               @keydown="handleBrowseInputKeydown($event)"
+               @input="if (newSessionCWD === browsePath) { browseFilter = ''; } else if (browsePath && newSessionCWD.startsWith(browsePath + '/')) { browseFilter = newSessionCWD.slice(browsePath.length + 1); }">
         <button class="btn btn-sm" @click="browseTo(newSessionCWD)" style="white-space:nowrap;">Go</button>
+      </div>
+      <div x-show="browseConfirmed" style="font-size:11px; color:var(--accent); margin-bottom:8px;">
+        Press Enter again to start session in this folder
+      </div>
+      <div x-show="!browseConfirmed && browseFilter" style="font-size:11px; color:var(--text-muted); margin-bottom:8px;">
+        Filtering: <span x-text="browseFilter"></span>
       </div>
 
       <!-- Breadcrumb navigation -->
@@ -365,11 +372,11 @@
         <template x-if="browseLoading">
           <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
         </template>
-        <template x-if="!browseLoading && browseEntries.length === 0">
-          <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">No subdirectories</div>
+        <template x-if="!browseLoading && filteredBrowseEntries.length === 0">
+          <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;" x-text="browseFilter ? 'No matching directories' : 'No subdirectories'"></div>
         </template>
-        <template x-for="entry in browseEntries" :key="entry.path">
-          <div class="browse-item" @click="browseTo(entry.path)">
+        <template x-for="entry in filteredBrowseEntries" :key="entry.path">
+          <div class="browse-item" @click="browseFilter = ''; browseTo(entry.path)">
             <span class="browse-icon" x-text="entry.is_git_repo ? '&#9679;' : '&#128193;'"
                   :style="entry.is_git_repo ? 'color:var(--green)' : 'color:var(--text-muted)'"></span>
             <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="entry.name"></span>


### PR DESCRIPTION
## Summary
- **Two-step Enter**: Pressing Enter in the path input now browses to that directory first (showing its contents). Pressing Enter again creates the session. Prevents accidentally starting sessions in unintended directories.
- **Live search filtering**: When typing beyond the current browse path (e.g. browsed to `~/workspaces` then typing `~/workspaces/my-pr`), directory entries filter in real-time to show only matching subdirectories.
- Visual hint ("Press Enter again to start session in this folder") shown when path is confirmed and ready for session creation.

## Changes
- `server/web/static/app.js`: Added `browseFilter`, `browseConfirmed` state, `filteredBrowseEntries` computed property, and `handleBrowseInputKeydown()` method
- `server/web/static/index.html`: Updated path input to use new keydown/input handlers, added confirmation hint, directory list uses filtered entries

Closes #23

## Test plan
- [ ] Type a path and press Enter — should browse to that directory (not create a session)
- [ ] Press Enter again on the same path — should create the session
- [ ] Type beyond the browsed path (e.g. add "/my-proj") — should filter directory list in real-time
- [ ] Click a filtered directory entry — should navigate into it and clear the filter
- [ ] Verify "Go" button still works for manual navigation
- [ ] Verify breadcrumb navigation still works