### PR TITLE
feat: SSE interrupt for turns management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,3 +73,5 @@ docker compose down                             # Stop
 - Managed sessions plan: `docs/superpowers/plans/2026-03-19-managed-sessions.md`
 - Resume command spec: `docs/superpowers/specs/2026-03-19-resume-command-design.md`
 - Resume command plan: `docs/superpowers/plans/2026-03-19-resume-command.md`
+- SSE interrupt / auto-continue spec: `docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md`
+- SSE interrupt / auto-continue plan: `docs/superpowers/plans/2026-03-23-sse-interrupt-turns-management.md`

--- a/docs/superpowers/plans/2026-03-23-sse-interrupt-turns-management.md
+++ b/docs/superpowers/plans/2026-03-23-sse-interrupt-turns-management.md
@@ -1,0 +1,607 @@
+# SSE Interrupt for Turns Management — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-continue managed sessions when turns run low, preventing Claude from stalling due to turn limits.
+
+**Architecture:** Extend `handleSendMessage`'s streaming goroutine with a loop that detects threshold crossings, sends SIGINT, and re-spawns `claude -p --resume` with a continuation prompt. Two new DB columns store configuration; continuation count is tracked in-memory. The web UI handles two new SSE event types to render auto-continue status.
+
+**Tech Stack:** Go (server), SQLite (DB), Alpine.js (web UI), SSE (streaming)
+
+**Spec:** `docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md`
+
+---
+
+### Task 1: Add DB columns and update Session struct
+
+**Files:**
+- Modify: `server/db/db.go:97` (add migrations)
+- Modify: `server/db/sessions.go:11-28` (Session struct, columns, scanner)
+
+- [ ] **Step 1: Add migration statements**
+
+In `server/db/db.go`, add two new `ALTER TABLE` entries to the `migrations` slice (after the existing `turn_count` migration at line 97):
+
+```go
+`ALTER TABLE sessions ADD COLUMN auto_continue_threshold REAL NOT NULL DEFAULT 0.8`,
+`ALTER TABLE sessions ADD COLUMN max_continuations INTEGER NOT NULL DEFAULT 5`,
+```
+
+- [ ] **Step 2: Update Session struct**
+
+In `server/db/sessions.go`, add fields to the `Session` struct:
+
+```go
+AutoContinueThreshold float64 `json:"auto_continue_threshold"`
+MaxContinuations      int     `json:"max_continuations"`
+```
+
+- [ ] **Step 3: Update sessionColumns and scanSession**
+
+Update `sessionColumns` constant to include the new columns:
+
+```go
+const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), turn_count, auto_continue_threshold, max_continuations`
+```
+
+Update `scanSession` to scan the two new fields:
+
+```go
+err := scanner.Scan(
+    &sess.ID, &sess.ComputerName, &sess.ProjectPath, &sess.TranscriptPath,
+    &sess.Status, &sess.CreatedAt, &sess.LastSeenAt, &archived,
+    &sess.Mode, &sess.CWD, &sess.AllowedTools, &sess.MaxTurns, &sess.MaxBudgetUSD, &initialized,
+    &sess.ClaudeSessionID, &sess.TurnCount, &sess.AutoContinueThreshold, &sess.MaxContinuations,
+)
+```
+
+- [ ] **Step 4: Run existing tests to verify no regressions**
+
+Run: `cd server && go test ./db/ -v`
+Expected: All existing tests PASS (migrations are additive, defaults handle existing rows)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/db/db.go server/db/sessions.go
+git commit -m "feat: add auto_continue_threshold and max_continuations columns"
+```
+
+---
+
+### Task 2: Add DB test for new columns
+
+**Files:**
+- Modify: `server/db/sessions_test.go`
+
+- [ ] **Step 1: Write test for auto-continue defaults**
+
+Add a test that creates a managed session and verifies the default values:
+
+```go
+func TestAutoContinueDefaults(t *testing.T) {
+	store := newTestStore(t)
+	sess, err := store.CreateManagedSession("/tmp/test-ac", `["Bash"]`, 50, 5.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.AutoContinueThreshold != 0.8 {
+		t.Errorf("expected threshold 0.8, got %f", sess.AutoContinueThreshold)
+	}
+	if sess.MaxContinuations != 5 {
+		t.Errorf("expected max_continuations 5, got %d", sess.MaxContinuations)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd server && go test ./db/ -v -run TestAutoContinueDefaults`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/db/sessions_test.go
+git commit -m "test: verify auto_continue defaults on managed sessions"
+```
+
+---
+
+### Task 3: Refactor handleSendMessage into auto-continue loop
+
+This is the core change. The streaming goroutine currently runs once; we wrap it in a loop.
+
+**Files:**
+- Modify: `server/api/managed_sessions.go:56-190`
+
+- [ ] **Step 1: Extract arg-building into a helper**
+
+Create a helper function `buildClaudeArgs` that builds the `claude -p` args from session + message. This will be called once for the initial message, and again for each continuation (with the continuation prompt).
+
+Add this before `handleSendMessage`:
+
+```go
+func buildClaudeArgs(sess *db.Session, message string) []string {
+	var args []string
+	args = append(args, "-p", message)
+
+	resumeID := sess.ID
+	if sess.ClaudeSessionID != "" {
+		resumeID = sess.ClaudeSessionID
+	}
+	if sess.Initialized {
+		args = append(args, "--resume", resumeID)
+	} else {
+		args = append(args, "--session-id", resumeID)
+	}
+
+	args = append(args, "--output-format", "stream-json", "--verbose")
+
+	if sess.AllowedTools != "" {
+		var tools []string
+		json.Unmarshal([]byte(sess.AllowedTools), &tools)
+		if len(tools) > 0 {
+			args = append(args, "--allowedTools", strings.Join(tools, ","))
+		}
+	}
+
+	if sess.MaxBudgetUSD > 0 {
+		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", sess.MaxBudgetUSD))
+	}
+
+	return args
+}
+```
+
+- [ ] **Step 2: Replace inline arg-building in handleSendMessage**
+
+Replace lines 86-112 in `handleSendMessage` with:
+
+```go
+args := buildClaudeArgs(sess, req.Message)
+```
+
+- [ ] **Step 3: Run tests to verify no regression**
+
+Run: `cd server && go test ./api/ -v`
+Expected: All existing API tests PASS
+
+- [ ] **Step 4: Commit refactor**
+
+```bash
+git add server/api/managed_sessions.go
+git commit -m "refactor: extract buildClaudeArgs helper from handleSendMessage"
+```
+
+---
+
+### Task 4: Implement the auto-continue streaming loop
+
+**Files:**
+- Modify: `server/api/managed_sessions.go` (the goroutine in `handleSendMessage`)
+
+- [ ] **Step 1: Rewrite the streaming goroutine**
+
+Replace the goroutine (lines 137-186) with the auto-continue loop. Key changes:
+
+1. Wrap spawn + stream in a `for` loop
+2. Track `continuationCount` and `autoInterrupting` as local variables
+3. Track `turnsSinceLastContinue` for minimum-progress guard
+4. In `onLine`, when threshold is hit: set `autoInterrupting = true`, call `Interrupt()`
+5. After `StreamNDJSON` returns and process exits, check whether to auto-continue
+6. Only send `done` event when the loop terminates
+
+```go
+go func() {
+	defer func() {
+		_ = s.store.SetSessionStatus(sessionID, "idle")
+	}()
+
+	ctx := r.Context()
+	continuationCount := 0
+	// int() truncates toward zero, same as floor() for positive numbers
+	threshold := int(sess.AutoContinueThreshold * float64(sess.MaxTurns))
+	currentMessage := req.Message
+
+	for {
+		// Check context cancellation before each spawn (SSE client disconnect)
+		select {
+		case <-ctx.Done():
+			log.Printf("session %s: client disconnected, stopping auto-continue", sessionID)
+			doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, 0)
+			broadcaster.Send(doneMsg)
+			return
+		default:
+		}
+
+		_ = s.store.ResetTurnCount(sessionID)
+		turnsSinceLastContinue := 0
+		autoInterrupting := false
+
+		args := buildClaudeArgs(sess, currentMessage)
+		proc, err := s.manager.Spawn(sessionID, managed.SpawnOpts{
+			Args: args,
+			CWD:  sess.CWD,
+		})
+		if err != nil {
+			log.Printf("auto-continue spawn error for session %s: %v", sessionID, err)
+			errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to spawn process: %s"}`, err.Error())
+			broadcaster.Send(errMsg)
+			break
+		}
+
+		// After first spawn, ensure subsequent spawns use --resume
+		if !sess.Initialized {
+			_ = s.store.SetInitialized(sessionID)
+			sess.Initialized = true
+		}
+
+		// onLine runs synchronously inside StreamNDJSON's read loop.
+		// autoInterrupting is safe to read after StreamNDJSON returns
+		// because StreamNDJSON blocks until stdout EOF, providing a
+		// happens-before guarantee with <-proc.Done.
+		onLine := func(line string) {
+			if parseRole(line) == "heartbeat" {
+				return
+			}
+			role := parseRole(line)
+			if role == "assistant" {
+				text := extractAssistantText(line)
+				if text != "" {
+					_, _ = s.store.CreateMessage(sessionID, role, text)
+				}
+				for _, toolName := range extractToolNames(line) {
+					_, _ = s.store.CreateMessage(sessionID, "activity", toolName)
+				}
+				turnsSinceLastContinue++
+				count, _ := s.store.IncrementTurnCount(sessionID)
+				if count >= threshold && !autoInterrupting {
+					autoInterrupting = true
+					log.Printf("session %s hit auto-continue threshold (%d/%d), interrupting", sessionID, count, sess.MaxTurns)
+					_ = s.manager.Interrupt(sessionID)
+				}
+			}
+			extractSessionFiles(line, sessionID, s.store)
+		}
+
+		managed.StreamNDJSON(proc.Stdout, broadcaster, onLine)
+
+		stderrBytes, _ := io.ReadAll(proc.Stderr)
+		<-proc.Done
+
+		if proc.ExitCode != 0 && len(stderrBytes) > 0 {
+			errMsg := fmt.Sprintf(`{"type":"system","error":true,"stderr":%q,"exit_code":%d}`, string(stderrBytes), proc.ExitCode)
+			_, _ = s.store.CreateMessageWithExitCode(sessionID, "system", errMsg, proc.ExitCode)
+			broadcaster.Send(errMsg)
+		}
+
+		// Natural exit (code 0) — Claude finished on its own, no auto-continue needed.
+		// This check must come before autoInterrupting, because if Claude exits
+		// naturally at the exact moment we set autoInterrupting, we should not
+		// auto-continue — the work is done.
+		if proc.ExitCode == 0 && !autoInterrupting {
+			doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+			broadcaster.Send(doneMsg)
+			break
+		}
+
+		// Process exited without our threshold SIGINT — manual interrupt or error
+		if !autoInterrupting {
+			doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+			broadcaster.Send(doneMsg)
+			break
+		}
+
+		// Minimum progress guard: need at least 2 turns of work
+		if turnsSinceLastContinue < 2 {
+			log.Printf("session %s not making progress (%d turns), stopping auto-continue", sessionID, turnsSinceLastContinue)
+			_, _ = s.store.CreateMessage(sessionID, "system", "Auto-continue stopped: not making progress")
+			noProgressMsg := fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d,"reason":"no_progress"}`, continuationCount)
+			broadcaster.Send(noProgressMsg)
+			doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+			broadcaster.Send(doneMsg)
+			break
+		}
+
+		continuationCount++
+
+		if continuationCount > sess.MaxContinuations {
+			log.Printf("session %s exhausted auto-continues (%d/%d)", sessionID, continuationCount, sess.MaxContinuations)
+			exhaustedMsg := fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d}`, continuationCount)
+			broadcaster.Send(exhaustedMsg)
+			_, _ = s.store.CreateMessage(sessionID, "system",
+				fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations))
+			doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+			broadcaster.Send(doneMsg)
+			break
+		}
+
+		// Auto-continue
+		continuingMsg := fmt.Sprintf(`{"type":"auto_continuing","continuation_count":%d,"max_continuations":%d}`,
+			continuationCount, sess.MaxContinuations)
+		broadcaster.Send(continuingMsg)
+		_, _ = s.store.CreateMessage(sessionID, "system",
+			fmt.Sprintf("Auto-continuing (%d/%d)...", continuationCount, sess.MaxContinuations))
+
+		currentMessage = "You were interrupted due to turn limits. Continue where you left off."
+	}
+}()
+```
+
+- [ ] **Step 2: Remove old arg-building and persistence code that was replaced**
+
+Remove the old `if !sess.Initialized` block (lines 127-129), the old `CreateMessage` and `SetSessionStatus` calls before the goroutine (lines 131-132), since these are now handled inside the loop. Move the user message persistence and status-setting to before the goroutine starts:
+
+```go
+_, _ = s.store.CreateMessage(sessionID, "user", req.Message)
+_ = s.store.SetSessionStatus(sessionID, "running")
+```
+
+These should remain before the goroutine — they only happen once per user-initiated message.
+
+Also move the initial `Spawn` and `SetInitialized` into the loop (they're handled in the new goroutine code above). The `handleSendMessage` function body before the goroutine should be simplified to:
+1. Parse request, validate session
+2. Do the first spawn to verify it works (or move spawn into the goroutine — see step 1 code)
+3. Persist user message, set status to running
+4. Launch goroutine with the loop
+
+**Important:** The first spawn should happen inside the goroutine (as shown in step 1) since subsequent spawns also happen there. The HTTP handler returns `{"status":"started"}` immediately. The only check needed before starting the goroutine is that no process is already running — use `s.manager.IsRunning(sessionID)` check.
+
+Update `handleSendMessage` to:
+
+```go
+func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	var req struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.Message == "" {
+		http.Error(w, "message is required", http.StatusBadRequest)
+		return
+	}
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			http.Error(w, "session not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	if sess.Mode != "managed" {
+		http.Error(w, "not a managed session", http.StatusBadRequest)
+		return
+	}
+	if s.manager.IsRunning(sessionID) {
+		http.Error(w, "session already has a running process", http.StatusConflict)
+		return
+	}
+
+	_, _ = s.store.CreateMessage(sessionID, "user", req.Message)
+	_ = s.store.SetSessionStatus(sessionID, "running")
+
+	broadcaster := s.manager.GetBroadcaster(sessionID)
+
+	// Auto-continue loop goroutine (from step 1)
+	go func() { /* ... the loop from step 1 ... */ }()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "started"})
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd server && go build ./...`
+Expected: No errors
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/api/managed_sessions.go
+git commit -m "feat: implement auto-continue loop in handleSendMessage"
+```
+
+---
+
+### Task 5: Add auto-continue integration test
+
+**Files:**
+- Modify: `server/api/managed_sessions_test.go`
+
+- [ ] **Step 1: Write test for auto-continue trigger**
+
+This test needs to simulate Claude output that triggers the threshold. Since `Spawn` starts a real process, the test should mock it. Check existing test patterns in `managed_sessions_test.go` for how tests handle process spawning.
+
+If the tests use a real `Manager`, write a test that:
+1. Creates a session with `max_turns=5`, `auto_continue_threshold=0.8` (threshold at turn 4)
+2. Sends a message
+3. Verifies that when turn count hits 4, the auto-continue SSE event is broadcast
+
+If direct mocking isn't practical, write a unit test for the threshold calculation:
+
+```go
+func TestAutoContinueThresholdCalculation(t *testing.T) {
+	// threshold = floor(0.8 * 50) = 40
+	threshold := int(0.8 * float64(50))
+	if threshold != 40 {
+		t.Errorf("expected 40, got %d", threshold)
+	}
+
+	// threshold = floor(0.8 * 5) = 4
+	threshold = int(0.8 * float64(5))
+	if threshold != 4 {
+		t.Errorf("expected 4, got %d", threshold)
+	}
+
+	// Edge: threshold = floor(0.8 * 1) = 0 — would trigger immediately, but minimum progress guard prevents tight loop
+	threshold = int(0.8 * float64(1))
+	if threshold != 0 {
+		t.Errorf("expected 0, got %d", threshold)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd server && go test ./api/ -v -run TestAutoContinue`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/api/managed_sessions_test.go
+git commit -m "test: add auto-continue threshold calculation test"
+```
+
+---
+
+### Task 6: Update web UI to handle auto-continue events
+
+**Files:**
+- Modify: `server/web/static/app.js` (SSE handler in `startSessionSSE`)
+
+- [ ] **Step 1: Handle `auto_continuing` event**
+
+In the `startSessionSSE` method's `onmessage` handler (around line 825, where `done` is handled), add handling for the new event types. Add this *before* the `done` check:
+
+```javascript
+if (data.type === 'auto_continuing') {
+  this.chatMessages.push({
+    id: 'auto-continue-' + Date.now(),
+    role: 'system',
+    content: `Auto-continuing (${data.continuation_count}/${data.max_continuations})...`,
+    isAutoContinue: true
+  });
+  // Reset turn threshold tracker since turn count will reset
+  this.lastTurnThreshold = 0;
+  this.$nextTick(() => this.scrollToBottom(true));
+  return;
+}
+
+if (data.type === 'auto_continue_exhausted') {
+  this.chatMessages.push({
+    id: 'auto-exhausted-' + Date.now(),
+    role: 'system',
+    content: data.reason === 'no_progress'
+      ? 'Auto-continue stopped: not making progress. Send a message to continue.'
+      : `Auto-continue limit reached (${data.continuation_count}). Send a message to continue.`,
+    isAutoContinue: true
+  });
+  this.$nextTick(() => this.scrollToBottom(true));
+  // Don't return — let the done handler below close the SSE
+}
+```
+
+- [ ] **Step 2: Add CSS for auto-continue system messages**
+
+In `server/web/static/app.js` or `index.html`, the system messages rendered in chat should have a distinct style. Check how existing system/error messages are rendered in `index.html` and add a similar template for `isAutoContinue` messages. Look for the chat message rendering template and add:
+
+```html
+<!-- Auto-continue system message -->
+<template x-if="msg.isAutoContinue">
+  <div class="chat-msg system-msg auto-continue-msg" style="text-align:center;opacity:0.7;font-style:italic;padding:8px 0;">
+    <span x-text="msg.content"></span>
+  </div>
+</template>
+```
+
+- [ ] **Step 3: Update turn toast logic**
+
+In the global SSE handler (around line 161-180), update the 100% threshold toast to account for auto-continue. When `turn_count` resets to 0, the existing code already resets `lastTurnThreshold`. No changes needed — the existing logic handles the reset correctly.
+
+However, update the 100% toast message to be more accurate when auto-continue is enabled:
+
+```javascript
+if (pct >= 100 && this.lastTurnThreshold < 100) {
+  this.toast(`Turn limit reached (${sess.turn_count}/${sess.max_turns}) — auto-continuing if enabled`, 8000, 'info');
+  this.lastTurnThreshold = 100;
+}
+```
+
+- [ ] **Step 4: Verify manually** (skip in automated tests — UI changes)
+
+Open the web UI, create a managed session, and verify that auto-continue events render correctly. This is a manual verification step.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/web/static/app.js server/web/static/index.html
+git commit -m "feat: handle auto-continue SSE events in web UI"
+```
+
+---
+
+### Task 7: Handle manual interrupt during auto-continue
+
+**Files:**
+- Modify: `server/api/managed_sessions.go` (the auto-continue loop)
+
+The current implementation already handles this correctly: `autoInterrupting` is a goroutine-local variable. If a manual `POST /interrupt` fires, the process exits with SIGINT but `autoInterrupting` is `false`, so the loop breaks and sends `done`.
+
+- [ ] **Step 1: Verify the logic by tracing the code path**
+
+Read through the loop and confirm:
+1. `autoInterrupting` starts as `false` each iteration
+2. Only set to `true` by the `onLine` callback when threshold is hit
+3. After `<-proc.Done`, if `!autoInterrupting` → break (manual interrupt or natural exit)
+4. If `autoInterrupting` → auto-continue
+
+This is already correct in the Task 4 implementation. No code changes needed.
+
+- [ ] **Step 2: Commit** (skip if no changes)
+
+---
+
+### Task 8: Run full test suite and verify
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all Go tests**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Build the server**
+
+Run: `cd server && go build -o claude-controller .`
+Expected: Compiles with no errors
+
+- [ ] **Step 3: Commit any final fixes**
+
+If any tests fail, fix and commit.
+
+---
+
+### Task 9: Update CLAUDE.md spec references
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add spec and plan references**
+
+Add to the "Spec & Plan" section in `CLAUDE.md`:
+
+```markdown
+- SSE interrupt / auto-continue spec: `docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md`
+- SSE interrupt / auto-continue plan: `docs/superpowers/plans/2026-03-23-sse-interrupt-turns-management.md`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add SSE interrupt spec and plan references to CLAUDE.md"
+```

