### PR TITLE
feat: show hidden files in file viewer

### DIFF
--- a/server/api/filetree.go
+++ b/server/api/filetree.go
@@ -209,8 +209,8 @@ func gitListFiles(cwd string) ([]string, error) {
 		files = append(files, line)
 	}
 
-	// Get untracked non-ignored files
-	cmd2 := exec.Command("git", "ls-files", "--others", "--exclude-standard")
+	// Get all untracked files (including ignored ones like .env)
+	cmd2 := exec.Command("git", "ls-files", "--others")
 	cmd2.Dir = cwd
 	out2, err := cmd2.Output()
 	if err == nil {
@@ -219,6 +219,7 @@ func gitListFiles(cwd string) ([]string, error) {
 				continue
 			}
 			if _, exists := fileSet[line]; !exists {
+				fileSet[line] = struct{}{}
 				files = append(files, line)
 			}
 		}


### PR DESCRIPTION
## Summary
- Remove `--exclude-standard` flag from `git ls-files --others` in the file tree API so gitignored files (like `.env`) appear in the file viewer
- Previously, only tracked and untracked-but-not-ignored files were shown; now all files on disk are included

Closes #27

## Test plan
- [ ] Open a session with a project that has `.env` or other gitignored dotfiles
- [ ] Verify the file tree shows `.env` and other hidden files
- [ ] Verify existing tracked and untracked files still appear correctly
- [ ] Confirm `go test ./...` passes