### PR TITLE
fix: don't mark session initialized on execution error

### DIFF
--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -183,21 +183,30 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 
-			// After first spawn, ensure subsequent spawns use --resume
-			if !sess.Initialized {
-				_ = s.store.SetInitialized(sessionID)
-				sess.Initialized = true
-			}
-
 			// onLine runs synchronously inside StreamNDJSON's read loop.
-			// autoInterrupting is safe to read after StreamNDJSON returns
-			// because StreamNDJSON blocks until stdout EOF, providing a
-			// happens-before guarantee with <-proc.Done.
+			// autoInterrupting and executionErrored are safe to read after
+			// StreamNDJSON returns because StreamNDJSON blocks until stdout
+			// EOF, providing a happens-before guarantee with <-proc.Done.
+			executionErrored := false
 			onLine := func(line string) {
-				if parseRole(line) == "heartbeat" {
+				role := parseRole(line)
+				if role == "heartbeat" {
 					return
 				}
-				role := parseRole(line)
+				if role == "result" {
+					var res struct {
+						Subtype string   `json:"subtype"`
+						IsError bool     `json:"is_error"`
+						Errors  []string `json:"errors"`
+					}
+					if json.Unmarshal([]byte(line), &res) == nil && res.Subtype == "error_during_execution" {
+						executionErrored = true
+						if len(res.Errors) > 0 {
+							errText := strings.Join(res.Errors, "; ")
+							_, _ = s.store.CreateMessage(sessionID, "assistant", errText)
+						}
+					}
+				}
 				if role == "assistant" {
 					text := extractAssistantText(line)
 					if text != "" {
@@ -221,6 +230,14 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 			stderrBytes, _ := io.ReadAll(proc.Stderr)
 			<-proc.Done
+
+			// Mark session as initialized only after a successful execution.
+			// If claude -p exits with error_during_execution (e.g. auth failure),
+			// no conversation was created, so --resume would fail on next message.
+			if !sess.Initialized && !executionErrored {
+				_ = s.store.SetInitialized(sessionID)
+				sess.Initialized = true
+			}
 
 			// Clean up temp MCP config file
 			os.Remove(fmt.Sprintf("/tmp/claude-mcp-%s.json", sessionID))


### PR DESCRIPTION
## Summary
- Detect `error_during_execution` in `claude -p` stream output and skip marking the session as initialized
- Persist error messages from failed executions so they survive page refreshes
- Prevents silent failures where `--resume` references a conversation that was never created

## Root Cause
When `claude -p` fails (e.g. auth error), it exits with code 0 and outputs `error_during_execution` in the result JSON. The session was marked `initialized=true` after any successful spawn, causing all subsequent messages to use `--resume` with a non-existent session ID.

Fixes #67

## Test Plan
- [x] `go test ./...` passes
- [ ] Verify: session with auth failure stays uninitialized, next message retries with `--session-id`
- [ ] Verify: error messages from failed executions appear in chat history after page refresh