--- a/docs/superpowers/specs/2026-03-22-usage-availability-design.md
+++ b/docs/superpowers/specs/2026-03-22-usage-availability-design.md
@@ -38,7 +38,7 @@ TurnCount int `json:"turn_count"`
 
 ### Managed Sessions (`api/managed_sessions.go`)
 
-- At start of `handleSendMessage`, call `ResetTurnCount(sessionID)` to reset for the new message
+- At start of `handleSendMessage`, call `ResetTurnCount(sessionID)` to reset for the new message. This matches the existing behavior where `turnCount` is a local variable scoped per `handleSendMessage` call — it tracks turns within a single user-message exchange, not cumulative across the session.
 - Replace local `turnCount` variable with DB-backed `IncrementTurnCount` call on each assistant message
 - The turn limit check uses the returned count from `IncrementTurnCount`
 
@@ -61,6 +61,8 @@ Layout:
 ```
 
 The panel sits between the session list and the bottom of the sidebar, separated by a border-top.
+
+**Mobile:** The left sidebar is hidden on mobile (replaced by a `<select>` dropdown). The usage panel will only be visible on desktop. Mobile usage visibility is out of scope for this iteration.
 
 ### Progress Bar Colors
 
@@ -89,7 +91,9 @@ Threshold triggers (fire once per threshold crossing):
 | 90% | error | "Turn limit critical (45/50) — session will be interrupted soon" |
 | 100% | error | "Session interrupted — turn limit reached (50/50)" |
 
-Track `lastTurnThreshold` per session in Alpine.js state to prevent duplicate toasts. Reset when selecting a different session or when turn count resets to 0.
+Track `lastTurnThreshold` per session in Alpine.js state to prevent duplicate toasts. Reset when selecting a different session or when turn count resets to 0. This state is ephemeral — on page refresh, thresholds may re-fire if the session is still above a threshold. This is acceptable since it serves as a reminder.
+
+Add `toastType` to Alpine.js state (default `'info'`). Update the toast HTML element to apply the type as a CSS class: `:class="{ visible: showToast, warning: toastType === 'warning', error: toastType === 'error' }"`.
 
 ### Toast Styling (`style.css`)
 
@@ -109,6 +113,11 @@ In the existing SSE "update" event handler that processes sessions, after updati
 3. Determine threshold bucket (0, 80, 90, 100)
 4. If threshold > lastTurnThreshold, fire appropriate toast
 5. Update `lastTurnThreshold`
+
+**Edge cases:**
+- **SSE race on reset:** When `ResetTurnCount` is called at the start of a new message, SSE may briefly deliver `0/50` before assistant messages arrive. The frontend should only update the usage display when the session status is "running" and `turn_count > 0`, or when status transitions to "idle".
+- **100% toast reliability:** The 3-second SSE polling interval means the frontend may not observe the exact 100% value if the session completes between polls. The 100% toast is best-effort. The session transitioning to "idle" after SIGINT is the definitive signal.
+- **Resume sessions:** `ResumeSession` in `db/sessions.go` should also reset `turn_count` to 0, consistent with how it resets `initialized` and deletes messages.
 
 ## Data Flow
 

--- a/docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md
+++ b/docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md
@@ -1,0 +1,99 @@
+# SSE Interrupt for Turns Management
+
+**Date:** 2026-03-23
+**Issue:** #36
+**Status:** Design
+
+## Problem
+
+Managed sessions using the Superpowers plugin consume many turns internally (tool calls, thinking, etc.). When `turn_count` reaches `max_turns`, the server sends SIGINT and Claude stops. The user must manually intervene to resume progress. This creates a poor experience for autonomous workflows.
+
+## Solution
+
+Server-side auto-continue: when turns approach the limit, the server interrupts Claude, then automatically resumes with a continuation prompt. The turn counter resets on each re-spawn, allowing Claude to keep working across multiple continuation cycles.
+
+## Data Model
+
+Two new columns on the `sessions` table:
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `auto_continue_threshold` | REAL | 0.8 | Fraction of `max_turns` at which to trigger auto-continue (0.0–1.0) |
+| `max_continuations` | INTEGER | 5 | Max auto-resumes per user message before requiring manual intervention |
+
+`continuation_count` is tracked in-memory within the streaming goroutine — not persisted. It resets with each user-initiated `POST /message`.
+
+## Auto-Continue Flow
+
+```
+1. User sends POST /message
+   → ResetTurnCount(), continuation_count = 0
+
+2. Spawn `claude -p` (with --resume if initialized)
+
+3. Stream NDJSON, count assistant turns
+
+4. On each assistant message:
+   a. IncrementTurnCount()
+   b. If turn_count >= floor(auto_continue_threshold * max_turns):
+      i.   Set autoInterrupting flag
+      ii.  Send SIGINT to process
+      iii. Wait for process to exit
+      iv.  Clear autoInterrupting flag
+      v.   Increment continuation_count
+      vi.  If continuation_count > max_continuations:
+           → Broadcast SSE: {"type":"auto_continue_exhausted","continuation_count":N}
+           → Persist system message: "Auto-continue limit reached (N/N)"
+           → Break loop, session goes idle
+      vii. Broadcast SSE: {"type":"auto_continuing","continuation_count":N,"max_continuations":M}
+      viii.Persist system message: "Auto-continuing (N/M)..."
+      ix.  ResetTurnCount()
+      x.   Spawn new `claude -p --resume` with prompt:
+           "You were interrupted due to turn limits. Continue where you left off."
+      xi.  Continue streaming from step 3
+
+5. If process exits naturally (exit code 0):
+   → Done, no auto-continue needed
+```
+
+## SSE Events
+
+Two new event types sent through the existing per-session SSE stream:
+
+| Event | Payload | When |
+|-------|---------|------|
+| `auto_continuing` | `{"type":"auto_continuing","continuation_count":N,"max_continuations":M}` | After threshold SIGINT, before re-spawn |
+| `auto_continue_exhausted` | `{"type":"auto_continue_exhausted","continuation_count":N}` | When `max_continuations` reached |
+
+## Web UI Behavior
+
+- **`auto_continuing` event**: Render a system message in chat: "Auto-continuing (2/5)..." Usage panel resets turn progress bar.
+- **`auto_continue_exhausted` event**: Render system message: "Auto-continue limit reached. Send a message to continue manually." Session transitions to idle.
+- Existing interrupt button still works — manual SIGINT breaks the auto-continue loop.
+
+## Edge Cases
+
+### Manual interrupt during auto-continue
+The streaming goroutine sets an `autoInterrupting` flag before sending SIGINT for threshold reasons. If the process exits via SIGINT without that flag set, it means the user manually interrupted — break the loop and go idle.
+
+### Claude finishes before threshold
+Process exits with code 0 naturally. No auto-continue needed, loop ends cleanly. This is the happy path.
+
+### Non-zero exit (error)
+Don't auto-continue on errors. Only auto-continue when the exit was caused by the server's threshold SIGINT.
+
+### Minimum progress guard
+If the process completes fewer than 2 assistant turns before hitting the threshold again, treat it as "not making progress" and stop the auto-continue loop. This prevents tight loops when `max_turns` is very small or the threshold is misconfigured.
+
+### SSE client disconnects
+The goroutine detects context cancellation and stops spawning new processes. Clean shutdown.
+
+## Configuration
+
+No changes to `POST /api/sessions/create` request shape — the new fields use defaults. They can be exposed in the session creation UI later if needed.
+
+The defaults (80% threshold, 5 max continuations) work with the existing `max_turns` default of 50, meaning auto-continue triggers at turn 40 and allows up to 5 cycles (effectively 200 assistant turns per user message before requiring manual intervention).
+
+## Global SSE Integration
+
+The existing `GET /api/events` endpoint (3-second broadcast) already includes `turn_count` per session. No changes needed — the UI will see `turn_count` reset to 0 on each auto-continue cycle, and the usage panel will update accordingly.

--- a/docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md
+++ b/docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md
@@ -12,6 +12,10 @@ Managed sessions using the Superpowers plugin consume many turns internally (too
 
 Server-side auto-continue: when turns approach the limit, the server interrupts Claude, then automatically resumes with a continuation prompt. The turn counter resets on each re-spawn, allowing Claude to keep working across multiple continuation cycles.
 
+## Terminology
+
+**`turn_count`** counts assistant message events in the NDJSON stream (each line with `type === "assistant"`), not logical conversation turns. A single logical turn with multiple tool calls produces multiple assistant messages. The threshold calculation and `max_turns` value are calibrated to this counting behavior.
+
 ## Data Model
 
 Two new columns on the `sessions` table:
@@ -21,9 +25,13 @@ Two new columns on the `sessions` table:
 | `auto_continue_threshold` | REAL | 0.8 | Fraction of `max_turns` at which to trigger auto-continue (0.0–1.0) |
 | `max_continuations` | INTEGER | 5 | Max auto-resumes per user message before requiring manual intervention |
 
+**Validation:** `auto_continue_threshold` must be in range (0.0, 1.0]. A value of 0.0 or negative is invalid (would trigger immediately). A value of 1.0 means auto-continue triggers at exactly `max_turns`, effectively replacing the existing hard-limit behavior.
+
 `continuation_count` is tracked in-memory within the streaming goroutine — not persisted. It resets with each user-initiated `POST /message`.
 
 ## Auto-Continue Flow
+
+The auto-continue logic **replaces** the existing hard-limit SIGINT in `handleSendMessage`. The current `if count >= sess.MaxTurns` block is removed; the threshold-based auto-continue subsumes it.
 
 ```
 1. User sends POST /message
