### PR TITLE
feat: session activity state indicators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ docker compose down                             # Stop
 - Tool restrictions via `--allowedTools`, turn limits via server-side SIGINT, budget caps via `--max-budget-usd`
 - `/resume` command reads Claude Code's native `sessions-index.json` to let users continue previous CLI sessions in the web UI
 - `claude_session_id` field decouples the managed session's stable ID from the CLI session being resumed
+- `activity_state` field tracks session lifecycle: `working` (process running), `waiting` (process exited cleanly, awaiting input), `idle` (no process, error, or new session). Updated server-side at process start/exit. Frontend shows yellow pulsing dot (working), green dot (waiting), gray dot (idle). On server startup, stale `working` states are reset to `idle`.
 
 ### Shared
 - SQLite with WAL mode + busy_timeout for concurrent writes from multiple hook scripts
@@ -75,3 +76,5 @@ docker compose down                             # Stop
 - Resume command plan: `docs/superpowers/plans/2026-03-19-resume-command.md`
 - SSE interrupt / auto-continue spec: `docs/superpowers/specs/2026-03-23-sse-interrupt-turns-management-design.md`
 - SSE interrupt / auto-continue plan: `docs/superpowers/plans/2026-03-23-sse-interrupt-turns-management.md`
+- Session activity state spec: `docs/superpowers/specs/2026-03-23-session-activity-state-design.md`
+- Session activity state plan: `docs/superpowers/plans/2026-03-23-session-activity-state.md`

