### PR TITLE
feat: add 👍 Looks Good quick-send button

### DIFF
--- a/docs/superpowers/plans/2026-03-30-looks-good-button.md
+++ b/docs/superpowers/plans/2026-03-30-looks-good-button.md
@@ -1,0 +1,38 @@
+# 👍 Looks Good Button — Implementation Plan
+
+**Spec:** `docs/superpowers/specs/2026-03-30-looks-good-button-design.md`
+
+## Steps
+
+### 1. Add `sendLgtm()` method to app.js
+
+In the Alpine.js data object, add:
+
+```javascript
+sendLgtm() {
+    this.inputText = '👍 Looks Good To Me';
+    this.handleInput();
+}
+```
+
+### 2. Add button to index.html
+
+Inside `.instruction-bar`, before the shell toggle button, add:
+
+```html
+<button class="lgtm-btn"
+        @click="sendLgtm()"
+        :disabled="inputSending"
+        title="Send 👍 Looks Good To Me">👍</button>
+```
+
+### 3. Add CSS for `.lgtm-btn` in style.css
+
+Style to match `.shell-toggle-btn` dimensions but with emoji content. Place adjacent styles near the existing `.shell-toggle-btn` rules.
+
+### 4. Test both modes
+
+- Verify button appears in managed mode sessions
+- Verify button appears in hook mode sessions
+- Verify clicking sends the message immediately
+- Verify button is disabled during send

--- a/docs/superpowers/specs/2026-03-30-looks-good-button-design.md
+++ b/docs/superpowers/specs/2026-03-30-looks-good-button-design.md
@@ -1,0 +1,43 @@
+# 👍 Looks Good Button — Design Spec
+
+**Date:** 2026-03-30
+**Issue:** #71
+
+## Problem
+
+Users frequently type "👍 Looks Good To Me" to approve Claude's output and keep generation moving. This is repetitive. A one-click button would save time.
+
+## Design
+
+Add a 👍 button to the left of the shell toggle button in the chat input bar. Clicking it immediately sends "👍 Looks Good To Me" as a message — no typing or Enter required.
+
+### Behavior
+
+- **Managed mode:** Calls `sendManagedMessage()` with "👍 Looks Good To Me"
+- **Hook mode:** Calls `sendInstruction()` with "👍 Looks Good To Me"
+- Uses the existing `handleInput()` flow: sets `inputText`, then calls `handleInput()`
+- Disabled while `inputSending` is true (prevents double-sends)
+- Does not interfere with any text already in the textarea (overwrites it)
+
+### UI Placement
+
+Inside `.instruction-bar`, before the shell toggle button:
+
+```
+[👍] [$] [textarea...] [Send]
+```
+
+- Visible in both managed and hook modes (no `x-show` mode filter)
+- Styled similarly to `.shell-toggle-btn` but with emoji content instead of `$`
+
+### Files Changed
+
+1. `server/web/static/index.html` — Add button element
+2. `server/web/static/style.css` — Add `.lgtm-btn` styles
+3. `server/web/static/app.js` — Add `sendLgtm()` method
+
+### Out of Scope
+
+- Customizable message text
+- Multiple quick-action buttons
+- Keyboard shortcut for LGTM

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1007,6 +1007,11 @@ document.addEventListener('alpine:init', () => {
 
     // --- End slash commands ---
 
+    sendLgtm() {
+      this.inputText = '\u{1F44D} Looks Good To Me';
+      this.handleInput();
+    },
+
     async handleInput() {
       if (!this.selectedSessionId || !this.inputText.trim()) return;
       this.showSlashMenu = false;

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -269,6 +269,10 @@
 
             <!-- Input bar (managed mode messages OR hook-mode instructions) -->
             <div class="instruction-bar" x-show="selectedSessionId && !currentPendingPrompt" style="position:relative">
+              <button class="lgtm-btn"
+                      @click="sendLgtm()"
+                      :disabled="inputSending"
+                      title="Send 👍 Looks Good To Me">👍</button>
               <button class="shell-toggle-btn"
                       x-show="currentSession?.mode === 'managed'"
                       :class="{ active: shellMode }"

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1696,6 +1696,25 @@ body {
     font-size: 10px;
 }
 
+/* LGTM quick-send button */
+.lgtm-btn {
+  background: var(--bg-secondary, #f3f4f6);
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 1;
+}
+.lgtm-btn:hover {
+  background: var(--bg-tertiary, #e5e7eb);
+}
+.lgtm-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Shell mode toggle button */
 .shell-toggle-btn {
   background: var(--bg-secondary, #f3f4f6);


### PR DESCRIPTION
## Summary

- Adds a 👍 button to the left of the shell toggle in the chat input bar
- Clicking immediately sends "👍 Looks Good To Me" — no typing or Enter needed
- Works in both managed mode (sends as chat message) and hook mode (sends as instruction)

Closes #71

## Changes

- `server/web/static/index.html` — Added button element in `.instruction-bar`
- `server/web/static/app.js` — Added `sendLgtm()` method
- `server/web/static/style.css` — Added `.lgtm-btn` styles

## Test plan

- [ ] Open a managed mode session, click 👍 — verify message sends immediately
- [ ] Open a hook mode session, click 👍 — verify instruction sends immediately
- [ ] Verify button is disabled while a message is sending
- [ ] Verify button styling matches shell toggle button aesthetics