@@ -31,22 +39,23 @@ Two new columns on the `sessions` table:
 
 2. Spawn `claude -p` (with --resume if initialized)
 
-3. Stream NDJSON, count assistant turns
+3. Stream NDJSON, count assistant messages
+   → Session status remains "running" throughout the entire loop
 
 4. On each assistant message:
    a. IncrementTurnCount()
    b. If turn_count >= floor(auto_continue_threshold * max_turns):
-      i.   Set autoInterrupting flag
-      ii.  Send SIGINT to process
-      iii. Wait for process to exit
+      i.   Set autoInterrupting flag (goroutine-local variable)
+      ii.  Send SIGINT to process via Manager.Interrupt()
+      iii. Wait for process to exit (<-proc.Done)
       iv.  Clear autoInterrupting flag
       v.   Increment continuation_count
       vi.  If continuation_count > max_continuations:
            → Broadcast SSE: {"type":"auto_continue_exhausted","continuation_count":N}
-           → Persist system message: "Auto-continue limit reached (N/N)"
+           → Persist message with role "system": "Auto-continue limit reached (N/N)"
            → Break loop, session goes idle
       vii. Broadcast SSE: {"type":"auto_continuing","continuation_count":N,"max_continuations":M}
-      viii.Persist system message: "Auto-continuing (N/M)..."
+      viii.Persist message with role "system": "Auto-continuing (N/M)..."
       ix.  ResetTurnCount()
       x.   Spawn new `claude -p --resume` with prompt:
            "You were interrupted due to turn limits. Continue where you left off."
