### PR TITLE
fix: restore stop button for managed sessions

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -682,7 +682,7 @@ document.addEventListener('alpine:init', () => {
       const sess = this.sessions.find(s => s.id === this.selectedSessionId);
       if (sess && sess.mode === 'managed') {
         await this.fetchManagedMessages(this.selectedSessionId);
-        if (sess.status === 'running') {
+        if (sess.activity_state === 'working') {
           this.startSessionSSE(this.selectedSessionId);
         }
       } else {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -162,7 +162,7 @@
                 :title="selectedSessionId ? 'Double-click to rename' : ''"
                 :style="selectedSessionId ? 'cursor:pointer' : ''"></h2>
           </template>
-          <button class="btn btn-sm" x-show="currentSession?.mode === 'managed' && currentSession?.status === 'running'"
+          <button class="btn btn-sm" x-show="currentSession?.mode === 'managed' && currentSession?.activity_state === 'working'"
                   @click="interruptSession()"
                   style="background:#e74c3c; color:white; margin-left:8px;">
             Stop


### PR DESCRIPTION
## Summary
- Stop button was invisible because it checked `currentSession?.status === 'running'`, but session `status` defaults to `'active'` and is never `'running'`
- Changed to check `currentSession?.activity_state === 'working'`, which is the field that actually tracks managed session lifecycle
- Also fixed SSE auto-connect when selecting an active session (same stale condition)

## Root Cause
The `activity_state` field (`working`/`waiting`/`idle`) was added to track managed session lifecycle, but the stop button and SSE connect logic were never updated from the old `status` field.

Fixes #53