### PR TITLE
feat: auto-continue with periodic /compact

### DIFF
--- a/docs/superpowers/specs/2026-03-29-auto-continue-compact-design.md
+++ b/docs/superpowers/specs/2026-03-29-auto-continue-compact-design.md
@@ -1,0 +1,89 @@
+# Auto-Continue with Compact — Design Spec
+
+**Date:** 2026-03-29
+**Issue:** #63
+
+## Problem
+
+Claude's auto-continue system resumes sessions up to `max_continuations` times, but each continuation carries the full conversation context. Over 5 continuations, token usage grows significantly. Running `/compact` periodically during auto-continue cycles reduces context size and saves tokens.
+
+## Solution
+
+Add a `compact_every_n_continues` setting per session. When set to N (> 0), every Nth continuation triggers a compact step before resuming work. When set to 0 (default), no compacting occurs — preserving current behavior.
+
+## New Setting
+
+- **`compact_every_n_continues`** — integer, default 0 (disabled)
+- When > 0, on continuation counts divisible by N, run `/compact` before resuming
+- Example: `compact_every_n_continues: 2` → compact on continuations 2, 4, 6...
+
+## Database Change
+
+New column on `sessions` table:
+
+```sql
+ALTER TABLE sessions ADD COLUMN compact_every_n_continues INTEGER NOT NULL DEFAULT 0
+```
+
+## Auto-Continue Loop Change
+
+Current flow:
+1. SIGINT the process (turn threshold reached)
+2. Increment continuation count
+3. Check max_continuations
+4. Resume with "Continue where you left off."
+
+New flow:
+1. SIGINT the process (turn threshold reached)
+2. Increment continuation count
+3. Check max_continuations
+4. **If `compact_every_n_continues > 0` AND `continuation_count % compact_every_n_continues == 0`:**
+   a. Broadcast `compacting` SSE event
+   b. Persist system message: "Running /compact to reduce context size..."
+   c. Spawn `claude --resume <session_id> -p "/compact"` and wait for exit
+   d. Broadcast `compact_complete` SSE event
+   e. Persist system message: "Compact complete."
+5. Resume with "Continue where you left off."
+
+The compact step is a separate `claude -p` invocation that runs the slash command and exits. The subsequent resume inherits the compacted context.
+
+## SSE Events
+
+New events:
+- `compacting`: `{"type":"compacting","continuation_count":N}` — broadcast before compact runs
+- `compact_complete`: `{"type":"compact_complete","continuation_count":N}` — broadcast after compact finishes
+
+## API Changes
+
+### Session Creation
+`POST /api/sessions/create` — new optional field:
+- `compact_every_n_continues` (integer, default 0)
+
+### Session JSON
+The `Session` struct includes `compact_every_n_continues` in JSON responses.
+
+## Web UI Changes
+
+### Session Creation Form
+- Add "Compact every N continues" number input (default 0, min 0)
+- Help text: "Run /compact every N auto-continues to reduce token usage. 0 = disabled."
+
+### SSE Event Handling
+- `compacting` event: show system message "Running /compact to reduce context size..."
+- `compact_complete` event: show system message "Compact complete."
+
+### Turn Monitor
+- When compacting is active, show a "Compacting..." indicator
+
+## Files to Change
+
+1. `server/db/db.go` — add migration for new column
+2. `server/db/sessions.go` — update Session struct and CreateSession query
+3. `server/api/managed_sessions.go` — update session creation endpoint and add compact logic to auto-continue loop
+4. `server/web/static/app.js` — add UI setting, handle new SSE events
+
+## Edge Cases
+
+- If compact process fails (non-zero exit), log the error and continue with the resume anyway — don't block auto-continue on a failed compact
+- If `compact_every_n_continues` is greater than `max_continuations`, compact never triggers — that's fine, user chose those settings
+- Compact counts as a separate process invocation but does NOT count as a continuation