@@ -55,6 +64,13 @@ Two new columns on the `sessions` table:
 5. If process exits naturally (exit code 0):
    → Done, no auto-continue needed
 ```
+
+### Key implementation details
+
+- **`autoInterrupting` is goroutine-local**: It is a plain `bool` variable inside the streaming goroutine, not a shared field on `Process` or `Manager`. Set before SIGINT, checked after process exits.
+- **`done` SSE event suppression**: The `{"type":"done","exit_code":N}` event must only be sent when the auto-continue loop terminates (natural exit, exhaustion, manual interrupt, or error) — not after each intermediate process exit. The web UI's `done` handler calls `stopSessionSSE()`, so sending it prematurely would disconnect the client mid-loop.
+- **Session status stays `"running"`**: Throughout the auto-continue loop, the session status remains `"running"` and only transitions to `"idle"` when the loop terminates. This prevents the UI from briefly showing the session as idle between cycles.
+- **Re-spawn safety**: `proc.Done` is closed after the process is removed from `m.procs` (current code: `delete` then `close(proc.Done)`), so calling `Spawn` after `<-proc.Done` is safe — no race with the cleanup goroutine.
 
 ## SSE Events
 
@@ -67,20 +83,20 @@ Two new event types sent through the existing per-session SSE stream:
 
 ## Web UI Behavior
 
-- **`auto_continuing` event**: Render a system message in chat: "Auto-continuing (2/5)..." Usage panel resets turn progress bar.
+- **`auto_continuing` event**: Render a system message in chat: "Auto-continuing (2/5)..." with role `"system"`. Usage panel resets the turn progress bar.
 - **`auto_continue_exhausted` event**: Render system message: "Auto-continue limit reached. Send a message to continue manually." Session transitions to idle.
 - Existing interrupt button still works — manual SIGINT breaks the auto-continue loop.
 
 ## Edge Cases
 
 ### Manual interrupt during auto-continue
-The streaming goroutine sets an `autoInterrupting` flag before sending SIGINT for threshold reasons. If the process exits via SIGINT without that flag set, it means the user manually interrupted — break the loop and go idle.
+The streaming goroutine checks the `autoInterrupting` flag after the process exits. If the process was SIGINT'd without the flag being set, it was a manual interrupt (via `POST /interrupt`). In that case, break the loop and go idle. Since the flag is goroutine-local and only the streaming goroutine sets it, there is no race condition.
 
 ### Claude finishes before threshold
 Process exits with code 0 naturally. No auto-continue needed, loop ends cleanly. This is the happy path.
 
 ### Non-zero exit (error)
-Don't auto-continue on errors. Only auto-continue when the exit was caused by the server's threshold SIGINT.
+Don't auto-continue on errors. Only auto-continue when the exit was caused by the server's threshold SIGINT (i.e., `autoInterrupting` was true when the process exited).
 
 ### Minimum progress guard
 If the process completes fewer than 2 assistant turns before hitting the threshold again, treat it as "not making progress" and stop the auto-continue loop. This prevents tight loops when `max_turns` is very small or the threshold is misconfigured.
@@ -92,8 +108,8 @@ The goroutine detects context cancellation and stops spawning new processes. Cle
 
 No changes to `POST /api/sessions/create` request shape — the new fields use defaults. They can be exposed in the session creation UI later if needed.
 
-The defaults (80% threshold, 5 max continuations) work with the existing `max_turns` default of 50, meaning auto-continue triggers at turn 40 and allows up to 5 cycles (effectively 200 assistant turns per user message before requiring manual intervention).
+The defaults (80% threshold, 5 max continuations) work with the existing `max_turns` default of 50, meaning auto-continue triggers at assistant message 40 and allows up to 5 cycles (effectively 200 assistant messages per user message before requiring manual intervention).
 
 ## Global SSE Integration
 
-The existing `GET /api/events` endpoint (3-second broadcast) already includes `turn_count` per session. No changes needed — the UI will see `turn_count` reset to 0 on each auto-continue cycle, and the usage panel will update accordingly.
+The existing `GET /api/events` endpoint (3-second broadcast) already includes `turn_count` per session. The global broadcast will also include `continuation_count` (read from an in-memory field on the manager) so the session list can show "Auto-continuing 2/5" status. The UI will see `turn_count` reset to 0 on each auto-continue cycle, and the usage panel will update accordingly.

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -53,6 +53,37 @@ func (s *Server) handleCreateManagedSession(w http.ResponseWriter, r *http.Reque
 	json.NewEncoder(w).Encode(sess)
 }
 
+func buildClaudeArgs(sess *db.Session, message string) []string {
+	var args []string
+	args = append(args, "-p", message)
+
+	resumeID := sess.ID
+	if sess.ClaudeSessionID != "" {
+		resumeID = sess.ClaudeSessionID
+	}
+	if sess.Initialized {
+		args = append(args, "--resume", resumeID)
+	} else {
+		args = append(args, "--session-id", resumeID)
+	}
+
+	args = append(args, "--output-format", "stream-json", "--verbose")
+
+	if sess.AllowedTools != "" {
+		var tools []string
+		json.Unmarshal([]byte(sess.AllowedTools), &tools)
+		if len(tools) > 0 {
+			args = append(args, "--allowedTools", strings.Join(tools, ","))
+		}
+	}
+
+	if sess.MaxBudgetUSD > 0 {
+		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", sess.MaxBudgetUSD))
+	}
+
+	return args
+}
+
 func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 
@@ -81,51 +112,9 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not a managed session", http.StatusBadRequest)
 		return
 	}
-
-	// Build claude args
-	var args []string
-	args = append(args, "-p", req.Message)
-
-	// Use claude_session_id if set (resumed session), otherwise use managed session's own ID
-	resumeID := sessionID
-	if sess.ClaudeSessionID != "" {
-		resumeID = sess.ClaudeSessionID
-	}
-	if sess.Initialized {
-		args = append(args, "--resume", resumeID)
-	} else {
-		args = append(args, "--session-id", resumeID)
-	}
-
-	args = append(args, "--output-format", "stream-json", "--verbose")
-
-	if sess.AllowedTools != "" {
-		var tools []string
-		json.Unmarshal([]byte(sess.AllowedTools), &tools)
-		if len(tools) > 0 {
-			args = append(args, "--allowedTools", strings.Join(tools, ","))
-		}
-	}
-
-	if sess.MaxBudgetUSD > 0 {
-		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", sess.MaxBudgetUSD))
-	}
-
-	proc, err := s.manager.Spawn(sessionID, managed.SpawnOpts{
-		Args: args,
-		CWD:  sess.CWD,
-	})
-	if err != nil {
-		if strings.Contains(err.Error(), "already has a running process") {
-			http.Error(w, err.Error(), http.StatusConflict)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+	if s.manager.IsRunning(sessionID) {
+		http.Error(w, "session already has a running process", http.StatusConflict)
 		return
-	}
-
-	if !sess.Initialized {
-		_ = s.store.SetInitialized(sessionID)
 	}
 
 	_, _ = s.store.CreateMessage(sessionID, "user", req.Message)
@@ -133,56 +122,136 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 	broadcaster := s.manager.GetBroadcaster(sessionID)
 
-	// Background: stream stdout, persist inline, cleanup
 	go func() {
-		_ = s.store.ResetTurnCount(sessionID)
+		defer func() {
+			_ = s.store.SetSessionStatus(sessionID, "idle")
+		}()
 
-		onLine := func(line string) {
-			// Don't persist heartbeat messages
-			if parseRole(line) == "heartbeat" {
+		ctx := r.Context()
+		continuationCount := 0
+		// int() truncates toward zero, same as floor() for positive numbers
+		threshold := int(sess.AutoContinueThreshold * float64(sess.MaxTurns))
+		currentMessage := req.Message
+
+		for {
+			// Check context cancellation before each spawn (SSE client disconnect)
+			select {
+			case <-ctx.Done():
+				log.Printf("session %s: client disconnected, stopping auto-continue", sessionID)
+				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, 0)
+				broadcaster.Send(doneMsg)
 				return
+			default:
 			}
 
-			role := parseRole(line)
+			_ = s.store.ResetTurnCount(sessionID)
+			turnsSinceLastContinue := 0
+			autoInterrupting := false
 
-			// Only persist assistant text to the DB — skip system init,
-			// user echo, tool_use, tool_result, and result messages.
-			if role == "assistant" {
-				text := extractAssistantText(line)
-				if text != "" {
-					_, _ = s.store.CreateMessage(sessionID, role, text)
-				}
-				// Persist tool_use blocks as activity pills
-				for _, toolName := range extractToolNames(line) {
-					_, _ = s.store.CreateMessage(sessionID, "activity", toolName)
-				}
-				count, _ := s.store.IncrementTurnCount(sessionID)
-				if count >= sess.MaxTurns {
-					log.Printf("session %s hit turn limit (%d), interrupting", sessionID, sess.MaxTurns)
-					_ = s.manager.Interrupt(sessionID)
-				}
+			args := buildClaudeArgs(sess, currentMessage)
+			proc, err := s.manager.Spawn(sessionID, managed.SpawnOpts{
+				Args: args,
+				CWD:  sess.CWD,
+			})
+			if err != nil {
+				log.Printf("auto-continue spawn error for session %s: %v", sessionID, err)
+				errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to spawn process: %s"}`, err.Error())
+				broadcaster.Send(errMsg)
+				break
 			}
 
