### PR TITLE
feat: permission prompt handling for managed sessions

### DIFF
--- a/docs/superpowers/plans/2026-03-26-permission-prompt-handling.md
+++ b/docs/superpowers/plans/2026-03-26-permission-prompt-handling.md
@@ -1,0 +1,1183 @@
+# Permission Prompt Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable the web UI to handle permission prompts and input requests from Claude Code managed sessions via an MCP bridge that forwards prompts to the user.
+
+**Architecture:** Embedded `mcp-bridge` subcommand in the Go binary acts as an MCP stdio server. When Claude hits a permission prompt, it calls the MCP tool, which POSTs to the Go server. The server blocks until the frontend user responds via a modal, then returns the decision through the chain.
+
+**Tech Stack:** Go (MCP bridge + API endpoints), Alpine.js (frontend modal), JSON-RPC 2.0 (MCP protocol)
+
+---
+
+### Task 0: Schema Discovery
+
+**Files:**
+- Create: `server/mcp/log_bridge.sh` (temporary, deleted after task)
+
+Before building anything, discover the exact JSON-RPC payload Claude Code sends to `--permission-prompt-tool`.
+
+- [ ] **Step 1: Create a logging MCP server script**
+
+```bash
+#!/bin/bash
+# Minimal MCP server that logs all stdin to a file and responds with allow
+LOG="/tmp/mcp-bridge-log.jsonl"
+while IFS= read -r line; do
+  echo "$line" >> "$LOG"
+  # Parse JSON-RPC method
+  method=$(echo "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('method',''))" 2>/dev/null)
+  id=$(echo "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null)
+  if [ "$method" = "initialize" ]; then
+    echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{\"tools\":{}},\"serverInfo\":{\"name\":\"log-bridge\",\"version\":\"0.1.0\"}}}"
+  elif [ "$method" = "notifications/initialized" ]; then
+    : # no response needed for notifications
+  elif [ "$method" = "tools/list" ]; then
+    echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"tools\":[{\"name\":\"permission_prompt\",\"description\":\"Handle permission prompts\",\"inputSchema\":{\"type\":\"object\"}}]}}"
+  elif [ "$method" = "tools/call" ]; then
+    echo "{\"jsonrpc\":\"2.0\",\"id\":$id,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"{\\\"decision\\\":\\\"allow\\\"}\"}]}}"
+  fi
+done
+```
+
+- [ ] **Step 2: Test with Claude Code**
+
+Create a temp MCP config and run Claude with the logging bridge:
+
+```bash
+chmod +x server/mcp/log_bridge.sh
+
+cat > /tmp/mcp-log-config.json << 'EOF'
+{
+  "mcpServers": {
+    "controller": {
+      "command": "/Users/jaychinthrajah/workspaces/_personal_/claude-control/server/mcp/log_bridge.sh"
+    }
+  }
+}
+EOF
+
+cd /tmp/claude-stdin-test && claude -p "run the command: echo hello world" \
+  --output-format stream-json --verbose \
+  --permission-prompt-tool mcp__controller__permission_prompt \
+  --mcp-config /tmp/mcp-log-config.json 2>/dev/null | head -50
+```
+
+- [ ] **Step 3: Inspect the logged payloads**
+
+```bash
+cat /tmp/mcp-bridge-log.jsonl
+```
+
+Document the exact `tools/call` payload structure — particularly the `params.arguments` field names and values. Update the MCP bridge implementation in Task 1 if the schema differs from the spec's assumed `tool_name`/`description`/`input` fields.
+
+- [ ] **Step 4: Clean up**
+
+```bash
+rm server/mcp/log_bridge.sh /tmp/mcp-log-config.json /tmp/mcp-bridge-log.jsonl
+```
+
+---
+
+### Task 1: MCP Bridge — Embedded Subcommand
+
+**Files:**
+- Create: `server/mcp/bridge.go`
+- Create: `server/mcp/bridge_test.go`
+- Modify: `server/main.go:28-31` (add subcommand dispatch before flag.Parse)
+
+- [ ] **Step 1: Write the failing test for JSON-RPC message parsing**
+
+```go
+// server/mcp/bridge_test.go
+package mcp
+
+import "testing"
+
+func TestParseRequest(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	req, err := parseRequest([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Method != "initialize" {
+		t.Errorf("method=%s, want initialize", req.Method)
+	}
+	if req.ID != 1 {
+		t.Errorf("id=%v, want 1", req.ID)
+	}
+}
+
+func TestParseRequestNotification(t *testing.T) {
+	input := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	req, err := parseRequest([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Method != "notifications/initialized" {
+		t.Errorf("method=%s, want notifications/initialized", req.Method)
+	}
+	if req.ID != 0 {
+		t.Errorf("id=%v, want 0 for notification", req.ID)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./mcp/ -v -run TestParseRequest`
+Expected: FAIL — package `mcp` does not exist yet
+
+- [ ] **Step 3: Implement the MCP bridge**
+
+```go
+// server/mcp/bridge.go
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int         `json:"id"`
+	Result  interface{} `json:"result"`
+}
+
+func parseRequest(data []byte) (*Request, error) {
+	var req Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+type ToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// Run starts the MCP stdio bridge. It reads JSON-RPC requests from stdin,
+// handles MCP protocol messages, and forwards permission_prompt tool calls
+// to the Go server via HTTP.
+func Run(sessionID string, serverPort int) error {
+	baseURL := fmt.Sprintf("http://localhost:%d", serverPort)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		req, err := parseRequest(line)
+		if err != nil {
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			writeResponse(os.Stdout, req.ID, map[string]interface{}{
+				"protocolVersion": "2024-11-05",
+				"capabilities":   map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":     map[string]interface{}{"name": "claude-controller-bridge", "version": "1.0.0"},
+			})
+
+		case "notifications/initialized":
+			// No response for notifications
+			continue
+
+		case "tools/list":
+			writeResponse(os.Stdout, req.ID, map[string]interface{}{
+				"tools": []map[string]interface{}{
+					{
+						"name":        "permission_prompt",
+						"description": "Handle permission prompts from Claude Code",
+						"inputSchema": map[string]interface{}{
+							"type":       "object",
+							"properties": map[string]interface{}{},
+						},
+					},
+				},
+			})
+
+		case "tools/call":
+			var params ToolCallParams
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				writeToolError(os.Stdout, req.ID, "invalid params")
+				continue
+			}
+			if params.Name != "permission_prompt" {
+				writeToolError(os.Stdout, req.ID, "unknown tool: "+params.Name)
+				continue
+			}
+
+			decision, err := forwardPermissionRequest(baseURL, sessionID, params.Arguments)
+			if err != nil {
+				writeToolError(os.Stdout, req.ID, "server error: "+err.Error())
+				continue
+			}
+
+			writeResponse(os.Stdout, req.ID, map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": decision},
+				},
+			})
+		}
+	}
+
+	return scanner.Err()
+}
+
+func forwardPermissionRequest(baseURL, sessionID string, arguments json.RawMessage) (string, error) {
+	url := fmt.Sprintf("%s/api/sessions/%s/permission-request", baseURL, sessionID)
+
+	client := &http.Client{Timeout: 6 * time.Minute} // longer than server's 5min timeout
+	resp, err := client.Post(url, "application/json", bytes.NewReader(arguments))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	return string(body), nil
+}
+
+func writeResponse(w io.Writer, id int, result interface{}) {
+	resp := Response{JSONRPC: "2.0", ID: id, Result: result}
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(w, "%s\n", data)
+}
+
+func writeToolError(w io.Writer, id int, message string) {
+	resp := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result": map[string]interface{}{
+			"content": []map[string]interface{}{
+				{"type": "text", "text": message},
+			},
+			"isError": true,
+		},
+	}
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(w, "%s\n", data)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && go test ./mcp/ -v -run TestParseRequest`
+Expected: PASS
+
+- [ ] **Step 5: Write test for tool call params parsing**
+
+```go
+// Add to server/mcp/bridge_test.go
+func TestParseToolCallParams(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"permission_prompt","arguments":{"tool_name":"Bash","command":"echo hello"}}}`
+	req, err := parseRequest([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var params ToolCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		t.Fatal(err)
+	}
+	if params.Name != "permission_prompt" {
+		t.Errorf("name=%s, want permission_prompt", params.Name)
+	}
+	if len(params.Arguments) == 0 {
+		t.Error("expected non-empty arguments")
+	}
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd server && go test ./mcp/ -v`
+Expected: PASS
+
+- [ ] **Step 7: Add subcommand dispatch to main.go**
+
+Add before the existing `flag.Parse()` call in `server/main.go`:
+
+```go
+// At the top of main(), before flag.Parse():
+if len(os.Args) >= 2 && os.Args[1] == "mcp-bridge" {
+    // Parse mcp-bridge specific flags
+    bridgeFlags := flag.NewFlagSet("mcp-bridge", flag.ExitOnError)
+    sessionID := bridgeFlags.String("session-id", "", "session ID")
+    port := bridgeFlags.Int("port", 8080, "server port")
+    bridgeFlags.Parse(os.Args[2:])
+    if *sessionID == "" {
+        log.Fatal("--session-id is required")
+    }
+    if err := mcp.Run(*sessionID, *port); err != nil {
+        log.Fatalf("mcp-bridge error: %v", err)
+    }
+    return
+}
+```
+
+Add import: `"github.com/jaychinthrajah/claude-controller/server/mcp"`
+
+- [ ] **Step 8: Verify build**
+
+Run: `cd server && go build -o claude-controller .`
+Expected: Build succeeds
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/mcp/bridge.go server/mcp/bridge_test.go server/main.go
+git commit -m "feat: add MCP bridge subcommand for permission prompt handling"
+```
+
+---
+
+### Task 2: Permission Request/Respond Endpoints
+
+**Files:**
+- Create: `server/api/permissions.go`
+- Create: `server/api/permissions_test.go`
+- Modify: `server/api/router.go:11-15` (add permissions field to Server struct)
+- Modify: `server/api/router.go:55-60` (register new routes)
+
+- [ ] **Step 1: Write the failing test for permission-request endpoint**
+
+```go
+// server/api/permissions_test.go
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPermissionRequestAndRespond(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	// Start permission request in background (it blocks)
+	type result struct {
+		status int
+		body   string
+	}
+	ch := make(chan result, 1)
+	go func() {
+		body := `{"tool_name":"Bash","description":"Run echo hello","input":{"command":"echo hello"}}`
+		req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-request", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			ch <- result{0, err.Error()}
+			return
+		}
+		defer resp.Body.Close()
+		var respBody map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&respBody)
+		b, _ := json.Marshal(respBody)
+		ch <- result{resp.StatusCode, string(b)}
+	}()
+
+	// Wait a moment for the request to register
+	time.Sleep(100 * time.Millisecond)
+
+	// Respond with allow
+	respondBody := `{"decision":"allow"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-respond", strings.NewReader(respondBody))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("respond status=%d, want 200", resp.StatusCode)
+	}
+
+	// Check the blocked request completed
+	select {
+	case r := <-ch:
+		if r.status != 200 {
+			t.Fatalf("permission-request status=%d, want 200, body=%s", r.status, r.body)
+		}
+		if !strings.Contains(r.body, "allow") {
+			t.Errorf("expected allow in response, got %s", r.body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("permission-request did not complete after respond")
+	}
+}
+
+func TestPermissionRespondNoRequest(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	body := `{"decision":"allow"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-respond", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Errorf("status=%d, want 404 when no pending request", resp.StatusCode)
+	}
+}
+
+func TestPermissionPendingEndpoint(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	// No pending permission initially
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-permission", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["pending"] != false {
+		t.Errorf("expected pending=false, got %v", result["pending"])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./api/ -v -run TestPermission`
+Expected: FAIL — handlers don't exist yet
+
+- [ ] **Step 3: Implement permissions.go**
+
+```go
+// server/api/permissions.go
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// PendingPermission represents a permission request waiting for user response.
+type PendingPermission struct {
+	ToolName    string          `json:"tool_name"`
+	Description string          `json:"description"`
+	Input       json.RawMessage `json:"input"`
+	ResponseCh  chan string     `json:"-"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// PermissionManager tracks pending permission requests per session.
+type PermissionManager struct {
+	mu      sync.Mutex
+	pending map[string]*PendingPermission // sessionID → pending request
+}
+
+func NewPermissionManager() *PermissionManager {
+	return &PermissionManager{
+		pending: make(map[string]*PendingPermission),
+	}
+}
+
+func (pm *PermissionManager) Set(sessionID string, p *PendingPermission) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.pending[sessionID] = p
+}
+
+func (pm *PermissionManager) Get(sessionID string) *PendingPermission {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.pending[sessionID]
+}
+
+func (pm *PermissionManager) Delete(sessionID string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	delete(pm.pending, sessionID)
+}
+
+const permissionTimeout = 5 * time.Minute
+
+func (s *Server) handlePermissionRequest(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	var req struct {
+		ToolName    string          `json:"tool_name"`
+		Description string          `json:"description"`
+		Input       json.RawMessage `json:"input"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	pending := &PendingPermission{
+		ToolName:    req.ToolName,
+		Description: req.Description,
+		Input:       req.Input,
+		ResponseCh:  make(chan string, 1),
+		CreatedAt:   time.Now(),
+	}
+
+	s.permissions.Set(sessionID, pending)
+	_ = s.store.UpdateActivityState(sessionID, "input_needed")
+
+	// Broadcast input_request SSE event
+	broadcaster := s.manager.GetBroadcaster(sessionID)
+	eventJSON, _ := json.Marshal(map[string]interface{}{
+		"type":        "input_request",
+		"tool_name":   req.ToolName,
+		"description": req.Description,
+		"input":       req.Input,
+	})
+	broadcaster.Send(string(eventJSON))
+
+	// Block until response or timeout
+	select {
+	case decision := <-pending.ResponseCh:
+		s.permissions.Delete(sessionID)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"decision": decision})
+	case <-time.After(permissionTimeout):
+		s.permissions.Delete(sessionID)
+		_ = s.store.UpdateActivityState(sessionID, "working")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"decision": "deny", "reason": "timeout"})
+	case <-r.Context().Done():
+		s.permissions.Delete(sessionID)
+		return
+	}
+}
+
+func (s *Server) handlePermissionRespond(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	var req struct {
+		Decision string `json:"decision"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.Decision == "" {
+		http.Error(w, "decision is required", http.StatusBadRequest)
+		return
+	}
+
+	pending := s.permissions.Get(sessionID)
+	if pending == nil {
+		http.Error(w, "no pending permission request", http.StatusNotFound)
+		return
+	}
+
+	pending.ResponseCh <- req.Decision
+	_ = s.store.UpdateActivityState(sessionID, "working")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handlePendingPermission(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	pending := s.permissions.Get(sessionID)
+
+	w.Header().Set("Content-Type", "application/json")
+	if pending == nil {
+		json.NewEncoder(w).Encode(map[string]interface{}{"pending": false})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"pending":     true,
+		"tool_name":   pending.ToolName,
+		"description": pending.Description,
+		"input":       pending.Input,
+		"created_at":  pending.CreatedAt,
+	})
+}
+```
+
+- [ ] **Step 4: Add PermissionManager to Server struct and routes**
+
+In `server/api/router.go`, add the `permissions` field to the `Server` struct:
+
+```go
+type Server struct {
+	store       *db.Store
+	manager     *managed.Manager
+	envPath     string
+	permissions *PermissionManager
+}
+```
+
+Update `NewRouter` to initialize it:
+
+```go
+s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager()}
+```
+
+Add routes in the managed session endpoints section:
+
+```go
+apiMux.HandleFunc("POST /api/sessions/{id}/permission-request", s.handlePermissionRequest)
+apiMux.HandleFunc("POST /api/sessions/{id}/permission-respond", s.handlePermissionRespond)
+apiMux.HandleFunc("GET /api/sessions/{id}/pending-permission", s.handlePendingPermission)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd server && go test ./api/ -v -run TestPermission`
+Expected: PASS (all 3 tests)
+
+- [ ] **Step 6: Run all existing tests to verify no regressions**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/api/permissions.go server/api/permissions_test.go server/api/router.go
+git commit -m "feat: add permission request/respond endpoints with blocking channel pattern"
+```
+
+---
+
+### Task 3: Spawn Changes — MCP Config Generation
+
+**Files:**
+- Modify: `server/managed/manager.go:13-17` (add ServerPort and BinaryPath to Config)
+- Modify: `server/api/managed_sessions.go:57-86` (add MCP config args to buildClaudeArgs)
+- Modify: `server/main.go:71-76` (pass port and binary path to managed config)
+
+- [ ] **Step 1: Add ServerPort and BinaryPath to managed.Config**
+
+In `server/managed/manager.go`, update the Config struct:
+
+```go
+type Config struct {
+	ClaudeBin  string
+	ClaudeArgs []string
+	ClaudeEnv  []string
+	ServerPort int
+	BinaryPath string
+}
+```
+
+- [ ] **Step 2: Add MCP config file generation to buildClaudeArgs**
+
+In `server/api/managed_sessions.go`, update `buildClaudeArgs` to accept the manager config and generate MCP args:
+
+```go
+func buildClaudeArgs(sess *db.Session, message string, cfg managed.Config) []string {
+	var args []string
+	args = append(args, "-p", message)
+
+	resumeID := sess.ID
+	if sess.ClaudeSessionID != "" {
+		resumeID = sess.ClaudeSessionID
+	}
+	if sess.Initialized {
+		args = append(args, "--resume", resumeID)
+	} else {
+		args = append(args, "--session-id", resumeID)
+	}
+
+	args = append(args, "--output-format", "stream-json", "--verbose")
+
+	if sess.AllowedTools != "" {
+		var tools []string
+		json.Unmarshal([]byte(sess.AllowedTools), &tools)
+		if len(tools) > 0 {
+			args = append(args, "--allowedTools", strings.Join(tools, ","))
+		}
+	}
+
+	if sess.MaxBudgetUSD > 0 {
+		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", sess.MaxBudgetUSD))
+	}
+
+	// Add MCP permission prompt config if binary path is available
+	if cfg.BinaryPath != "" && cfg.ServerPort > 0 {
+		mcpConfig := map[string]interface{}{
+			"mcpServers": map[string]interface{}{
+				"controller": map[string]interface{}{
+					"command": cfg.BinaryPath,
+					"args":   []string{"mcp-bridge", "--session-id", sess.ID, "--port", fmt.Sprintf("%d", cfg.ServerPort)},
+				},
+			},
+		}
+		mcpJSON, err := json.Marshal(mcpConfig)
+		if err == nil {
+			tmpFile := fmt.Sprintf("/tmp/claude-mcp-%s.json", sess.ID)
+			if os.WriteFile(tmpFile, mcpJSON, 0644) == nil {
+				args = append(args, "--permission-prompt-tool", "mcp__controller__permission_prompt")
+				args = append(args, "--mcp-config", tmpFile)
+			}
+		}
+	}
+
+	return args
+}
+```
+
+Add `"os"` to the imports at the top of `managed_sessions.go`.
+
+- [ ] **Step 3: Update all buildClaudeArgs call sites**
+
+In `handleSendMessage`, update the call to pass the manager config. The `Server` struct already has `s.manager` — we need to expose the config. Add a getter to the Manager:
+
+In `server/managed/manager.go`, add:
+
+```go
+func (m *Manager) Config() Config {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cfg
+}
+```
+
+Then in `server/api/managed_sessions.go`, update the call in `handleSendMessage`:
+
+```go
+args := buildClaudeArgs(sess, currentMessage, s.manager.Config())
+```
+
+- [ ] **Step 4: Set ServerPort and BinaryPath in main.go**
+
+In `server/main.go`, after port is determined and before `managed.NewManager`:
+
+```go
+binaryPath, _ := os.Executable()
+managedCfg := managed.Config{
+	ClaudeBin:  envOrDefault("CLAUDE_BIN", "claude"),
+	ClaudeArgs: strings.Fields(os.Getenv("CLAUDE_ARGS")),
+	ClaudeEnv:  splitEnv(os.Getenv("CLAUDE_ENV")),
+	ServerPort: *port,
+	BinaryPath: binaryPath,
+}
+```
+
+- [ ] **Step 5: Clean up temp MCP config on process exit**
+
+In `handleSendMessage`, after `<-proc.Done`, add cleanup:
+
+```go
+// Clean up temp MCP config file
+tmpFile := fmt.Sprintf("/tmp/claude-mcp-%s.json", sessionID)
+os.Remove(tmpFile)
+```
+
+Add this right after `<-proc.Done` in the goroutine (around line 202).
+
+- [ ] **Step 6: Verify build and tests pass**
+
+Run: `cd server && go build -o claude-controller . && go test ./... -v`
+Expected: Build succeeds, all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/managed/manager.go server/api/managed_sessions.go server/main.go
+git commit -m "feat: generate MCP config and pass --permission-prompt-tool on spawn"
+```
+
+---
+
+### Task 4: Frontend — Permission Modal UI
+
+**Files:**
+- Modify: `server/web/static/app.js:1321-1485` (SSE handler — add input_request case)
+- Modify: `server/web/static/app.js` (add pendingPermission state and respondToPermission method)
+- Modify: `server/web/static/index.html` (add permission modal template)
+- Modify: `server/web/static/style.css:191-202` (add input_needed status dot style)
+
+- [ ] **Step 1: Add pendingPermission state to Alpine.js data**
+
+In `server/web/static/app.js`, find the Alpine data object (the `return {` block) and add:
+
+```javascript
+pendingPermission: null,
+```
+
+- [ ] **Step 2: Add SSE handler for input_request events**
+
+In the `startSessionSSE` method's `onmessage` handler, add after the `auto_continue_exhausted` block (around line 1389) and before the `done` check:
+
+```javascript
+if (data.type === 'input_request') {
+    this.pendingPermission = data;
+    return;
+}
+```
+
+Also, in the `done` handler (around line 1405), clear the pending permission:
+
+```javascript
+if (data.type === 'done') {
+    this.pendingPermission = null;
+    this.stopSessionSSE();
+    return;
+}
+```
+
+- [ ] **Step 3: Add respondToPermission method**
+
+Add a new method to the Alpine component:
+
+```javascript
+async respondToPermission(decision) {
+    if (!this.pendingPermission || !this.selectedSessionId) return;
+    try {
+        await fetch(`/api/sessions/${this.selectedSessionId}/permission-respond`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ decision })
+        });
+    } catch (e) {
+        console.error('Failed to respond to permission:', e);
+    }
+    this.pendingPermission = null;
+},
+```
+
+- [ ] **Step 4: Check for pending permission on SSE reconnect**
+
+In the `startSessionSSE` method, add a check right after creating the EventSource:
+
+```javascript
+// Check for pending permission on reconnect
+fetch(`/api/sessions/${sessionId}/pending-permission`, {
+    headers: { 'Authorization': `Bearer ${this.apiKey}` }
+}).then(r => r.json()).then(data => {
+    if (data.pending) {
+        this.pendingPermission = data;
+    }
+}).catch(() => {});
+```
+
+- [ ] **Step 5: Add permission modal to index.html**
+
+Add after the existing settings modal (around line 1070, before the closing `</div>` of the main Alpine app):
+
+```html
+<!-- Permission Prompt Modal -->
+<div x-show="pendingPermission" x-cloak
+     style="position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:200; display:flex; align-items:center; justify-content:center;">
+  <div @click.stop class="modal-inner" style="background:var(--bg); border-radius:12px; padding:24px; width:500px; max-width:90vw; border:1px solid var(--border); box-shadow:0 20px 60px rgba(0,0,0,0.5);">
+    <h3 style="margin-top:0; margin-bottom:16px; display:flex; align-items:center; gap:8px;">
+      <span style="color:var(--yellow);">&#9888;</span> Permission Required
+    </h3>
+    <template x-if="pendingPermission">
+      <div>
+        <div style="margin-bottom:12px;">
+          <span style="font-weight:600;" x-text="pendingPermission.tool_name || 'Tool'"></span>
+          <span style="color:var(--text-muted); margin-left:8px;" x-text="pendingPermission.description || ''"></span>
+        </div>
+        <template x-if="pendingPermission.input">
+          <pre style="background:var(--input-bg); border:1px solid var(--border); border-radius:6px; padding:12px; font-size:12px; overflow-x:auto; max-height:200px; overflow-y:auto; margin-bottom:16px; white-space:pre-wrap; word-break:break-all;"
+               x-text="typeof pendingPermission.input === 'string' ? pendingPermission.input : JSON.stringify(pendingPermission.input, null, 2)"></pre>
+        </template>
+        <div style="display:flex; gap:8px; justify-content:flex-end;">
+          <button class="btn" @click="respondToPermission('deny')"
+                  style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer;">
+            Deny
+          </button>
+          <button class="btn" @click="respondToPermission('allow_always')"
+                  style="background:var(--input-bg); color:var(--text); border:1px solid var(--border); padding:8px 16px; border-radius:6px; cursor:pointer;">
+            Allow Always
+          </button>
+          <button class="btn" @click="respondToPermission('allow')"
+                  style="background:var(--green); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer;">
+            Allow
+          </button>
+        </div>
+      </div>
+    </template>
+  </div>
+</div>
+```
+
+- [ ] **Step 6: Add input_needed status dot style**
+
+In `server/web/static/style.css`, add after the `.status-dot.idle` rule (line 202):
+
+```css
+.status-dot.input_needed {
+  background: var(--yellow);
+  animation: status-pulse 0.8s ease-in-out infinite;
+}
+```
+
+- [ ] **Step 7: Update sessionStatus() to handle input_needed**
+
+In `server/web/static/app.js`, update the `sessionStatus` method:
+
+```javascript
+sessionStatus(session) {
+    if (session.mode === 'managed') {
+        const state = session.activity_state || 'idle';
+        if (state === 'working') return 'active';
+        if (state === 'waiting') return 'waiting';
+        if (state === 'input_needed') return 'input_needed';
+        return 'idle';
+    }
+    // ... rest of existing code
+},
+```
+
+Also update the `:title` attribute on the status dot in the session list (line 82) to include input_needed:
+
+```html
+:title="sessionStatus(session) === 'active' ? 'Working' : sessionStatus(session) === 'waiting' ? 'Waiting for input' : sessionStatus(session) === 'input_needed' ? 'Permission needed' : 'Idle'"
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/web/static/app.js server/web/static/index.html server/web/static/style.css
+git commit -m "feat: add permission prompt modal to web UI with SSE integration"
+```
+
+---
+
+### Task 5: Integration Test — End-to-End Permission Flow
+
+**Files:**
+- Modify: `server/api/permissions_test.go` (add integration test)
+
+- [ ] **Step 1: Write an integration test that simulates the full flow**
+
+```go
+// Add to server/api/permissions_test.go
+func TestPermissionRequestBroadcastsSSE(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	// Verify activity state starts as empty
+	s, _ := store.GetSessionByID(sess.ID)
+	if s.ActivityState != "" {
+		t.Errorf("initial activity_state=%s, want empty", s.ActivityState)
+	}
+
+	// Start permission request in background
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		body := `{"tool_name":"Edit","description":"Edit file","input":{"file_path":"/tmp/test.go"}}`
+		req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-request", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("Content-Type", "application/json")
+		http.DefaultClient.Do(req)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify pending-permission endpoint shows the request
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-permission", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	var pending map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&pending)
+	if pending["pending"] != true {
+		t.Errorf("expected pending=true, got %v", pending["pending"])
+	}
+	if pending["tool_name"] != "Edit" {
+		t.Errorf("tool_name=%v, want Edit", pending["tool_name"])
+	}
+
+	// Verify activity state changed to input_needed
+	s, _ = store.GetSessionByID(sess.ID)
+	if s.ActivityState != "input_needed" {
+		t.Errorf("activity_state=%s, want input_needed", s.ActivityState)
+	}
+
+	// Respond
+	respondBody := `{"decision":"deny"}`
+	req2, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-respond", strings.NewReader(respondBody))
+	req2.Header.Set("Authorization", "Bearer test-api-key")
+	req2.Header.Set("Content-Type", "application/json")
+	http.DefaultClient.Do(req2)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("permission-request goroutine did not finish")
+	}
+
+	// Verify pending cleared
+	req3, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-permission", nil)
+	req3.Header.Set("Authorization", "Bearer test-api-key")
+	resp3, _ := http.DefaultClient.Do(req3)
+	defer resp3.Body.Close()
+
+	var cleared map[string]interface{}
+	json.NewDecoder(resp3.Body).Decode(&cleared)
+	if cleared["pending"] != false {
+		t.Errorf("expected pending=false after respond, got %v", cleared["pending"])
+	}
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `cd server && go test ./api/ -v -run TestPermission`
+Expected: All permission tests pass
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/api/permissions_test.go
+git commit -m "test: add integration test for permission request broadcast and lifecycle"
+```
+
+---
+
+### Task 6: Manual Testing & Schema Adjustment
+
+This task uses the schema discovered in Task 0 to verify and adjust the implementation.
+
+- [ ] **Step 1: Build the server**
+
+```bash
+cd server && go build -o claude-controller .
+```
+
+- [ ] **Step 2: Start the server and create a managed session**
+
+```bash
+cd server && ./claude-controller --port 8080
+```
+
+In another terminal, create a session and send a message that should trigger a permission prompt (e.g., a Bash command):
+
+```bash
+curl -X POST http://localhost:8080/api/sessions/create \
+  -H "Authorization: Bearer $(cat ~/.claude-controller/api.key)" \
+  -H "Content-Type: application/json" \
+  -d '{"cwd": "/tmp/test-project"}'
+```
+
+- [ ] **Step 3: Send a message that triggers permission**
+
+```bash
+SESSION_ID=<id from above>
+curl -X POST http://localhost:8080/api/sessions/$SESSION_ID/message \
+  -H "Authorization: Bearer $(cat ~/.claude-controller/api.key)" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Run the bash command: echo hello world"}'
+```
+
+- [ ] **Step 4: Verify the modal appears in the web UI**
+
+Open `http://localhost:8080` in a browser, select the session, and verify:
+- Permission modal appears with tool details
+- Clicking "Allow" sends the response and Claude continues
+- Activity state shows orange dot during pending
+
+- [ ] **Step 5: Adjust MCP bridge schema if needed**
+
+If the `tools/call` payload from Claude differs from what the bridge expects, update `server/mcp/bridge.go` accordingly. The logging script from Task 0 should have captured the exact format.
+
+- [ ] **Step 6: Commit any adjustments**
+
+```bash
+git add -A
+git commit -m "fix: adjust MCP bridge schema based on empirical testing"
+```
+
+---
+
+### Task 7: Create Feature Branch and Draft PR
+
+- [ ] **Step 1: Create feature branch from current branch**
+
+```bash
+git checkout -b feat/permission-prompt-handling
+```
+
+- [ ] **Step 2: Verify all tests pass**
+
+```bash
+cd server && go test ./... -v
+```
+
+- [ ] **Step 3: Create draft PR**
+
+```bash
+gh pr create --draft --title "feat: permission prompt handling for managed sessions" --body "$(cat <<'EOF'
+## Summary
+- Adds MCP bridge subcommand (`mcp-bridge`) to forward permission prompts from Claude Code to the Go server
+- New `/api/sessions/:id/permission-request` and `/api/sessions/:id/permission-respond` endpoints with blocking channel pattern
+- Permission modal in web UI with Allow/Deny/Allow Always buttons
+- New `input_needed` activity state with orange pulsing indicator
+
+Closes #58
+
+## Test plan
+- [ ] Unit tests for MCP bridge JSON-RPC parsing
+- [ ] Integration tests for permission request/respond blocking flow
+- [ ] Manual test: trigger permission prompt in managed session, verify modal appears
+- [ ] Manual test: click Allow, verify Claude continues
+- [ ] Manual test: click Deny, verify Claude handles gracefully
+- [ ] Manual test: verify timeout (5min) auto-denies
+- [ ] Manual test: verify SSE reconnect restores pending modal
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-03-26-permission-prompt-handling-design.md
+++ b/docs/superpowers/specs/2026-03-26-permission-prompt-handling-design.md
@@ -1,0 +1,207 @@
+# Permission Prompt Handling for Managed Sessions
+
+**Date:** 2026-03-26
+**Issue:** #58 — Allow Claude to edit its own settings in the current Repo
+**Status:** Design
+
+## Problem
+
+When Claude Code runs in managed mode (`claude -p`), it sometimes needs user permission to execute tools (e.g., Bash commands, file edits outside the allowed list) or presents multi-choice questions requiring user input. In the terminal CLI, these appear as interactive prompts with selectable options. In the web UI's managed sessions, there is no mechanism to detect or respond to these prompts — the process blocks indefinitely waiting for input that never comes.
+
+## Solution: MCP Permission Prompt Tool
+
+Use Claude Code's official `--permission-prompt-tool` flag to delegate permission prompts to an MCP tool. The MCP tool is an embedded subcommand of the Go server binary (`claude-controller mcp-bridge`) that forwards permission requests to the main Go server via HTTP. The Go server broadcasts the request to the web UI via SSE, the user responds via a modal, and the response flows back through the chain.
+
+## Architecture
+
+### Data Flow
+
+```
+Claude -p (needs permission)
+  → calls MCP tool "permission_prompt"
+    → MCP bridge (embedded Go subcommand, stdio)
+      → HTTP POST to Go server: POST /api/sessions/:id/permission-request
+        → Go server stores pending permission, broadcasts SSE "input_request"
+          → Browser receives SSE, shows modal
+            → User clicks Allow / Deny / Allow Always
+              → Browser POSTs to /api/sessions/:id/permission-respond
+                → Go server unblocks the permission-request handler
+                  → HTTP response to MCP bridge
+                    → MCP bridge returns JSON-RPC response to Claude
+                      → Claude proceeds with the decision
+```
+
+### Components
+
+#### 1. MCP Bridge (Embedded Subcommand)
+
+**Invocation:** `claude-controller mcp-bridge --session-id <id> --port <port>`
+
+Implements the MCP stdio protocol (JSON-RPC 2.0 over stdin/stdout):
+
+- **`initialize`** — returns server info and capabilities
+- **`tools/list`** — returns a single tool: `permission_prompt`
+- **`tools/call`** for `permission_prompt` — forwards the permission request to the Go server and blocks until the user responds
+
+The `permission_prompt` tool receives the following input from Claude:
+- `tool_name` (string): the tool requesting permission (e.g., "Bash", "Edit")
+- `description` (string): human-readable description of what the tool wants to do
+- `input` (object): the tool's input parameters (command, file_path, etc.)
+
+On receiving a call, the bridge:
+1. POSTs to `http://localhost:<port>/api/sessions/<session-id>/permission-request`
+2. Blocks waiting for the HTTP response (up to 5 minutes)
+3. Returns the decision as the tool call result
+
+#### 2. Go Server — New Endpoints
+
+**`POST /api/sessions/:id/permission-request`** (called by MCP bridge)
+
+- Receives: `{"tool_name": "Bash", "description": "Run echo hello", "input": {"command": "echo hello"}}`
+- Creates a `pendingPermission` entry for the session (in-memory, mutex-protected)
+- Broadcasts an `input_request` SSE event to all subscribers:
+  ```json
+  {
+    "type": "input_request",
+    "tool_name": "Bash",
+    "description": "Run echo hello",
+    "input": {"command": "echo hello"}
+  }
+  ```
+- Updates activity state to `"input_needed"`
+- **Blocks** on a response channel (buffered chan of size 1)
+- On response or timeout (5 minutes): returns the decision to the MCP bridge
+- On timeout: returns `{"decision": "deny", "reason": "timeout"}`
+
+**`POST /api/sessions/:id/permission-respond`** (called by frontend)
+
+- Receives: `{"decision": "allow" | "deny" | "allow_always"}`
+- Writes the decision to the pending channel, unblocking the permission-request handler
+- Clears `pendingPermission` for the session
+- Updates activity state back to `"working"`
+- Returns 404 if no pending permission request for the session
+- Returns 200 on success
+
+#### 3. Pending Permission State
+
+In-memory state on the Go server, per session:
+
+```go
+type PendingPermission struct {
+    ToolName    string          `json:"tool_name"`
+    Description string          `json:"description"`
+    Input       json.RawMessage `json:"input"`
+    ResponseCh  chan string     // buffered, size 1
+    CreatedAt   time.Time
+}
+```
+
+Stored in a `map[string]*PendingPermission` on the `Server` struct (or a dedicated manager), protected by a mutex. Entries are created when the MCP bridge calls `permission-request` and removed when the user responds or the request times out.
+
+On SSE reconnection, the frontend can check for a pending permission by hitting the existing session state endpoint (or a new `GET /api/sessions/:id/pending-permission` endpoint).
+
+#### 4. Spawn Changes
+
+When spawning `claude -p`, generate a temporary MCP config file:
+
+```json
+{
+  "mcpServers": {
+    "controller": {
+      "command": "<path-to-claude-controller-binary>",
+      "args": ["mcp-bridge", "--session-id", "<session-id>", "--port", "<server-port>"]
+    }
+  }
+}
+```
+
+Write to a temp file (e.g., `/tmp/claude-mcp-<session-id>.json`). Clean up on process exit.
+
+Add to claude args:
+- `--permission-prompt-tool mcp__controller__permission_prompt`
+- `--mcp-config <temp-file-path>`
+
+The binary path is determined at startup (via `os.Executable()`).
+
+#### 5. Frontend — Permission Modal
+
+**SSE Handler (`app.js`):**
+
+Add a case for `type: "input_request"` events:
+```javascript
+case 'input_request':
+    this.pendingPermission = data;
+    break;
+```
+
+**Modal UI (`index.html`):**
+
+An overlay modal shown when `pendingPermission !== null`:
+
+- **Header:** "Permission Required" (or "Input Required" for unstructured)
+- **Body:** Tool name, description, and input context (e.g., the Bash command, the file path and edit details)
+- **Actions for permission prompts:**
+  - "Allow" button → `{"decision": "allow"}`
+  - "Deny" button → `{"decision": "deny"}`
+  - "Allow Always" button → `{"decision": "allow_always"}`
+- **Auto-clear:** On receiving a `done` SSE event (process died), clear the modal
+
+**Activity State:**
+
+- New `"input_needed"` state alongside existing `working` / `waiting` / `idle`
+- Visual indicator: orange pulsing dot + "Waiting for permission" banner in the session header
+- The existing activity pill system continues showing tool context
+
+#### 6. Activity State: `input_needed`
+
+Add `"input_needed"` as a valid value for the `activity_state` field in the sessions table. Frontend handles this with:
+- Orange pulsing dot in session list
+- Banner in chat view: "Claude is waiting for your permission"
+- The permission modal itself
+
+On process exit or user response, state transitions back to `"working"` (if responded) or `"idle"` (if process died).
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| User doesn't respond within 5 minutes | MCP bridge receives timeout → returns deny to Claude |
+| Process dies while waiting for permission | `done` SSE event clears the modal; pending permission entry cleaned up |
+| Browser reconnects mid-permission | Frontend checks `GET /api/sessions/:id/pending-permission` on SSE connect |
+| Multiple rapid permission requests | Sequential — Claude blocks on each, only one pending at a time |
+| MCP bridge can't reach Go server | Bridge returns error to Claude; Claude handles gracefully |
+| Server restarts while permission pending | Pending permissions are in-memory, so they're lost; process will time out |
+
+## Implementation Note: Schema Discovery
+
+The exact input/output schema for `--permission-prompt-tool` MCP calls has not been verified empirically. The schema described in this spec (tool_name, description, input fields; allow/deny/allow_always response values) is based on the documented behavior and reasonable inference. During implementation, the first task should be to trigger an actual permission prompt with `--permission-prompt-tool` pointing to a logging script, capture the exact JSON-RPC payload Claude sends, and adjust the MCP bridge accordingly.
+
+## Testing Strategy
+
+1. **Unit tests:** MCP bridge JSON-RPC parsing, permission request/respond endpoint logic
+2. **Integration test:** Spawn a mock process that calls the permission endpoint, verify the blocking/unblocking flow
+3. **Manual test:** Run a managed session, trigger a Bash command that needs permission, verify modal appears and response flows back
+
+## Future: PTY Approach (Documented for Later)
+
+For a future iteration, spawning Claude in a pseudo-terminal (PTY) would give full terminal emulation — handling colored output, interactive prompts, cursor control, and escape sequences natively. This would be more robust for edge cases (e.g., prompts that don't use the MCP permission tool) but significantly more complex:
+
+- Requires terminal escape sequence parsing (ANSI codes, cursor positioning)
+- Screen buffer management to extract readable text
+- Fragile — dependent on Claude Code's terminal rendering, which can change
+- Platform-specific PTY handling (different on macOS vs Linux)
+
+The MCP-based approach handles the primary use case (permission prompts) cleanly. PTY could be explored later for full terminal parity if needed.
+
+## Files to Modify / Create
+
+| File | Change |
+|------|--------|
+| `server/main.go` | Add `mcp-bridge` subcommand dispatch |
+| `server/mcp/bridge.go` (new) | MCP stdio bridge implementation |
+| `server/managed/manager.go` | Store binary path; generate MCP config on spawn |
+| `server/api/managed_sessions.go` | New permission-request/respond endpoints; spawn arg changes |
+| `server/api/server.go` | Register new routes; add pending permission state |
+| `server/db/db.go` | Add `input_needed` to activity state migration (if validated) |
+| `server/web/static/app.js` | SSE handler for `input_request`; permission modal logic |
+| `server/web/static/index.html` | Permission modal template; activity state styling |

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -54,7 +55,7 @@ func (s *Server) handleCreateManagedSession(w http.ResponseWriter, r *http.Reque
 	json.NewEncoder(w).Encode(sess)
 }
 
-func buildClaudeArgs(sess *db.Session, message string) []string {
+func buildClaudeArgs(sess *db.Session, message string, cfg managed.Config) []string {
 	var args []string
 	args = append(args, "-p", message)
 
@@ -80,6 +81,26 @@ func buildClaudeArgs(sess *db.Session, message string) []string {
 
 	if sess.MaxBudgetUSD > 0 {
 		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", sess.MaxBudgetUSD))
+	}
+
+	// Add MCP permission prompt config if binary path is available
+	if cfg.BinaryPath != "" && cfg.ServerPort > 0 {
+		mcpConfig := map[string]interface{}{
+			"mcpServers": map[string]interface{}{
+				"controller": map[string]interface{}{
+					"command": cfg.BinaryPath,
+					"args":   []string{"mcp-bridge", "--session-id", sess.ID, "--port", fmt.Sprintf("%d", cfg.ServerPort)},
+				},
+			},
+		}
+		mcpJSON, err := json.Marshal(mcpConfig)
+		if err == nil {
+			tmpFile := fmt.Sprintf("/tmp/claude-mcp-%s.json", sess.ID)
+			if os.WriteFile(tmpFile, mcpJSON, 0644) == nil {
+				args = append(args, "--permission-prompt-tool", "mcp__controller__permission_prompt")
+				args = append(args, "--mcp-config", tmpFile)
+			}
+		}
 	}
 
 	return args
@@ -149,7 +170,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			turnsSinceLastContinue := 0
 			autoInterrupting := false
 
-			args := buildClaudeArgs(sess, currentMessage)
+			args := buildClaudeArgs(sess, currentMessage, s.manager.Config())
 			proc, err := s.manager.Spawn(sessionID, managed.SpawnOpts{
 				Args: args,
 				CWD:  sess.CWD,
@@ -200,6 +221,12 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 			stderrBytes, _ := io.ReadAll(proc.Stderr)
 			<-proc.Done
+
+			// Clean up temp MCP config file
+			os.Remove(fmt.Sprintf("/tmp/claude-mcp-%s.json", sessionID))
+
+			// Clean up any pending permission request
+			s.permissions.Delete(sessionID)
 
 			if proc.ExitCode != 0 && len(stderrBytes) > 0 {
 				errMsg := fmt.Sprintf(`{"type":"system","error":true,"stderr":%q,"exit_code":%d}`, string(stderrBytes), proc.ExitCode)

--- a/server/api/permissions.go
+++ b/server/api/permissions.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type PendingPermission struct {
+	ToolName    string          `json:"tool_name"`
+	Description string          `json:"description"`
+	Input       json.RawMessage `json:"input"`
+	ResponseCh  chan string     `json:"-"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+type PermissionManager struct {
+	mu      sync.Mutex
+	pending map[string]*PendingPermission
+}
+
+func NewPermissionManager() *PermissionManager {
+	return &PermissionManager{
+		pending: make(map[string]*PendingPermission),
+	}
+}
+
+func (pm *PermissionManager) Set(sessionID string, p *PendingPermission) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.pending[sessionID] = p
+}
+
+func (pm *PermissionManager) Get(sessionID string) *PendingPermission {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.pending[sessionID]
+}
+
+func (pm *PermissionManager) Delete(sessionID string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	delete(pm.pending, sessionID)
+}
+
+const permissionTimeout = 5 * time.Minute
+
+func (s *Server) handlePermissionRequest(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	var req struct {
+		ToolName    string          `json:"tool_name"`
+		Description string          `json:"description"`
+		Input       json.RawMessage `json:"input"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	pending := &PendingPermission{
+		ToolName:    req.ToolName,
+		Description: req.Description,
+		Input:       req.Input,
+		ResponseCh:  make(chan string, 1),
+		CreatedAt:   time.Now(),
+	}
+
+	s.permissions.Set(sessionID, pending)
+	_ = s.store.UpdateActivityState(sessionID, "input_needed")
+
+	broadcaster := s.manager.GetBroadcaster(sessionID)
+	eventJSON, _ := json.Marshal(map[string]interface{}{
+		"type":        "input_request",
+		"tool_name":   req.ToolName,
+		"description": req.Description,
+		"input":       req.Input,
+	})
+	broadcaster.Send(string(eventJSON))
+
+	select {
+	case decision := <-pending.ResponseCh:
+		s.permissions.Delete(sessionID)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"decision": decision})
+	case <-time.After(permissionTimeout):
+		s.permissions.Delete(sessionID)
+		_ = s.store.UpdateActivityState(sessionID, "working")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"decision": "deny", "reason": "timeout"})
+	case <-r.Context().Done():
+		s.permissions.Delete(sessionID)
+		return
+	}
+}
+
+func (s *Server) handlePermissionRespond(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	var req struct {
+		Decision string `json:"decision"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.Decision == "" {
+		http.Error(w, "decision is required", http.StatusBadRequest)
+		return
+	}
+
+	pending := s.permissions.Get(sessionID)
+	if pending == nil {
+		http.Error(w, "no pending permission request", http.StatusNotFound)
+		return
+	}
+
+	pending.ResponseCh <- req.Decision
+	_ = s.store.UpdateActivityState(sessionID, "working")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handlePendingPermission(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	pending := s.permissions.Get(sessionID)
+
+	w.Header().Set("Content-Type", "application/json")
+	if pending == nil {
+		json.NewEncoder(w).Encode(map[string]interface{}{"pending": false})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"pending":     true,
+		"tool_name":   pending.ToolName,
+		"description": pending.Description,
+		"input":       pending.Input,
+		"created_at":  pending.CreatedAt,
+	})
+}

--- a/server/api/permissions_test.go
+++ b/server/api/permissions_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPermissionRequestAndRespond(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	type result struct {
+		status int
+		body   string
+	}
+	ch := make(chan result, 1)
+	go func() {
+		body := `{"tool_name":"Bash","description":"Run echo hello","input":{"command":"echo hello"}}`
+		req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-request", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			ch <- result{0, err.Error()}
+			return
+		}
+		defer resp.Body.Close()
+		var respBody map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&respBody)
+		b, _ := json.Marshal(respBody)
+		ch <- result{resp.StatusCode, string(b)}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	respondBody := `{"decision":"allow"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-respond", strings.NewReader(respondBody))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("respond status=%d, want 200", resp.StatusCode)
+	}
+
+	select {
+	case r := <-ch:
+		if r.status != 200 {
+			t.Fatalf("permission-request status=%d, want 200, body=%s", r.status, r.body)
+		}
+		if !strings.Contains(r.body, "allow") {
+			t.Errorf("expected allow in response, got %s", r.body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("permission-request did not complete after respond")
+	}
+}
+
+func TestPermissionRespondNoRequest(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	body := `{"decision":"allow"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-respond", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Errorf("status=%d, want 404 when no pending request", resp.StatusCode)
+	}
+}
+
+func TestPermissionPendingEndpoint(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-permission", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["pending"] != false {
+		t.Errorf("expected pending=false, got %v", result["pending"])
+	}
+}

--- a/server/api/permissions_test.go
+++ b/server/api/permissions_test.go
@@ -85,6 +85,79 @@ func TestPermissionRespondNoRequest(t *testing.T) {
 	}
 }
 
+func TestPermissionRequestBroadcastsAndLifecycle(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+
+	// Verify activity state starts as idle
+	s, _ := store.GetSessionByID(sess.ID)
+	if s.ActivityState != "idle" {
+		t.Errorf("initial activity_state=%s, want idle", s.ActivityState)
+	}
+
+	// Start permission request in background
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		body := `{"tool_name":"Edit","description":"Edit file","input":{"file_path":"/tmp/test.go"}}`
+		req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-request", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("Content-Type", "application/json")
+		http.DefaultClient.Do(req)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify pending-permission endpoint shows the request
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-permission", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	var pending map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&pending)
+	if pending["pending"] != true {
+		t.Errorf("expected pending=true, got %v", pending["pending"])
+	}
+	if pending["tool_name"] != "Edit" {
+		t.Errorf("tool_name=%v, want Edit", pending["tool_name"])
+	}
+
+	// Verify activity state changed to input_needed
+	s, _ = store.GetSessionByID(sess.ID)
+	if s.ActivityState != "input_needed" {
+		t.Errorf("activity_state=%s, want input_needed", s.ActivityState)
+	}
+
+	// Respond
+	respondBody := `{"decision":"deny"}`
+	req2, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-respond", strings.NewReader(respondBody))
+	req2.Header.Set("Authorization", "Bearer test-api-key")
+	req2.Header.Set("Content-Type", "application/json")
+	http.DefaultClient.Do(req2)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("permission-request goroutine did not finish")
+	}
+
+	// Verify pending cleared
+	req3, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-permission", nil)
+	req3.Header.Set("Authorization", "Bearer test-api-key")
+	resp3, _ := http.DefaultClient.Do(req3)
+	defer resp3.Body.Close()
+
+	var cleared map[string]interface{}
+	json.NewDecoder(resp3.Body).Decode(&cleared)
+	if cleared["pending"] != false {
+		t.Errorf("expected pending=false after respond, got %v", cleared["pending"])
+	}
+}
+
 func TestPermissionPendingEndpoint(t *testing.T) {
 	ts, store := setupTestServer(t)
 	defer ts.Close()

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -9,13 +9,14 @@ import (
 )
 
 type Server struct {
-	store   *db.Store
-	manager *managed.Manager
-	envPath string
+	store       *db.Store
+	manager     *managed.Manager
+	envPath     string
+	permissions *PermissionManager
 }
 
 func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string) http.Handler {
-	s := &Server{store: store, manager: mgr, envPath: envPath}
+	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager()}
 
 	// API mux — all existing endpoints, behind auth middleware
 	apiMux := http.NewServeMux()
@@ -58,6 +59,9 @@ func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath str
 	apiMux.HandleFunc("GET /api/sessions/{id}/resumable", s.handleResumableList)
 	apiMux.HandleFunc("POST /api/sessions/{id}/resume", s.handleResumeSession)
 	apiMux.HandleFunc("POST /api/sessions/{id}/shell", s.handleShellExecute)
+	apiMux.HandleFunc("POST /api/sessions/{id}/permission-request", s.handlePermissionRequest)
+	apiMux.HandleFunc("POST /api/sessions/{id}/permission-respond", s.handlePermissionRespond)
+	apiMux.HandleFunc("GET /api/sessions/{id}/pending-permission", s.handlePendingPermission)
 	apiMux.HandleFunc("GET /api/sessions/{id}/commands", s.handleListCommands)
 	apiMux.HandleFunc("GET /api/sessions/{id}/commands/content", s.handleCommandContent)
 

--- a/server/main.go
+++ b/server/main.go
@@ -21,11 +21,26 @@ import (
 	"github.com/jaychinthrajah/claude-controller/server/api"
 	"github.com/jaychinthrajah/claude-controller/server/db"
 	"github.com/jaychinthrajah/claude-controller/server/managed"
+	"github.com/jaychinthrajah/claude-controller/server/mcp"
 	"github.com/jaychinthrajah/claude-controller/server/scheduler"
 	"github.com/jaychinthrajah/claude-controller/server/tunnel"
 )
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "mcp-bridge" {
+		bridgeFlags := flag.NewFlagSet("mcp-bridge", flag.ExitOnError)
+		sessionID := bridgeFlags.String("session-id", "", "session ID")
+		port := bridgeFlags.Int("port", 8080, "server port")
+		bridgeFlags.Parse(os.Args[2:])
+		if *sessionID == "" {
+			log.Fatal("--session-id is required")
+		}
+		if err := mcp.Run(*sessionID, *port); err != nil {
+			log.Fatalf("mcp-bridge error: %v", err)
+		}
+		return
+	}
+
 	port := flag.Int("port", 0, "port to listen on (default: 8080, auto-detect if occupied)")
 	dbPath := flag.String("db", "", "path to SQLite database (default: ~/.claude-controller/data.db)")
 	flag.Parse()

--- a/server/main.go
+++ b/server/main.go
@@ -83,10 +83,13 @@ func main() {
 
 	loadDotEnv(".env")
 	envPath, _ := filepath.Abs(".env")
+	binaryPath, _ := os.Executable()
 	managedCfg := managed.Config{
 		ClaudeBin:  envOrDefault("CLAUDE_BIN", "claude"),
 		ClaudeArgs: strings.Fields(os.Getenv("CLAUDE_ARGS")),
 		ClaudeEnv:  splitEnv(os.Getenv("CLAUDE_ENV")),
+		ServerPort: *port,
+		BinaryPath: binaryPath,
 	}
 	mgr := managed.NewManager(managedCfg)
 

--- a/server/managed/manager.go
+++ b/server/managed/manager.go
@@ -14,6 +14,8 @@ type Config struct {
 	ClaudeBin  string
 	ClaudeArgs []string
 	ClaudeEnv  []string
+	ServerPort int
+	BinaryPath string
 }
 
 type SpawnOpts struct {
@@ -69,6 +71,12 @@ func (m *Manager) UpdateConfig(cfg Config) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.cfg = cfg
+}
+
+func (m *Manager) Config() Config {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cfg
 }
 
 func (m *Manager) Spawn(sessionID string, opts SpawnOpts) (*Process, error) {

--- a/server/mcp/bridge.go
+++ b/server/mcp/bridge.go
@@ -1,0 +1,150 @@
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type Response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int         `json:"id"`
+	Result  interface{} `json:"result"`
+}
+
+func parseRequest(data []byte) (*Request, error) {
+	var req Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+type ToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func Run(sessionID string, serverPort int) error {
+	baseURL := fmt.Sprintf("http://localhost:%d", serverPort)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		req, err := parseRequest(line)
+		if err != nil {
+			continue
+		}
+
+		switch req.Method {
+		case "initialize":
+			writeResponse(os.Stdout, req.ID, map[string]interface{}{
+				"protocolVersion": "2024-11-05",
+				"capabilities":   map[string]interface{}{"tools": map[string]interface{}{}},
+				"serverInfo":     map[string]interface{}{"name": "claude-controller-bridge", "version": "1.0.0"},
+			})
+
+		case "notifications/initialized":
+			continue
+
+		case "tools/list":
+			writeResponse(os.Stdout, req.ID, map[string]interface{}{
+				"tools": []map[string]interface{}{
+					{
+						"name":        "permission_prompt",
+						"description": "Handle permission prompts from Claude Code",
+						"inputSchema": map[string]interface{}{
+							"type":       "object",
+							"properties": map[string]interface{}{},
+						},
+					},
+				},
+			})
+
+		case "tools/call":
+			var params ToolCallParams
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				writeToolError(os.Stdout, req.ID, "invalid params")
+				continue
+			}
+			if params.Name != "permission_prompt" {
+				writeToolError(os.Stdout, req.ID, "unknown tool: "+params.Name)
+				continue
+			}
+
+			decision, err := forwardPermissionRequest(baseURL, sessionID, params.Arguments)
+			if err != nil {
+				writeToolError(os.Stdout, req.ID, "server error: "+err.Error())
+				continue
+			}
+
+			writeResponse(os.Stdout, req.ID, map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": decision},
+				},
+			})
+		}
+	}
+
+	return scanner.Err()
+}
+
+func forwardPermissionRequest(baseURL, sessionID string, arguments json.RawMessage) (string, error) {
+	url := fmt.Sprintf("%s/api/sessions/%s/permission-request", baseURL, sessionID)
+
+	client := &http.Client{Timeout: 6 * time.Minute}
+	resp, err := client.Post(url, "application/json", bytes.NewReader(arguments))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	return string(body), nil
+}
+
+func writeResponse(w io.Writer, id int, result interface{}) {
+	resp := Response{JSONRPC: "2.0", ID: id, Result: result}
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(w, "%s\n", data)
+}
+
+func writeToolError(w io.Writer, id int, message string) {
+	resp := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result": map[string]interface{}{
+			"content": []map[string]interface{}{
+				{"type": "text", "text": message},
+			},
+			"isError": true,
+		},
+	}
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(w, "%s\n", data)
+}

--- a/server/mcp/bridge_test.go
+++ b/server/mcp/bridge_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseRequest(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	req, err := parseRequest([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Method != "initialize" {
+		t.Errorf("method=%s, want initialize", req.Method)
+	}
+	if req.ID != 1 {
+		t.Errorf("id=%v, want 1", req.ID)
+	}
+}
+
+func TestParseRequestNotification(t *testing.T) {
+	input := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+	req, err := parseRequest([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Method != "notifications/initialized" {
+		t.Errorf("method=%s, want notifications/initialized", req.Method)
+	}
+	if req.ID != 0 {
+		t.Errorf("id=%v, want 0 for notification", req.ID)
+	}
+}
+
+func TestParseToolCallParams(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"permission_prompt","arguments":{"tool_name":"Bash","command":"echo hello"}}}`
+	req, err := parseRequest([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var params ToolCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		t.Fatal(err)
+	}
+	if params.Name != "permission_prompt" {
+		t.Errorf("name=%s, want permission_prompt", params.Name)
+	}
+	if len(params.Arguments) == 0 {
+		t.Error("expected non-empty arguments")
+	}
+}

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -34,6 +34,7 @@ document.addEventListener('alpine:init', () => {
 
     // Managed session state
     showNewSessionModal: false,
+    pendingPermission: null,
     newSessionCWD: '',
     sessionSSE: null,
 
@@ -666,6 +667,7 @@ document.addEventListener('alpine:init', () => {
         const state = session.activity_state || 'idle';
         if (state === 'working') return 'active';
         if (state === 'waiting') return 'waiting';
+        if (state === 'input_needed') return 'input_needed';
         return 'idle';
       }
       const lastSeen = new Date(session.last_seen_at);
@@ -1318,6 +1320,15 @@ document.addEventListener('alpine:init', () => {
       this.sessionSSE = new EventSource(url);
       this.resetHeartbeatTimer();
 
+      // Check for pending permission on reconnect
+      fetch(`/api/sessions/${sessionId}/pending-permission`, {
+        headers: { 'Authorization': `Bearer ${this.apiKey}` }
+      }).then(r => r.json()).then(data => {
+        if (data.pending) {
+          this.pendingPermission = data;
+        }
+      }).catch(() => {});
+
       this.sessionSSE.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
@@ -1388,6 +1399,11 @@ document.addEventListener('alpine:init', () => {
             // Don't return — let the done handler below close the SSE
           }
 
+          if (data.type === 'input_request') {
+            this.pendingPermission = data;
+            return;
+          }
+
           if (data.type === 'done' || data.type === 'result') {
             // Track cost from result events
             if (data.type === 'result' && data.cost != null) {
@@ -1403,6 +1419,7 @@ document.addEventListener('alpine:init', () => {
             this.clearStalenessTimer();
           }
           if (data.type === 'done') {
+            this.pendingPermission = null;
             this.stopSessionSSE();
             return;
           }
@@ -1495,6 +1512,23 @@ document.addEventListener('alpine:init', () => {
         this.sessionSSE = null;
       }
       this.clearHeartbeatTimer();
+    },
+
+    async respondToPermission(decision) {
+      if (!this.pendingPermission || !this.selectedSessionId) return;
+      try {
+        await fetch(`/api/sessions/${this.selectedSessionId}/permission-respond`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ decision })
+        });
+      } catch (e) {
+        console.error('Failed to respond to permission:', e);
+      }
+      this.pendingPermission = null;
     },
 
     async interruptSession() {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -79,7 +79,7 @@
             <div class="session-item" :class="{ active: selectedSessionId === session.id }"
                  @click="selectSession(session.id)">
               <span class="status-dot" :class="sessionStatus(session)"
-                    :title="sessionStatus(session) === 'active' ? 'Working' : sessionStatus(session) === 'waiting' ? 'Waiting for input' : 'Idle'"></span>
+                    :title="sessionStatus(session) === 'active' ? 'Working' : sessionStatus(session) === 'waiting' ? 'Waiting for input' : sessionStatus(session) === 'input_needed' ? 'Permission needed' : 'Idle'"></span>
               <template x-if="editingSessionName === session.id">
                 <input type="text" x-model="editingNameValue"
                        @keydown.enter="saveSessionName(session.id)"
@@ -1023,6 +1023,42 @@
           <span x-show="settingsSaving">Saving...</span>
         </button>
       </div>
+    </div>
+  </div>
+
+  <!-- Permission Prompt Modal -->
+  <div x-show="pendingPermission" x-cloak
+       style="position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:200; display:flex; align-items:center; justify-content:center;">
+    <div @click.stop class="modal-inner" style="background:var(--bg); border-radius:12px; padding:24px; width:500px; max-width:90vw; border:1px solid var(--border); box-shadow:0 20px 60px rgba(0,0,0,0.5);">
+      <h3 style="margin-top:0; margin-bottom:16px; display:flex; align-items:center; gap:8px;">
+        <span style="color:var(--yellow);">&#9888;</span> Permission Required
+      </h3>
+      <template x-if="pendingPermission">
+        <div>
+          <div style="margin-bottom:12px;">
+            <span style="font-weight:600;" x-text="pendingPermission.tool_name || 'Tool'"></span>
+            <span style="color:var(--text-muted); margin-left:8px;" x-text="pendingPermission.description || ''"></span>
+          </div>
+          <template x-if="pendingPermission.input">
+            <pre style="background:var(--input-bg); border:1px solid var(--border); border-radius:6px; padding:12px; font-size:12px; overflow-x:auto; max-height:200px; overflow-y:auto; margin-bottom:16px; white-space:pre-wrap; word-break:break-all;"
+                 x-text="typeof pendingPermission.input === 'string' ? pendingPermission.input : JSON.stringify(pendingPermission.input, null, 2)"></pre>
+          </template>
+          <div style="display:flex; gap:8px; justify-content:flex-end;">
+            <button class="btn" @click="respondToPermission('deny')"
+                    style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer;">
+              Deny
+            </button>
+            <button class="btn" @click="respondToPermission('allow_always')"
+                    style="background:var(--input-bg); color:var(--text); border:1px solid var(--border); padding:8px 16px; border-radius:6px; cursor:pointer;">
+              Allow Always
+            </button>
+            <button class="btn" @click="respondToPermission('allow')"
+                    style="background:var(--green); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer;">
+              Allow
+            </button>
+          </div>
+        </div>
+      </template>
     </div>
   </div>
 

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -200,6 +200,10 @@ body {
   animation: status-pulse 1.5s ease-in-out infinite;
 }
 .status-dot.idle { background: var(--gray); }
+.status-dot.input_needed {
+  background: var(--yellow);
+  animation: status-pulse 0.8s ease-in-out infinite;
+}
 
 @keyframes status-pulse {
   0%, 100% { opacity: 1; }


### PR DESCRIPTION
## Summary
- Adds MCP bridge subcommand (`mcp-bridge`) to forward permission prompts from Claude Code to the Go server via `--permission-prompt-tool`
- New `/api/sessions/:id/permission-request` and `/api/sessions/:id/permission-respond` endpoints with blocking channel pattern
- Permission modal in web UI with Allow/Deny/Allow Always buttons
- New `input_needed` activity state with orange pulsing indicator
- Pending permission recovery on SSE reconnect

Closes #58

## Architecture
When Claude Code hits a permission prompt in managed mode, it calls the MCP tool `permission_prompt`. The MCP bridge (embedded Go subcommand) forwards this as an HTTP POST to the Go server, which blocks until the web UI user responds via the modal. The decision flows back through the chain to Claude.

## Test plan
- [x] Unit tests for MCP bridge JSON-RPC parsing
- [x] Integration tests for permission request/respond blocking flow
- [x] Integration test for activity state lifecycle (idle → input_needed → working)
- [ ] Manual test: trigger permission prompt in managed session, verify modal appears
- [ ] Manual test: click Allow, verify Claude continues
- [ ] Manual test: click Deny, verify Claude handles gracefully
- [ ] Manual test: verify timeout (5min) auto-denies
- [ ] Manual test: verify SSE reconnect restores pending modal