--- a/docs/superpowers/plans/2026-03-23-session-activity-state.md
+++ b/docs/superpowers/plans/2026-03-23-session-activity-state.md
@@ -1,0 +1,440 @@
+# Session Activity State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persisted `activity_state` field to sessions so the web UI can show at a glance whether Claude is working, waiting for input, or idle.
+
+**Architecture:** New `activity_state` column in SQLite sessions table, updated by managed session handlers at process start/exit. Frontend reads it via the global events endpoint and maps to existing status-dot CSS classes with a new pulse animation.
+
+**Tech Stack:** Go (server), SQLite (db), Alpine.js + CSS (frontend)
+
+**Spec:** `docs/superpowers/specs/2026-03-23-session-activity-state-design.md`
+
+---
+
+### Task 1: Database — Add `activity_state` column and `UpdateActivityState` method
+
+**Files:**
+- Modify: `server/db/db.go:97-100` (add migration)
+- Modify: `server/db/sessions.go:11-30` (add field to struct)
+- Modify: `server/db/sessions.go:32` (update `sessionColumns`)
+- Modify: `server/db/sessions.go:34-49` (update `scanSession`)
+- Modify: `server/db/sessions.go:175-178` (add new method after `SetSessionStatus`)
+- Test: `server/db/sessions_test.go`
+
+- [ ] **Step 1: Write the failing test for `UpdateActivityState`**
+
+Add to `server/db/sessions_test.go`:
+
+```go
+func TestUpdateActivityState(t *testing.T) {
+	store := newTestStore(t)
+	sess, err := store.CreateManagedSession("/tmp/test-activity", `["Bash"]`, 50, 5.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Default activity_state is "idle"
+	if sess.ActivityState != "idle" {
+		t.Errorf("expected initial activity_state='idle', got %q", sess.ActivityState)
+	}
+
+	// Update to working
+	if err := store.UpdateActivityState(sess.ID, "working"); err != nil {
+		t.Fatalf("update to working: %v", err)
+	}
+	updated, _ := store.GetSessionByID(sess.ID)
+	if updated.ActivityState != "working" {
+		t.Errorf("expected activity_state='working', got %q", updated.ActivityState)
+	}
+
+	// Update to waiting
+	if err := store.UpdateActivityState(sess.ID, "waiting"); err != nil {
+		t.Fatalf("update to waiting: %v", err)
+	}
+	updated, _ = store.GetSessionByID(sess.ID)
+	if updated.ActivityState != "waiting" {
+		t.Errorf("expected activity_state='waiting', got %q", updated.ActivityState)
+	}
+
+	// Update to idle
+	if err := store.UpdateActivityState(sess.ID, "idle"); err != nil {
+		t.Fatalf("update to idle: %v", err)
+	}
+	updated, _ = store.GetSessionByID(sess.ID)
+	if updated.ActivityState != "idle" {
+		t.Errorf("expected activity_state='idle', got %q", updated.ActivityState)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./db/ -v -run TestUpdateActivityState`
+Expected: Compilation error — `ActivityState` field and `UpdateActivityState` method don't exist.
+
+- [ ] **Step 3: Add migration to `db.go`**
+
+In `server/db/db.go`, add to the `migrations` slice (after line 99, before the closing `]`):
+
+```go
+`ALTER TABLE sessions ADD COLUMN activity_state TEXT NOT NULL DEFAULT 'idle'`,
+```
+
+- [ ] **Step 4: Add `ActivityState` field to Session struct**
+
+In `server/db/sessions.go`, add after `MaxContinuations` field (line 29):
+
+```go
+ActivityState string `json:"activity_state"`
+```
+
+- [ ] **Step 5: Update `sessionColumns` constant**
+
+In `server/db/sessions.go` line 32, append `, COALESCE(activity_state,'idle')` to the end of the string.
+
+- [ ] **Step 6: Update `scanSession` to read the new column**
+
+In `server/db/sessions.go`, add `&sess.ActivityState` as the last argument to `scanner.Scan()` (after `&sess.MaxContinuations` on line 41).
+
+- [ ] **Step 7: Add `UpdateActivityState` method**
+
+In `server/db/sessions.go`, add after `SetSessionStatus` (after line 178):
+
+```go
+func (s *Store) UpdateActivityState(id, state string) error {
+	_, err := s.db.Exec("UPDATE sessions SET activity_state = ? WHERE id = ?", state, id)
+	return err
+}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `cd server && go test ./db/ -v -run TestUpdateActivityState`
+Expected: PASS
+
+- [ ] **Step 9: Run all DB tests to check for regressions**
+
+Run: `cd server && go test ./db/ -v`
+Expected: All tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add server/db/db.go server/db/sessions.go server/db/sessions_test.go
+git commit -m "feat(db): add activity_state column and UpdateActivityState method"
+```
+
+---
+
+### Task 2: Add `ResetStaleActivityStates` method (TDD)
+
+**Files:**
+- Modify: `server/db/sessions.go` (add method after `UpdateActivityState`)
+- Test: `server/db/sessions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/db/sessions_test.go`:
+
+```go
+func TestResetStaleActivityStates(t *testing.T) {
+	store := newTestStore(t)
+
+	s1, _ := store.CreateManagedSession("/tmp/stale1", `["Bash"]`, 50, 5.0)
+	s2, _ := store.CreateManagedSession("/tmp/stale2", `["Bash"]`, 50, 5.0)
+
+	// Set s1 to working, s2 to waiting
+	store.UpdateActivityState(s1.ID, "working")
+	store.UpdateActivityState(s2.ID, "waiting")
+
+	// Reset stale states
+	if err := store.ResetStaleActivityStates(); err != nil {
+		t.Fatalf("reset stale: %v", err)
+	}
+
+	got1, _ := store.GetSessionByID(s1.ID)
+	if got1.ActivityState != "idle" {
+		t.Errorf("s1: expected 'idle', got %q", got1.ActivityState)
+	}
+
+	got2, _ := store.GetSessionByID(s2.ID)
+	if got2.ActivityState != "waiting" {
+		t.Errorf("s2: expected 'waiting' (unchanged), got %q", got2.ActivityState)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./db/ -v -run TestResetStaleActivityStates`
+Expected: Compilation error — `ResetStaleActivityStates` method doesn't exist.
+
+- [ ] **Step 3: Add `ResetStaleActivityStates` method**
+
+In `server/db/sessions.go`, add after `UpdateActivityState`:
+
+```go
+func (s *Store) ResetStaleActivityStates() error {
+	_, err := s.db.Exec("UPDATE sessions SET activity_state = 'idle' WHERE activity_state = 'working'")
+	return err
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && go test ./db/ -v -run TestResetStaleActivityStates`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/db/sessions.go server/db/sessions_test.go
+git commit -m "feat(db): add ResetStaleActivityStates method"
+```
+
+---
+
+### Task 3: Server startup — reset stale activity states
+
+**Files:**
+- Modify: `server/main.go:51-54` (add reset call after store creation)
+
+- [ ] **Step 1: Add reset call in `main.go`**
+
+In `server/main.go`, add after `defer store.Close()` (line 55):
+
+```go
+if err := store.ResetStaleActivityStates(); err != nil {
+	log.Printf("Warning: failed to reset stale activity states: %v", err)
+}
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `cd server && go build -o /dev/null .`
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/main.go
+git commit -m "feat: reset stale working activity states on server startup"
+```
+
+---
+
+### Task 4: Backend — wire activity state transitions in managed session handlers
+
+**Files:**
+- Modify: `server/api/managed_sessions.go:122` (replace `SetSessionStatus("running")` with `UpdateActivityState("working")`)
+- Modify: `server/api/managed_sessions.go:128` (replace `SetSessionStatus("idle")` in defer)
+- Modify: `server/api/managed_sessions.go:211-216` (set `waiting` on clean exit)
+- Modify: `server/api/managed_sessions.go:219-223` (set `idle` on error exit)
+- Modify: `server/api/managed_sessions.go:473` (replace `SetSessionStatus("running")` in shell handler)
+- Modify: `server/api/managed_sessions.go:540` (replace `SetSessionStatus("idle")` in shell handler)
+
+- [ ] **Step 1: Update `handleSendMessage` — set `working` on message send**
+
+In `server/api/managed_sessions.go` line 122, replace:
+```go
+_ = s.store.SetSessionStatus(sessionID, "running")
+```
+with:
+```go
+_ = s.store.UpdateActivityState(sessionID, "working")
+```
+
+- [ ] **Step 2: Remove the defer that sets status in `handleSendMessage` goroutine**
+
+In `server/api/managed_sessions.go`, remove the entire defer block (lines 127-129):
+```go
+defer func() {
+	_ = s.store.SetSessionStatus(sessionID, "idle")
+}()
+```
+
+**Why:** The defer unconditionally sets `idle`, which would clobber the `waiting` state set by clean-exit paths (Steps 3, 5, 6). The explicit state transitions before each `break` handle all exit paths. The `ResetStaleActivityStates` on server startup handles the crash-recovery edge case.
+
+- [ ] **Step 3: Set `idle` on client disconnect**
+
+In `server/api/managed_sessions.go`, inside the `case <-ctx.Done():` block (around line 143), add before the `return`:
+```go
+_ = s.store.UpdateActivityState(sessionID, "idle")
+```
+
+- [ ] **Step 4: Set `idle` on spawn error**
+
+In `server/api/managed_sessions.go`, inside the spawn error block (around line 163), add before the `break`:
+```go
+_ = s.store.UpdateActivityState(sessionID, "idle")
+```
+
+- [ ] **Step 5: Set `waiting` on clean exit (code 0, no auto-interrupt)**
+
+In `server/api/managed_sessions.go`, just before the `break` on line 215 (inside the `if proc.ExitCode == 0 && !autoInterrupting` block), add:
+```go
+_ = s.store.UpdateActivityState(sessionID, "waiting")
+```
+
+- [ ] **Step 6: Set `idle` on non-zero exit without auto-interrupt**
+
+In `server/api/managed_sessions.go`, just before the `break` on line 222 (inside the `if !autoInterrupting` block), add:
+```go
+_ = s.store.UpdateActivityState(sessionID, "idle")
+```
+
+- [ ] **Step 7: Set `waiting` when auto-continue exhausted (no progress)**
+
+In `server/api/managed_sessions.go`, just before the `break` on line 233 (inside `turnsSinceLastContinue < 2` block), add:
+```go
+_ = s.store.UpdateActivityState(sessionID, "waiting")
+```
+
+- [ ] **Step 8: Set `waiting` when auto-continue limit reached**
+
+In `server/api/managed_sessions.go`, just before the `break` on line 246 (inside `continuationCount > sess.MaxContinuations` block), add:
+```go
+_ = s.store.UpdateActivityState(sessionID, "waiting")
+```
+
+- [ ] **Step 9: Update `handleShellExecute` — set `working` on shell start**
+
+In `server/api/managed_sessions.go` line 473, replace:
+```go
+_ = s.store.SetSessionStatus(sessionID, "running")
+```
+with:
+```go
+_ = s.store.UpdateActivityState(sessionID, "working")
+```
+
+- [ ] **Step 10: Update shell exit — set state based on exit code**
+
+In `server/api/managed_sessions.go` line 540, replace:
+```go
+_ = s.store.SetSessionStatus(sessionID, "idle")
+```
+with:
+```go
+if proc.ExitCode == 0 {
+	_ = s.store.UpdateActivityState(sessionID, "waiting")
+} else {
+	_ = s.store.UpdateActivityState(sessionID, "idle")
+}
+```
+
+- [ ] **Step 11: Verify build compiles**
+
+Run: `cd server && go build -o /dev/null .`
+Expected: Compiles without errors.
+
+- [ ] **Step 12: Run all tests**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add server/api/managed_sessions.go
+git commit -m "feat: wire activity_state transitions in managed session handlers"
+```
+
+---
+
+### Task 5: Frontend — update `sessionStatus()` and CSS
+
+**Files:**
+- Modify: `server/web/static/app.js:408-416` (update `sessionStatus()`)
+- Modify: `server/web/static/style.css:183-185` (add pulse animation)
+
+- [ ] **Step 1: Update `sessionStatus()` in `app.js`**
+
+In `server/web/static/app.js`, replace lines 408-416:
+
+```javascript
+sessionStatus(session) {
+  if (session.mode === 'managed') {
+    return session.status; // managed sessions have accurate status (idle/running)
+  }
+  const lastSeen = new Date(session.last_seen_at);
+  const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+  if (lastSeen < fiveMinAgo) return 'idle';
+  return session.status;
+},
+```
+
+with:
+
+```javascript
+sessionStatus(session) {
+  if (session.mode === 'managed') {
+    const state = session.activity_state || 'idle';
+    if (state === 'working') return 'active';
+    if (state === 'waiting') return 'waiting';
+    return 'idle';
+  }
+  const lastSeen = new Date(session.last_seen_at);
+  const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+  if (lastSeen < fiveMinAgo) return 'idle';
+  return session.status;
+},
+```
+
+- [ ] **Step 2: Add pulse animation to CSS**
+
+In `server/web/static/style.css`, replace lines 183-185:
+
+```css
+.status-dot.waiting { background: var(--green); }
+.status-dot.active { background: var(--yellow); }
+.status-dot.idle { background: var(--gray); }
+```
+
+with:
+
+```css
+.status-dot.waiting { background: var(--green); }
+.status-dot.active {
+  background: var(--yellow);
+  animation: status-pulse 1.5s ease-in-out infinite;
+}
+.status-dot.idle { background: var(--gray); }
+
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+```
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `cd server && go build -o /dev/null .`
+Expected: Compiles (static files are embedded).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/web/static/app.js server/web/static/style.css
+git commit -m "feat(ui): show activity state indicators in session list"
+```
+
+---
+
+### Task 6: Manual smoke test
+
+- [ ] **Step 1: Start the server**
+
+Run: `cd server && go run .`
+
+- [ ] **Step 2: Create a managed session and send a message via the web UI**
+
+Open the web UI, create a managed session, and send a message. Verify:
+- The status dot turns yellow and pulses while Claude is working
+- The status dot turns green when Claude finishes (exits code 0)
+- The dot stays green until you send another message
+
+- [ ] **Step 3: Verify idle state**
+
+Create a new managed session without sending any messages. Verify the dot is gray (idle).

--- a/docs/superpowers/specs/2026-03-23-session-activity-state-design.md
+++ b/docs/superpowers/specs/2026-03-23-session-activity-state-design.md
@@ -1,0 +1,115 @@
+# Session Activity State Indicators
+
+**Date:** 2026-03-23
+**Issue:** #37 — Need a visual identifier for when a session requires user input
+
+## Problem
+
+When working across multiple projects simultaneously, there's no way to tell at a glance which sessions are actively working, which need user input, and which are idle. The session list sidebar shows a status dot, but the logic only distinguishes `idle` vs `active`/`running` — it never surfaces a "waiting for input" state.
+
+## Approach
+
+**Backend-derived state persisted to DB (Approach B).** Track a new `activity_state` field on each session, updated server-side during the managed process lifecycle. This makes state available to all clients (web UI, iOS app) via the existing global events endpoint, and survives page reloads.
+
+## States
+
+| State | Meaning | When Set | Visual |
+|-------|---------|----------|--------|
+| `working` | Claude process is actively running | Process spawned | Yellow dot, pulsing animation |
+| `waiting` | Process exited cleanly, awaiting next user message | Process exits with code 0 | Green dot |
+| `idle` | No active process, session inactive or errored out | Default, process exits non-zero, or no recent activity | Gray dot |
+
+## Design
+
+### Database
+
+Add `activity_state` column to the `sessions` table:
+
+```sql
+ALTER TABLE sessions ADD COLUMN activity_state TEXT NOT NULL DEFAULT 'idle';
+```
+
+Valid values: `working`, `waiting`, `idle`. Existing rows default to `idle`.
+
+The `activity_state` field is added to the `Session` Go struct with JSON tag `"activity_state"`.
+
+### Backend Lifecycle Transitions
+
+All transitions happen in the managed session handler code (`server/api/managed_sessions.go`):
+
+1. **User sends a message** (POST to send endpoint, which spawns `claude -p`) → set `activity_state = 'working'`
+2. **Process exits with code 0** (normal completion in SSE stream handler) → set `activity_state = 'waiting'`
+3. **Process exits with non-zero code** (error/interrupt) → set `activity_state = 'idle'`
+4. **Session created** → starts as `idle` (default)
+
+A new DB method `UpdateActivityState(sessionID, state string)` handles these updates.
+
+### Hook-Mode Sessions
+
+Hook-mode sessions don't have server-managed processes, so `activity_state` stays at its default `idle`. The frontend continues to derive hook-mode status from `last_seen_at` staleness (existing logic). This is a managed-mode enhancement only.
+
+### Frontend Changes
+
+**`sessionStatus()` in `app.js`:** For managed sessions, return `session.activity_state` instead of `session.status`. Map to CSS classes:
+
+```javascript
+sessionStatus(session) {
+  if (session.mode === 'managed') {
+    const state = session.activity_state || 'idle';
+    if (state === 'working') return 'active';   // yellow dot (existing CSS)
+    if (state === 'waiting') return 'waiting';   // green dot (existing CSS)
+    return 'idle';                                // gray dot (existing CSS)
+  }
+  // Hook mode: existing staleness logic unchanged
+  const lastSeen = new Date(session.last_seen_at);
+  const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
+  if (lastSeen < fiveMinAgo) return 'idle';
+  return session.status;
+}
+```
+
+**CSS:** Add a pulse animation to the `.status-dot.active` class to visually distinguish "working" from static states:
+
+```css
+.status-dot.active {
+  background: var(--yellow);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+```
+
+The existing `.status-dot.waiting` (green) and `.status-dot.idle` (gray) classes already have correct colors.
+
+### Global Events Endpoint
+
+No changes needed — `/api/events` already returns the full session object. Once `activity_state` is in the Go struct, it's automatically included in JSON serialization.
+
+### SSE Per-Session Stream
+
+When the stream handler detects process exit, it updates `activity_state` in the DB before sending the `done` SSE event. This ensures the global events endpoint reflects the new state immediately.
+
+## Scope
+
+### In Scope
+- New `activity_state` DB column + migration
+- `UpdateActivityState()` DB method
+- Lifecycle transitions in managed session handlers
+- Frontend `sessionStatus()` update for managed sessions
+- Pulse animation CSS for working state
+
+### Out of Scope
+- Hook-mode activity state tracking (would require protocol changes)
+- iOS app UI changes (it will receive the data; UI updates are separate)
+- Per-session SSE event for state changes (global polling is sufficient at 3s interval)
+
+## Files to Modify
+
+1. `server/db/db.go` — Add migration for `activity_state` column
+2. `server/db/sessions.go` — Add `ActivityState` field to struct, add `UpdateActivityState()` method
+3. `server/api/managed_sessions.go` — Set activity state at process start/exit
+4. `server/web/static/app.js` — Update `sessionStatus()` for managed sessions
+5. `server/web/static/style.css` — Add pulse animation for working state

--- a/docs/superpowers/specs/2026-03-23-session-activity-state-design.md
+++ b/docs/superpowers/specs/2026-03-23-session-activity-state-design.md
@@ -40,9 +40,16 @@ All transitions happen in the managed session handler code (`server/api/managed_
 1. **User sends a message** (POST to send endpoint, which spawns `claude -p`) → set `activity_state = 'working'`
 2. **Process exits with code 0** (normal completion in SSE stream handler) → set `activity_state = 'waiting'`
 3. **Process exits with non-zero code** (error/interrupt) → set `activity_state = 'idle'`
-4. **Session created** → starts as `idle` (default)
+4. **Shell command starts** (`handleShellExecute`) → set `activity_state = 'working'`
+5. **Shell command exits** → set `activity_state = 'waiting'` (code 0) or `idle` (non-zero)
+6. **Session created** → starts as `idle` (default)
+7. **Server startup** → reset any `activity_state = 'working'` to `idle` (stale from prior crash/restart)
 
 A new DB method `UpdateActivityState(sessionID, state string)` handles these updates.
+
+### Relationship to Existing `status` Field
+
+The existing `status` field (`idle`/`running`/`active`) and its `SetSessionStatus()` calls in managed session handlers are **replaced** by `activity_state` and `UpdateActivityState()`. The `status` field remains in the DB and struct for backward compatibility with hook-mode sessions and the iOS app, but managed session code will no longer call `SetSessionStatus()` — it will use `UpdateActivityState()` exclusively. The frontend switches to reading `activity_state` for managed sessions.
 
 ### Hook-Mode Sessions
 

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -118,16 +119,15 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, _ = s.store.CreateMessage(sessionID, "user", req.Message)
-	_ = s.store.SetSessionStatus(sessionID, "running")
+	_ = s.store.UpdateActivityState(sessionID, "working")
 
 	broadcaster := s.manager.GetBroadcaster(sessionID)
 
 	go func() {
-		defer func() {
-			_ = s.store.SetSessionStatus(sessionID, "idle")
-		}()
 
-		ctx := r.Context()
+		// Use a detached context — this goroutine outlives the HTTP request,
+		// so r.Context() would be cancelled as soon as the handler returns.
+		ctx := context.Background()
 		continuationCount := 0
 		// int() truncates toward zero, same as floor() for positive numbers
 		threshold := int(sess.AutoContinueThreshold * float64(sess.MaxTurns))
@@ -138,6 +138,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			select {
 			case <-ctx.Done():
 				log.Printf("session %s: client disconnected, stopping auto-continue", sessionID)
+				_ = s.store.UpdateActivityState(sessionID, "idle")
 				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, 0)
 				broadcaster.Send(doneMsg)
 				return
@@ -157,6 +158,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				log.Printf("auto-continue spawn error for session %s: %v", sessionID, err)
 				errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to spawn process: %s"}`, err.Error())
 				broadcaster.Send(errMsg)
+				_ = s.store.UpdateActivityState(sessionID, "idle")
 				break
 			}
 
@@ -207,6 +209,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 			// Natural exit (code 0) — Claude finished on its own, no auto-continue needed.
 			if proc.ExitCode == 0 && !autoInterrupting {
+				_ = s.store.UpdateActivityState(sessionID, "waiting")
 				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
 				broadcaster.Send(doneMsg)
 				break
@@ -214,6 +217,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 			// Process exited without our threshold SIGINT — manual interrupt or error
 			if !autoInterrupting {
+				_ = s.store.UpdateActivityState(sessionID, "idle")
 				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
 				broadcaster.Send(doneMsg)
 				break
@@ -225,6 +229,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				_, _ = s.store.CreateMessage(sessionID, "system", "Auto-continue stopped: not making progress")
 				noProgressMsg := fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d,"reason":"no_progress"}`, continuationCount)
 				broadcaster.Send(noProgressMsg)
+				_ = s.store.UpdateActivityState(sessionID, "waiting")
 				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
 				broadcaster.Send(doneMsg)
 				break
@@ -238,6 +243,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				broadcaster.Send(exhaustedMsg)
 				_, _ = s.store.CreateMessage(sessionID, "system",
 					fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations))
+				_ = s.store.UpdateActivityState(sessionID, "waiting")
 				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode)
 				broadcaster.Send(doneMsg)
 				break
@@ -467,7 +473,7 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, _ = s.store.CreateMessage(sessionID, "shell", req.Command)
-	_ = s.store.SetSessionStatus(sessionID, "running")
+	_ = s.store.UpdateActivityState(sessionID, "working")
 
 	broadcaster := s.manager.GetBroadcaster(sessionID)
 
@@ -534,7 +540,11 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 			proc.ExitCode, jsonString(commandID), timedOut)
 		broadcaster.Send(exitMsg)
 
-		_ = s.store.SetSessionStatus(sessionID, "idle")
+		if proc.ExitCode == 0 {
+			_ = s.store.UpdateActivityState(sessionID, "waiting")
+		} else {
+			_ = s.store.UpdateActivityState(sessionID, "idle")
+		}
 	}()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -97,6 +97,7 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE sessions ADD COLUMN turn_count INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN auto_continue_threshold REAL NOT NULL DEFAULT 0.8`,
 		`ALTER TABLE sessions ADD COLUMN max_continuations INTEGER NOT NULL DEFAULT 5`,
+		`ALTER TABLE sessions ADD COLUMN activity_state TEXT NOT NULL DEFAULT 'idle'`,
 	}
 
 	for _, m := range migrations {

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -27,9 +27,10 @@ type Session struct {
 	TurnCount             int     `json:"turn_count"`
 	AutoContinueThreshold float64 `json:"auto_continue_threshold"`
 	MaxContinuations      int     `json:"max_continuations"`
+	ActivityState         string  `json:"activity_state"`
 }
 
-const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), turn_count, auto_continue_threshold, max_continuations`
+const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), turn_count, auto_continue_threshold, max_continuations, COALESCE(activity_state,'idle')`
 
 func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, error) {
 	var sess Session
@@ -38,7 +39,7 @@ func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, erro
 		&sess.ID, &sess.ComputerName, &sess.ProjectPath, &sess.TranscriptPath,
 		&sess.Status, &sess.CreatedAt, &sess.LastSeenAt, &archived,
 		&sess.Mode, &sess.CWD, &sess.AllowedTools, &sess.MaxTurns, &sess.MaxBudgetUSD, &initialized,
-		&sess.ClaudeSessionID, &sess.TurnCount, &sess.AutoContinueThreshold, &sess.MaxContinuations,
+		&sess.ClaudeSessionID, &sess.TurnCount, &sess.AutoContinueThreshold, &sess.MaxContinuations, &sess.ActivityState,
 	)
 	if err != nil {
 		return sess, err
@@ -174,6 +175,16 @@ func (s *Store) SetArchived(id string, archived bool) error {
 
 func (s *Store) SetSessionStatus(id, status string) error {
 	_, err := s.db.Exec("UPDATE sessions SET status = ? WHERE id = ?", status, id)
+	return err
+}
+
+func (s *Store) UpdateActivityState(id, state string) error {
+	_, err := s.db.Exec("UPDATE sessions SET activity_state = ? WHERE id = ?", state, id)
+	return err
+}
+
+func (s *Store) ResetStaleActivityStates() error {
+	_, err := s.db.Exec("UPDATE sessions SET activity_state = 'idle' WHERE activity_state = 'working'")
 	return err
 }
 

--- a/server/db/sessions_test.go
+++ b/server/db/sessions_test.go
@@ -199,3 +199,54 @@ func TestAutoContinueDefaults(t *testing.T) {
 		t.Errorf("expected max_continuations 5, got %d", sess.MaxContinuations)
 	}
 }
+
+func TestUpdateActivityState(t *testing.T) {
+	store := newTestStore(t)
+	sess, err := store.CreateManagedSession("/tmp/test-activity", `["Bash"]`, 50, 5.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.ActivityState != "idle" {
+		t.Errorf("expected initial activity_state='idle', got %q", sess.ActivityState)
+	}
+	if err := store.UpdateActivityState(sess.ID, "working"); err != nil {
+		t.Fatalf("update to working: %v", err)
+	}
+	updated, _ := store.GetSessionByID(sess.ID)
+	if updated.ActivityState != "working" {
+		t.Errorf("expected activity_state='working', got %q", updated.ActivityState)
+	}
+	if err := store.UpdateActivityState(sess.ID, "waiting"); err != nil {
+		t.Fatalf("update to waiting: %v", err)
+	}
+	updated, _ = store.GetSessionByID(sess.ID)
+	if updated.ActivityState != "waiting" {
+		t.Errorf("expected activity_state='waiting', got %q", updated.ActivityState)
+	}
+	if err := store.UpdateActivityState(sess.ID, "idle"); err != nil {
+		t.Fatalf("update to idle: %v", err)
+	}
+	updated, _ = store.GetSessionByID(sess.ID)
+	if updated.ActivityState != "idle" {
+		t.Errorf("expected activity_state='idle', got %q", updated.ActivityState)
+	}
+}
+
+func TestResetStaleActivityStates(t *testing.T) {
+	store := newTestStore(t)
+	s1, _ := store.CreateManagedSession("/tmp/stale1", `["Bash"]`, 50, 5.0)
+	s2, _ := store.CreateManagedSession("/tmp/stale2", `["Bash"]`, 50, 5.0)
+	store.UpdateActivityState(s1.ID, "working")
+	store.UpdateActivityState(s2.ID, "waiting")
+	if err := store.ResetStaleActivityStates(); err != nil {
+		t.Fatalf("reset stale: %v", err)
+	}
+	got1, _ := store.GetSessionByID(s1.ID)
+	if got1.ActivityState != "idle" {
+		t.Errorf("s1: expected 'idle', got %q", got1.ActivityState)
+	}
+	got2, _ := store.GetSessionByID(s2.ID)
+	if got2.ActivityState != "waiting" {
+		t.Errorf("s2: expected 'waiting' (unchanged), got %q", got2.ActivityState)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -54,6 +54,10 @@ func main() {
 	}
 	defer store.Close()
 
+	if err := store.ResetStaleActivityStates(); err != nil {
+		log.Printf("Warning: failed to reset stale activity states: %v", err)
+	}
+
 	apiKey := loadOrCreateAPIKey(*dbPath)
 
 	loadDotEnv(".env")

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -407,7 +407,10 @@ document.addEventListener('alpine:init', () => {
 
     sessionStatus(session) {
       if (session.mode === 'managed') {
-        return session.status; // managed sessions have accurate status (idle/running)
+        const state = session.activity_state || 'idle';
+        if (state === 'working') return 'active';
+        if (state === 'waiting') return 'waiting';
+        return 'idle';
       }
       const lastSeen = new Date(session.last_seen_at);
       const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -64,7 +64,8 @@
           <template x-for="session in sessions" :key="session.id">
             <div class="session-item" :class="{ active: selectedSessionId === session.id }"
                  @click="selectSession(session.id)">
-              <span class="status-dot" :class="sessionStatus(session)"></span>
+              <span class="status-dot" :class="sessionStatus(session)"
+                    :title="sessionStatus(session) === 'active' ? 'Working' : sessionStatus(session) === 'waiting' ? 'Waiting for input' : 'Idle'"></span>
               <span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"
                     x-text="sessionName(session)"></span>
               <span x-show="session.mode === 'managed'"

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -181,8 +181,16 @@ body {
   flex-shrink: 0;
 }
 .status-dot.waiting { background: var(--green); }
-.status-dot.active { background: var(--yellow); }
+.status-dot.active {
+  background: var(--yellow);
+  animation: status-pulse 1.5s ease-in-out infinite;
+}
 .status-dot.idle { background: var(--gray); }
+
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
 
 .badge {
   background: var(--red);


### PR DESCRIPTION
## Summary

Closes #37

Adds visual session activity state indicators so you can tell at a glance which sessions are working, need input, or are idle.

### Three states

| State | Dot | Meaning |
|-------|-----|---------|
| **Working** | Yellow (pulsing) | Claude process is actively running |
| **Waiting** | Green | Claude finished, waiting for your next message |
| **Idle** | Gray | No active process, new session, or error |

### Changes

**Database** (`server/db/`)
- New `activity_state` column (`working`/`waiting`/`idle`, default `idle`)
- `UpdateActivityState()` method for state transitions
- `ResetStaleActivityStates()` to recover from server crashes (resets stale `working` → `idle` on startup)

**Backend** (`server/api/managed_sessions.go`)
- Replaces `SetSessionStatus` calls with `UpdateActivityState` in `handleSendMessage` and `handleShellExecute`
- Removed defer that would clobber `waiting` back to `idle`
- Explicit state transitions for all exit paths: clean exit → `waiting`, error/interrupt → `idle`, spawn error → `idle`, auto-continue exhausted → `waiting`

**Frontend** (`server/web/static/`)
- `sessionStatus()` reads `activity_state` for managed sessions, maps to CSS classes
- Pulsing animation on yellow dot to distinguish active work from static states
- Hover tooltips on status dots ("Working", "Waiting for input", "Idle")

**Documentation**
- CLAUDE.md updated with `activity_state` design decision and spec/plan references
- Design spec: `docs/superpowers/specs/2026-03-23-session-activity-state-design.md`
- Implementation plan: `docs/superpowers/plans/2026-03-23-session-activity-state.md`

## Test plan

- [x] `TestUpdateActivityState` — verifies all three state transitions
- [x] `TestResetStaleActivityStates` — verifies only `working` states get reset, `waiting` preserved
- [x] All existing tests pass (`go test ./...`)
- [ ] Manual: create managed session → send message → verify yellow pulsing dot while Claude works
- [ ] Manual: verify green dot when Claude finishes (exit code 0)
- [ ] Manual: verify gray dot for new/idle sessions
- [ ] Manual: hover status dot → verify tooltip text