-			// Extract file paths from tool_use content blocks
-			extractSessionFiles(line, sessionID, s.store)
+			// After first spawn, ensure subsequent spawns use --resume
+			if !sess.Initialized {
+				_ = s.store.SetInitialized(sessionID)
+				sess.Initialized = true
+			}
+
+			// onLine runs synchronously inside StreamNDJSON's read loop.
+			// autoInterrupting is safe to read after StreamNDJSON returns
+			// because StreamNDJSON blocks until stdout EOF, providing a
+			// happens-before guarantee with <-proc.Done.
+			onLine := func(line string) {
+				if parseRole(line) == "heartbeat" {
+					return
+				}
+				role := parseRole(line)
+				if role == "assistant" {
+					text := extractAssistantText(line)
+					if text != "" {
+						_, _ = s.store.CreateMessage(sessionID, role, text)
+					}
+					for _, toolName := range extractToolNames(line) {
+						_, _ = s.store.CreateMessage(sessionID, "activity", toolName)
+					}
+					turnsSinceLastContinue++
+					count, _ := s.store.IncrementTurnCount(sessionID)
+					if count >= threshold && !autoInterrupting {
+						autoInterrupting = true
+						log.Printf("session %s hit auto-continue threshold (%d/%d), interrupting", sessionID, count, sess.MaxTurns)
+						_ = s.manager.Interrupt(sessionID)
+					}
+				}
+				extractSessionFiles(line, sessionID, s.store)
+			}
+
+			managed.StreamNDJSON(proc.Stdout, broadcaster, onLine)
+
+			stderrBytes, _ := io.ReadAll(proc.Stderr)
+			<-proc.Done
+
+			if proc.ExitCode != 0 && len(stderrBytes) > 0 {
+				errMsg := fmt.Sprintf(`{"type":"system","error":true,"stderr":%q,"exit_code":%d}`, string(stderrBytes), proc.ExitCode)
+				_, _ = s.store.CreateMessageWithExitCode(sessionID, "system", errMsg, proc.ExitCode)
+				broadcaster.Send(errMsg)
+			}
+
+			// Natural exit (code 0) — Claude finished on its own, no auto-continue needed.
+			if proc.ExitCode == 0 && !autoInterrupting {
+				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+				broadcaster.Send(doneMsg)
+				break
+			}
+
+			// Process exited without our threshold SIGINT — manual interrupt or error
+			if !autoInterrupting {
+				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+				broadcaster.Send(doneMsg)
+				break
+			}
+
+			// Minimum progress guard: need at least 2 turns of work
+			if turnsSinceLastContinue < 2 {
+				log.Printf("session %s not making progress (%d turns), stopping auto-continue", sessionID, turnsSinceLastContinue)
+				_, _ = s.store.CreateMessage(sessionID, "system", "Auto-continue stopped: not making progress")
+				noProgressMsg := fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d,"reason":"no_progress"}`, continuationCount)
+				broadcaster.Send(noProgressMsg)
+				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+				broadcaster.Send(doneMsg)
+				break
+			}
+
+			continuationCount++
+
+			if continuationCount > sess.MaxContinuations {
+				log.Printf("session %s exhausted auto-continues (%d/%d)", sessionID, continuationCount, sess.MaxContinuations)
+				exhaustedMsg := fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d}`, continuationCount)
+				broadcaster.Send(exhaustedMsg)
+				_, _ = s.store.CreateMessage(sessionID, "system",
+					fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations))
+				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
+				broadcaster.Send(doneMsg)
+				break
+			}
+
+			// Auto-continue
+			continuingMsg := fmt.Sprintf(`{"type":"auto_continuing","continuation_count":%d,"max_continuations":%d}`,
+				continuationCount, sess.MaxContinuations)
+			broadcaster.Send(continuingMsg)
+			_, _ = s.store.CreateMessage(sessionID, "system",
+				fmt.Sprintf("Auto-continuing (%d/%d)...", continuationCount, sess.MaxContinuations))
+
+			currentMessage = "You were interrupted due to turn limits. Continue where you left off."
 		}