--- a/server/api/commands_test.go
+++ b/server/api/commands_test.go
@@ -91,7 +91,7 @@ func TestHandleListCommands(t *testing.T) {
 	os.WriteFile(filepath.Join(cmdDir, "test.md"),
 		[]byte("---\nname: test\ndescription: Test cmd\n---\ntest body"), 0644)
 
-	sess, _ := store.CreateManagedSession(tmpDir, `["Bash"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession(tmpDir, `["Bash"]`, 50, 5.0, 0)
 
 	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/commands", nil)
 	req.Header.Set("Authorization", "Bearer test-api-key")
@@ -142,7 +142,7 @@ func TestHandleCommandContent(t *testing.T) {
 	os.WriteFile(filepath.Join(cmdDir, "greet.md"),
 		[]byte("---\nname: greet\ndescription: Greet someone\nargument-hint: [name]\n---\nHello, please greet $ARGUMENTS warmly."), 0644)
 
-	sess, _ := store.CreateManagedSession(tmpDir, `["Bash"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession(tmpDir, `["Bash"]`, 50, 5.0, 0)
 
 	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/commands/content?name=/greet", nil)
 	req.Header.Set("Authorization", "Bearer test-api-key")
@@ -172,7 +172,7 @@ func TestHandleCommandContentNotFound(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp/nonexistent", `["Bash"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp/nonexistent", `["Bash"]`, 50, 5.0, 0)
 
 	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/commands/content?name=/nope", nil)
 	req.Header.Set("Authorization", "Bearer test-api-key")

--- a/server/api/create_project.go
+++ b/server/api/create_project.go
@@ -116,6 +116,7 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		`["Bash","Read","Edit","Write","Glob","Grep"]`,
 		50,
 		5.0,
+		0,
 	)
 	if err != nil {
 		os.RemoveAll(fullPath)

--- a/server/api/github_test.go
+++ b/server/api/github_test.go
@@ -56,7 +56,7 @@ func TestListGithubIssues_ManagedNoCWDReturns400(t *testing.T) {
 	defer store.Close()
 
 	// CreateManagedSession with empty cwd
-	sess, err := store.CreateManagedSession("", `[]`, 0, 0)
+	sess, err := store.CreateManagedSession("", `[]`, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("CreateManagedSession: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestListGithubIssues_InvalidStateParam(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0)
+	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("CreateManagedSession: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestGetGithubIssue_InvalidNumberReturns400(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0)
+	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("CreateManagedSession: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestGetGithubIssue_ManagedNoCWDReturns400(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, err := store.CreateManagedSession("", `[]`, 0, 0)
+	sess, err := store.CreateManagedSession("", `[]`, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("CreateManagedSession: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestListGithubIssues_DefaultParamsAccepted(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0)
+	sess, err := store.CreateManagedSession("/tmp", `[]`, 0, 0, 0)
 	if err != nil {
 		t.Fatalf("CreateManagedSession: %v", err)
 	}

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,6 +41,11 @@ func (s *Server) handleCreateManagedSession(w http.ResponseWriter, r *http.Reque
 	}
 	if req.MaxBudgetUSD == 0 {
 		req.MaxBudgetUSD = 5.0
+	}
+	if req.CompactEveryNContinues == 0 {
+		if v, err := strconv.Atoi(readEnvFile(s.envPath)["COMPACT_EVERY_N_CONTINUES"]); err == nil && v > 0 {
+			req.CompactEveryNContinues = v
+		}
 	}
 
 	sess, err := s.store.CreateManagedSession(req.CWD, req.AllowedTools, req.MaxTurns, req.MaxBudgetUSD, req.CompactEveryNContinues)

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -18,10 +18,11 @@ import (
 
 func (s *Server) handleCreateManagedSession(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		CWD          string  `json:"cwd"`
-		AllowedTools string  `json:"allowed_tools"`
-		MaxTurns     int     `json:"max_turns"`
-		MaxBudgetUSD float64 `json:"max_budget_usd"`
+		CWD                    string  `json:"cwd"`
+		AllowedTools           string  `json:"allowed_tools"`
+		MaxTurns               int     `json:"max_turns"`
+		MaxBudgetUSD           float64 `json:"max_budget_usd"`
+		CompactEveryNContinues int     `json:"compact_every_n_continues"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -41,7 +42,7 @@ func (s *Server) handleCreateManagedSession(w http.ResponseWriter, r *http.Reque
 		req.MaxBudgetUSD = 5.0
 	}
 
-	sess, err := s.store.CreateManagedSession(req.CWD, req.AllowedTools, req.MaxTurns, req.MaxBudgetUSD)
+	sess, err := s.store.CreateManagedSession(req.CWD, req.AllowedTools, req.MaxTurns, req.MaxBudgetUSD, req.CompactEveryNContinues)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint") {
 			http.Error(w, "session already exists for this directory", http.StatusConflict)
@@ -282,6 +283,39 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			broadcaster.Send(continuingMsg)
 			_, _ = s.store.CreateMessage(sessionID, "system",
 				fmt.Sprintf("Auto-continuing (%d/%d)...", continuationCount, sess.MaxContinuations))
+
+			// Compact step: run /compact before resuming if configured
+			if sess.CompactEveryNContinues > 0 && continuationCount%sess.CompactEveryNContinues == 0 {
+				compactingMsg := fmt.Sprintf(`{"type":"compacting","continuation_count":%d}`, continuationCount)
+				broadcaster.Send(compactingMsg)
+				_, _ = s.store.CreateMessage(sessionID, "system", "Running /compact to reduce context size...")
+
+				compactArgs := buildClaudeArgs(sess, "/compact", s.manager.Config())
+				compactProc, compactErr := s.manager.Spawn(sessionID, managed.SpawnOpts{
+					Args: compactArgs,
+					CWD:  sess.CWD,
+				})
+				if compactErr != nil {
+					log.Printf("session %s: compact spawn failed: %v", sessionID, compactErr)
+					_, _ = s.store.CreateMessage(sessionID, "system", "Compact failed, continuing without it.")
+				} else {
+					// Drain stdout to avoid blocking, but don't process lines as regular output
+					go io.Copy(io.Discard, compactProc.Stdout)
+					go io.Copy(io.Discard, compactProc.Stderr)
+					<-compactProc.Done
+					os.Remove(fmt.Sprintf("/tmp/claude-mcp-%s.json", sessionID))
+
+					if compactProc.ExitCode == 0 {
+						log.Printf("session %s: compact completed successfully", sessionID)
+						_, _ = s.store.CreateMessage(sessionID, "system", "Compact complete.")
+					} else {
+						log.Printf("session %s: compact exited with code %d", sessionID, compactProc.ExitCode)
+						_, _ = s.store.CreateMessage(sessionID, "system", "Compact failed, continuing without it.")
+					}
+					compactCompleteMsg := fmt.Sprintf(`{"type":"compact_complete","continuation_count":%d}`, continuationCount)
+					broadcaster.Send(compactCompleteMsg)
+				}
+			}
 
 			currentMessage = "You were interrupted due to turn limits. Continue where you left off."
 		}

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -91,7 +91,7 @@ func TestListMessagesAPI(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0, 0)
 	store.CreateMessage(sess.ID, "user", "hello")
 	store.CreateMessage(sess.ID, "assistant", `{"type":"assistant","content":"hi"}`)
 
@@ -120,7 +120,7 @@ func TestShellExecuteAPI(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0, 0)
 
 	body := `{"command": "echo hello"}`
 	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/shell", strings.NewReader(body))
@@ -149,7 +149,7 @@ func TestShellExecuteRejectsEmptyCommand(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0, 0)
 
 	body := `{"command": ""}`
 	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/shell", strings.NewReader(body))
@@ -208,7 +208,7 @@ func TestShellExecutePersistsMessages(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0, 0)
 
 	body := `{"command": "echo hello", "timeout": 5}`
 	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/shell", strings.NewReader(body))
@@ -306,8 +306,8 @@ func TestRecentDirsAPI(t *testing.T) {
 	}
 
 	// Create sessions, then check
-	store.CreateManagedSession("/tmp/project-a", `["Bash"]`, 50, 5.0)
-	store.CreateManagedSession("/tmp/project-b", `["Bash"]`, 50, 5.0)
+	store.CreateManagedSession("/tmp/project-a", `["Bash"]`, 50, 5.0, 0)
+	store.CreateManagedSession("/tmp/project-b", `["Bash"]`, 50, 5.0, 0)
 
 	req2, _ := http.NewRequest("GET", ts.URL+"/api/sessions/recent-dirs", nil)
 	req2.Header.Set("Authorization", "Bearer test-api-key")

--- a/server/api/permissions_test.go
+++ b/server/api/permissions_test.go
@@ -13,7 +13,7 @@ func TestPermissionRequestAndRespond(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0, 0)
 
 	type result struct {
 		status int
@@ -71,7 +71,7 @@ func TestPermissionRespondNoRequest(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0, 0)
 
 	body := `{"decision":"allow"}`
 	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/permission-respond", strings.NewReader(body))
@@ -90,7 +90,7 @@ func TestPermissionRequestBroadcastsAndLifecycle(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0, 0)
 
 	// Verify activity state starts as idle
 	s, _ := store.GetSessionByID(sess.ID)
@@ -163,7 +163,7 @@ func TestPermissionPendingEndpoint(t *testing.T) {
 	defer ts.Close()
 	defer store.Close()
 
-	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0, 0)
 
 	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-permission", nil)
 	req.Header.Set("Authorization", "Bearer test-api-key")

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -12,11 +12,12 @@ import (
 )
 
 type settingsPayload struct {
-	Port           string `json:"port"`
-	NgrokAuthtoken string `json:"ngrok_authtoken"`
-	ClaudeBin      string `json:"claude_bin"`
-	ClaudeArgs     string `json:"claude_args"`
-	ClaudeEnv      string `json:"claude_env"`
+	Port                   string `json:"port"`
+	NgrokAuthtoken         string `json:"ngrok_authtoken"`
+	ClaudeBin              string `json:"claude_bin"`
+	ClaudeArgs             string `json:"claude_args"`
+	ClaudeEnv              string `json:"claude_env"`
+	CompactEveryNContinues string `json:"compact_every_n_continues"`
 }
 
 func (s *Server) handleSettingsExists(w http.ResponseWriter, r *http.Request) {
@@ -36,11 +37,12 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := settingsPayload{
-		Port:           vals["PORT"],
-		NgrokAuthtoken: vals["NGROK_AUTHTOKEN"],
-		ClaudeBin:      vals["CLAUDE_BIN"],
-		ClaudeArgs:     vals["CLAUDE_ARGS"],
-		ClaudeEnv:      vals["CLAUDE_ENV"],
+		Port:                   vals["PORT"],
+		NgrokAuthtoken:         vals["NGROK_AUTHTOKEN"],
+		ClaudeBin:              vals["CLAUDE_BIN"],
+		ClaudeArgs:             vals["CLAUDE_ARGS"],
+		ClaudeEnv:              vals["CLAUDE_ENV"],
+		CompactEveryNContinues: vals["COMPACT_EVERY_N_CONTINUES"],
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
@@ -143,6 +145,9 @@ func formatEnvFile(p settingsPayload) string {
 	}
 	if p.ClaudeEnv != "" {
 		b.WriteString("CLAUDE_ENV=" + p.ClaudeEnv + "\n")
+	}
+	if p.CompactEveryNContinues != "" && p.CompactEveryNContinues != "0" {
+		b.WriteString("COMPACT_EVERY_N_CONTINUES=" + p.CompactEveryNContinues + "\n")
 	}
 	return b.String()
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -129,6 +129,7 @@ func migrate(db *sql.DB) error {
 			name TEXT NOT NULL,
 			last_used_at DATETIME NOT NULL DEFAULT (datetime('now'))
 		)`,
+		`ALTER TABLE sessions ADD COLUMN compact_every_n_continues INTEGER NOT NULL DEFAULT 0`,
 	}
 
 	for _, m := range migrations {

--- a/server/db/messages_test.go
+++ b/server/db/messages_test.go
@@ -13,7 +13,7 @@ func TestCreateAndListMessages(t *testing.T) {
 	}
 	defer store.Close()
 
-	sess, err := store.CreateManagedSession("/tmp/project", `["Bash","Read","Edit"]`, 50, 5.0)
+	sess, err := store.CreateManagedSession("/tmp/project", `["Bash","Read","Edit"]`, 50, 5.0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestDeleteSessionCascadesMessages(t *testing.T) {
 	}
 	defer store.Close()
 
-	sess, err := store.CreateManagedSession("/tmp/project", `["Read"]`, 50, 5.0)
+	sess, err := store.CreateManagedSession("/tmp/project", `["Read"]`, 50, 5.0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -30,9 +30,10 @@ type Session struct {
 	MaxContinuations      int     `json:"max_continuations"`
 	ActivityState         string  `json:"activity_state"`
 	Name                  string  `json:"name"`
+	CompactEveryNContinues int    `json:"compact_every_n_continues"`
 }
 
-const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), turn_count, auto_continue_threshold, max_continuations, COALESCE(activity_state,'idle'), COALESCE(name,'')`
+const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), turn_count, auto_continue_threshold, max_continuations, COALESCE(activity_state,'idle'), COALESCE(name,''), compact_every_n_continues`
 
 func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, error) {
 	var sess Session
@@ -42,7 +43,7 @@ func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, erro
 		&sess.Status, &sess.CreatedAt, &sess.LastSeenAt, &archived,
 		&sess.Mode, &sess.CWD, &sess.AllowedTools, &sess.MaxTurns, &sess.MaxBudgetUSD, &initialized,
 		&sess.ClaudeSessionID, &sess.TurnCount, &sess.AutoContinueThreshold, &sess.MaxContinuations, &sess.ActivityState,
-		&sess.Name,
+		&sess.Name, &sess.CompactEveryNContinues,
 	)
 	if err != nil {
 		return sess, err
@@ -110,13 +111,13 @@ func (s *Store) GetSessionByID(id string) (*Session, error) {
 	return &sess, nil
 }
 
-func (s *Store) CreateManagedSession(cwd, allowedTools string, maxTurns int, maxBudgetUSD float64) (*Session, error) {
+func (s *Store) CreateManagedSession(cwd, allowedTools string, maxTurns int, maxBudgetUSD float64, compactEveryNContinues int) (*Session, error) {
 	id := uuid.New().String()
 	// Use "__managed__" as computer_name and cwd as project_path to avoid
 	// colliding with the existing UNIQUE(computer_name, project_path) constraint.
-	_, err := s.db.Exec(`INSERT INTO sessions (id, computer_name, project_path, mode, cwd, allowed_tools, max_turns, max_budget_usd, status)
-		VALUES (?, '__managed__', ?, 'managed', ?, ?, ?, ?, 'idle')`,
-		id, cwd, cwd, allowedTools, maxTurns, maxBudgetUSD)
+	_, err := s.db.Exec(`INSERT INTO sessions (id, computer_name, project_path, mode, cwd, allowed_tools, max_turns, max_budget_usd, compact_every_n_continues, status)
+		VALUES (?, '__managed__', ?, 'managed', ?, ?, ?, ?, ?, 'idle')`,
+		id, cwd, cwd, allowedTools, maxTurns, maxBudgetUSD, compactEveryNContinues)
 	if err != nil {
 		return nil, fmt.Errorf("create managed session: %w", err)
 	}

--- a/server/db/sessions_test.go
+++ b/server/db/sessions_test.go
@@ -87,7 +87,7 @@ func TestArchiveSession(t *testing.T) {
 func TestCreateManagedSession(t *testing.T) {
 	store := newTestStore(t)
 
-	sess, err := store.CreateManagedSession("/tmp/project", `["Bash","Read"]`, 50, 5.0)
+	sess, err := store.CreateManagedSession("/tmp/project", `["Bash","Read"]`, 50, 5.0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestCreateManagedSession(t *testing.T) {
 		t.Error("new session should not be initialized")
 	}
 
-	_, err = store.CreateManagedSession("/tmp/project", `["Bash"]`, 50, 5.0)
+	_, err = store.CreateManagedSession("/tmp/project", `["Bash"]`, 50, 5.0, 0)
 	if err == nil {
 		t.Error("expected error for duplicate cwd, got nil")
 	}
@@ -125,7 +125,7 @@ func TestHeartbeat(t *testing.T) {
 
 func TestTurnCount(t *testing.T) {
 	store := newTestStore(t)
-	sess, err := store.CreateManagedSession("/tmp/test-turns", `["Bash"]`, 50, 5.0)
+	sess, err := store.CreateManagedSession("/tmp/test-turns", `["Bash"]`, 50, 5.0, 0)
 	if err != nil {
 		t.Fatalf("create session: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestTurnCount(t *testing.T) {
 
 func TestResumeSessionResetsTurnCount(t *testing.T) {
 	store := newTestStore(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-resume-turns", `["Bash"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/tmp/test-resume-turns", `["Bash"]`, 50, 5.0, 0)
 
 	// Increment some turns
 	store.IncrementTurnCount(sess.ID)
@@ -189,7 +189,7 @@ func TestResumeSessionResetsTurnCount(t *testing.T) {
 
 func TestAutoContinueDefaults(t *testing.T) {
 	store := newTestStore(t)
-	sess, err := store.CreateManagedSession("/tmp/test-ac", `["Bash"]`, 50, 5.0)
+	sess, err := store.CreateManagedSession("/tmp/test-ac", `["Bash"]`, 50, 5.0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestAutoContinueDefaults(t *testing.T) {
 
 func TestUpdateActivityState(t *testing.T) {
 	store := newTestStore(t)
-	sess, err := store.CreateManagedSession("/tmp/test-activity", `["Bash"]`, 50, 5.0)
+	sess, err := store.CreateManagedSession("/tmp/test-activity", `["Bash"]`, 50, 5.0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,8 +246,8 @@ func TestRecentDirectories(t *testing.T) {
 	}
 
 	// Create some managed sessions
-	store.CreateManagedSession("/projects/alpha", `["Bash"]`, 50, 5.0)
-	store.CreateManagedSession("/projects/beta", `["Bash"]`, 50, 5.0)
+	store.CreateManagedSession("/projects/alpha", `["Bash"]`, 50, 5.0, 0)
+	store.CreateManagedSession("/projects/beta", `["Bash"]`, 50, 5.0, 0)
 
 	dirs, err = store.RecentDirectories(5)
 	if err != nil {
@@ -272,7 +272,7 @@ func TestRecentDirectories_Limit(t *testing.T) {
 	store := newTestStore(t)
 
 	for i := 0; i < 7; i++ {
-		store.CreateManagedSession(fmt.Sprintf("/projects/p%d", i), `["Bash"]`, 50, 5.0)
+		store.CreateManagedSession(fmt.Sprintf("/projects/p%d", i), `["Bash"]`, 50, 5.0, 0)
 	}
 
 	dirs, err := store.RecentDirectories(5)
@@ -287,7 +287,7 @@ func TestRecentDirectories_Limit(t *testing.T) {
 func TestRecentDirectories_IncludesArchived(t *testing.T) {
 	store := newTestStore(t)
 
-	sess, _ := store.CreateManagedSession("/projects/archived-proj", `["Bash"]`, 50, 5.0)
+	sess, _ := store.CreateManagedSession("/projects/archived-proj", `["Bash"]`, 50, 5.0, 0)
 	store.SetArchived(sess.ID, true)
 
 	dirs, err := store.RecentDirectories(5)
@@ -306,9 +306,9 @@ func TestRecentDirectories_DeduplicatesCWD(t *testing.T) {
 	store := newTestStore(t)
 
 	// Create first session, then delete it so the unique constraint allows a second
-	sess1, _ := store.CreateManagedSession("/projects/same", `["Bash"]`, 50, 5.0)
+	sess1, _ := store.CreateManagedSession("/projects/same", `["Bash"]`, 50, 5.0, 0)
 	store.DeleteSession(sess1.ID)
-	store.CreateManagedSession("/projects/same", `["Bash"]`, 50, 5.0)
+	store.CreateManagedSession("/projects/same", `["Bash"]`, 50, 5.0, 0)
 
 	dirs, err := store.RecentDirectories(5)
 	if err != nil {
@@ -321,8 +321,8 @@ func TestRecentDirectories_DeduplicatesCWD(t *testing.T) {
 
 func TestResetStaleActivityStates(t *testing.T) {
 	store := newTestStore(t)
-	s1, _ := store.CreateManagedSession("/tmp/stale1", `["Bash"]`, 50, 5.0)
-	s2, _ := store.CreateManagedSession("/tmp/stale2", `["Bash"]`, 50, 5.0)
+	s1, _ := store.CreateManagedSession("/tmp/stale1", `["Bash"]`, 50, 5.0, 0)
+	s2, _ := store.CreateManagedSession("/tmp/stale2", `["Bash"]`, 50, 5.0, 0)
 	store.UpdateActivityState(s1.ID, "working")
 	store.UpdateActivityState(s2.ID, "waiting")
 	if err := store.ResetStaleActivityStates(); err != nil {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -115,6 +115,7 @@ document.addEventListener('alpine:init', () => {
     lastTurnThreshold: 0,
     lastThresholdSessionId: null,
     continuationCount: 0,
+    isCompacting: false,
 
     // Shell mode
     shellMode: false,
@@ -690,6 +691,7 @@ document.addEventListener('alpine:init', () => {
       this.showSlashMenu = false;
       this.sessionCost = null;
       this.continuationCount = 0;
+      this.isCompacting = false;
       this.sessionFiles = [];
       this.fileTreeData = [];
       this.fileContentCache = {};
@@ -1382,6 +1384,30 @@ document.addEventListener('alpine:init', () => {
             });
             // Reset turn threshold tracker since turn count will reset
             this.lastTurnThreshold = 0;
+            this.$nextTick(() => this.scrollToBottom(true));
+            return;
+          }
+
+          if (data.type === 'compacting') {
+            this.isCompacting = true;
+            this.chatMessages.push({
+              id: 'compact-' + Date.now(),
+              role: 'system',
+              content: 'Running /compact to reduce context size...',
+              isAutoContinue: true
+            });
+            this.$nextTick(() => this.scrollToBottom(true));
+            return;
+          }
+
+          if (data.type === 'compact_complete') {
+            this.isCompacting = false;
+            this.chatMessages.push({
+              id: 'compact-done-' + Date.now(),
+              role: 'system',
+              content: 'Compact complete.',
+              isAutoContinue: true
+            });
             this.$nextTick(() => this.scrollToBottom(true));
             return;
           }

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -106,7 +106,7 @@ document.addEventListener('alpine:init', () => {
     // Settings state
     showSettingsModal: false,
     settingsFirstRun: false,
-    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '' },
+    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '' },
     settingsError: '',
     settingsSaving: false,
     settingsRestartRequired: false,
@@ -450,6 +450,7 @@ document.addEventListener('alpine:init', () => {
           claude_bin: data.claude_bin || '',
           claude_args: data.claude_args || '',
           claude_env: data.claude_env || '',
+          compact_every_n_continues: data.compact_every_n_continues || '',
         };
       } catch (e) {
         this.settingsForm = { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '' };

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -174,6 +174,9 @@
               <span style="opacity:0.7;">Continues</span>
               <span x-text="continuationCount + '/' + (currentSession?.max_continuations || 0)" style="font-weight:600;"></span>
             </div>
+            <div x-show="isCompacting" style="display:flex; align-items:center; gap:4px; padding-left:4px; border-left:1px solid var(--border); color:#f39c12;">
+              <span style="font-weight:600;">Compacting...</span>
+            </div>
             <button class="btn btn-sm"
                     @click="interruptSession()"
                     :disabled="currentSession?.activity_state !== 'working'"

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1015,6 +1015,13 @@
                  style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
           <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Comma-separated KEY=VALUE pairs for managed session environment</div>
         </div>
+
+        <div>
+          <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">COMPACT_EVERY_N_CONTINUES</label>
+          <input x-model="settingsForm.compact_every_n_continues" type="number" min="0" placeholder="0"
+                 style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
+          <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Run /compact every N auto-continues to reduce token usage. 0 = disabled.</div>
+        </div>
       </div>
 
       <p class="error-msg" x-show="settingsError" x-text="settingsError" style="margin-top:8px;"></p>


### PR DESCRIPTION
## Summary

- Adds compact_every_n_continues setting per session (default 0 = disabled)
- When set to N, every Nth auto-continuation runs /compact before resuming, reducing token drain over long sessions
- New SSE events (compacting, compact_complete) with UI indicator in the turn monitor
- Graceful fallback: if compact fails, auto-continue proceeds normally

## Changes

- **DB**: New compact_every_n_continues column on sessions table
- **API**: POST /api/sessions/create accepts the new field; auto-continue loop in handleSendMessage spawns a compact step when the interval hits
- **Web UI**: compacting/compact_complete SSE handlers, Compacting indicator in turn monitor
- **Spec**: docs/superpowers/specs/2026-03-29-auto-continue-compact-design.md

Closes #63

## Test plan

- [x] All existing tests pass (go test ./...)
- [ ] Create a session with compact_every_n_continues: 2, verify compact runs on continuations 2, 4, etc.
- [ ] Create a session with compact_every_n_continues: 0, verify no compact runs (existing behavior)
- [ ] Verify Compacting indicator appears in UI during compact step
- [ ] Verify compact failure does not block auto-continue