-
-		managed.StreamNDJSON(proc.Stdout, broadcaster, onLine)
-
-		stderrBytes, _ := io.ReadAll(proc.Stderr)
-
-		<-proc.Done
-
-		if proc.ExitCode != 0 && len(stderrBytes) > 0 {
-			errMsg := fmt.Sprintf(`{"type":"system","error":true,"stderr":%q,"exit_code":%d}`, string(stderrBytes), proc.ExitCode)
-			_, _ = s.store.CreateMessageWithExitCode(sessionID, "system", errMsg, proc.ExitCode)
-			broadcaster.Send(errMsg)
-		}
-
-		doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
-		broadcaster.Send(doneMsg)
-
-		_ = s.store.SetSessionStatus(sessionID, "idle")
 	}()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -251,3 +251,26 @@ func TestShellExecutePersistsMessages(t *testing.T) {
 		t.Error("expected shell_output message to be persisted")
 	}
 }
+
+func TestAutoContinueThresholdCalculation(t *testing.T) {
+	// threshold = floor(0.8 * 50) = 40
+	val := float64(50) * 0.8
+	threshold := int(val)
+	if threshold != 40 {
+		t.Errorf("expected 40, got %d", threshold)
+	}
+
+	// threshold = floor(0.8 * 5) = 4
+	val = float64(5) * 0.8
+	threshold = int(val)
+	if threshold != 4 {
+		t.Errorf("expected 4, got %d", threshold)
+	}
+
+	// Edge: threshold = floor(0.8 * 1) = 0
+	val = float64(1) * 0.8
+	threshold = int(val)
+	if threshold != 0 {
+		t.Errorf("expected 0, got %d", threshold)
+	}
+}

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -95,6 +95,8 @@ func migrate(db *sql.DB) error {
     UNIQUE(session_id, file_path, action)
 )`,
 		`ALTER TABLE sessions ADD COLUMN turn_count INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN auto_continue_threshold REAL NOT NULL DEFAULT 0.8`,
+		`ALTER TABLE sessions ADD COLUMN max_continuations INTEGER NOT NULL DEFAULT 5`,
 	}
 
 	for _, m := range migrations {

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -23,11 +23,13 @@ type Session struct {
 	MaxTurns       int       `json:"max_turns"`
 	MaxBudgetUSD   float64   `json:"max_budget_usd"`
 	Initialized     bool   `json:"initialized"`
-	ClaudeSessionID string `json:"claude_session_id,omitempty"`
-	TurnCount       int    `json:"turn_count"`
+	ClaudeSessionID       string  `json:"claude_session_id,omitempty"`
+	TurnCount             int     `json:"turn_count"`
+	AutoContinueThreshold float64 `json:"auto_continue_threshold"`
+	MaxContinuations      int     `json:"max_continuations"`
 }
 
-const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), turn_count`
+const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), turn_count, auto_continue_threshold, max_continuations`
 
 func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, error) {
 	var sess Session
@@ -36,7 +38,7 @@ func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, erro
 		&sess.ID, &sess.ComputerName, &sess.ProjectPath, &sess.TranscriptPath,
 		&sess.Status, &sess.CreatedAt, &sess.LastSeenAt, &archived,
 		&sess.Mode, &sess.CWD, &sess.AllowedTools, &sess.MaxTurns, &sess.MaxBudgetUSD, &initialized,
-		&sess.ClaudeSessionID, &sess.TurnCount,
+		&sess.ClaudeSessionID, &sess.TurnCount, &sess.AutoContinueThreshold, &sess.MaxContinuations,
 	)
 	if err != nil {
 		return sess, err

--- a/server/db/sessions_test.go
+++ b/server/db/sessions_test.go
@@ -185,3 +185,17 @@ func TestResumeSessionResetsTurnCount(t *testing.T) {
 		t.Errorf("expected turn_count=0 after resume, got %d", resumed.TurnCount)
 	}
 }
+
+func TestAutoContinueDefaults(t *testing.T) {
+	store := newTestStore(t)
+	sess, err := store.CreateManagedSession("/tmp/test-ac", `["Bash"]`, 50, 5.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.AutoContinueThreshold != 0.8 {
+		t.Errorf("expected threshold 0.8, got %f", sess.AutoContinueThreshold)
+	}
+	if sess.MaxContinuations != 5 {
+		t.Errorf("expected max_continuations 5, got %d", sess.MaxContinuations)
+	}
+}

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -169,7 +169,7 @@ document.addEventListener('alpine:init', () => {
               }
               // Fire toasts at threshold crossings
               if (pct >= 100 && this.lastTurnThreshold < 100) {
-                this.toast(`Session interrupted \u2014 turn limit reached (${sess.turn_count}/${sess.max_turns})`, 8000, 'error');
+                this.toast(`Turn limit reached (${sess.turn_count}/${sess.max_turns}) — auto-continuing if enabled`, 8000, 'info');
                 this.lastTurnThreshold = 100;
               } else if (pct >= 90 && this.lastTurnThreshold < 90) {
                 this.toast(`Turn limit critical (${sess.turn_count}/${sess.max_turns}) \u2014 session will be interrupted soon`, 6000, 'error');
@@ -822,6 +822,32 @@ document.addEventListener('alpine:init', () => {
             return;
           }
 
+          if (data.type === 'auto_continuing') {
+            this.chatMessages.push({
+              id: 'auto-continue-' + Date.now(),
+              role: 'system',
+              content: `Auto-continuing (${data.continuation_count}/${data.max_continuations})...`,
+              isAutoContinue: true
+            });
+            // Reset turn threshold tracker since turn count will reset
+            this.lastTurnThreshold = 0;
+            this.$nextTick(() => this.scrollToBottom(true));
+            return;
+          }
+
+          if (data.type === 'auto_continue_exhausted') {
+            this.chatMessages.push({
+              id: 'auto-exhausted-' + Date.now(),
+              role: 'system',
+              content: data.reason === 'no_progress'
+                ? 'Auto-continue stopped: not making progress. Send a message to continue.'
+                : `Auto-continue limit reached (${data.continuation_count}). Send a message to continue.`,
+              isAutoContinue: true
+            });
+            this.$nextTick(() => this.scrollToBottom(true));
+            // Don't return — let the done handler below close the SSE
+          }
+
           if (data.type === 'done' || data.type === 'result') {
             // Mark the current active pill as completed (don't clear — pills persist until next message)
             const activePill = this.chatMessages.find(m => m.role === 'activity' && m.pillState === 'active');
@@ -999,7 +1025,7 @@ document.addEventListener('alpine:init', () => {
         if (!res.ok) return;
         const msgs = await res.json();
         this.chatMessages = (msgs || [])
-          .filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'activity' || m.role === 'shell' || m.role === 'shell_output' || (m.role === 'system' && m.content && m.content.includes('"error"')))
+          .filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'activity' || m.role === 'shell' || m.role === 'shell_output' || (m.role === 'system' && m.content && (m.content.includes('"error"') || m.content.startsWith('Auto-continu'))))
           .map(m => {
             if (m.role === 'activity') {
               return {
@@ -1030,6 +1056,14 @@ document.addEventListener('alpine:init', () => {
               } catch (e) {
                 return { role: 'shell_output', stdout: m.content, stderr: '', exitCode: null, timedOut: false, shellId: null, complete: true, timestamp: m.created_at };
               }
+            }
+            if (m.role === 'system' && m.content && m.content.startsWith('Auto-continu')) {
+              return {
+                role: 'system',
+                content: m.content,
+                isAutoContinue: true,
+                timestamp: m.created_at
+              };
             }
             return {
               role: m.role,

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -162,7 +162,12 @@
                       </div>
                     </div>
                   </template>
-                  <template x-if="msg.role !== 'activity' && msg.role !== 'shell' && msg.role !== 'shell_output'">
+                  <template x-if="msg.isAutoContinue">
+                    <div class="chat-msg system-msg auto-continue-msg" style="text-align:center;opacity:0.7;font-style:italic;padding:8px 0;">
+                      <span x-text="msg.content"></span>
+                    </div>
+                  </template>
+                  <template x-if="!msg.isAutoContinue && msg.role !== 'activity' && msg.role !== 'shell' && msg.role !== 'shell_output'">
                     <div class="chat-bubble"
                          :class="bubbleClass(msg, idx)"
                          x-html="bubbleHTML(msg)">


### PR DESCRIPTION
## Summary

Implements auto-continue for managed sessions when turns run low, preventing Claude from stalling due to turn limits. Closes #36.

- **Auto-continue loop**: When `turn_count` reaches the threshold (default 80% of `max_turns`), the server sends SIGINT, then automatically re-spawns `claude -p --resume` with a continuation prompt
- **Configurable**: New `auto_continue_threshold` (default 0.8) and `max_continuations` (default 5) session columns
- **Safety guards**: Minimum progress check (2+ turns), max continuation limit, context cancellation on SSE disconnect
- **SSE events**: `auto_continuing` and `auto_continue_exhausted` events for real-time UI feedback
- **Web UI**: Auto-continue system messages rendered in chat, turn toast updated

## Key changes

- `server/db/db.go` — Two new migration columns
- `server/db/sessions.go` — Session struct + scan updates
- `server/api/managed_sessions.go` — `buildClaudeArgs` helper + auto-continue loop replacing hard SIGINT
- `server/web/static/app.js` — SSE event handlers for auto-continue
- `server/web/static/index.html` — Auto-continue message template

## Test plan

- [x] All existing Go tests pass (`go test ./...`)
- [x] Server builds cleanly (`go build ./...`)
- [x] DB defaults verified (TestAutoContinueDefaults)
- [x] Threshold calculation verified (TestAutoContinueThresholdCalculation)
- [ ] Manual: Create managed session, verify auto-continue triggers at threshold
- [ ] Manual: Verify manual interrupt breaks auto-continue loop
- [ ] Manual: Verify auto-continue messages render in chat UI