### PR TITLE
fix: compact reconnect during auto-continue (#81)

### DIFF
--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -409,26 +409,25 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			_, _ = s.store.CreateMessage(sessionID, "system",
 				fmt.Sprintf("Auto-continuing (%d/%d)...", continuationCount, sess.MaxContinuations))
 
-			// Compact step
+			// Compact step — spawn a separate one-shot `claude -p "/compact" --resume <id>`
+			// process. The warm process is already dead from the SIGINT, so we can't
+			// SendTurn to it. The one-shot process compacts the session context on disk,
+			// and the next --resume picks up the compacted context.
 			if sess.CompactEveryNContinues > 0 && continuationCount%sess.CompactEveryNContinues == 0 {
 				compactingMsg := fmt.Sprintf(`{"type":"compacting","continuation_count":%d}`, continuationCount)
 				broadcaster.Send(compactingMsg)
 				_, _ = s.store.CreateMessage(sessionID, "system", "Running /compact to reduce context size...")
 
-				compactTurn := formatUserTurn("/compact")
-				if err := s.manager.SendTurn(sessionID, compactTurn); err != nil {
-					log.Printf("session %s: compact send failed: %v", sessionID, err)
-					_, _ = s.store.CreateMessage(sessionID, "system", "Compact failed, continuing without it.")
+				resumeID := sess.ID
+				if sess.ClaudeSessionID != "" {
+					resumeID = sess.ClaudeSessionID
+				}
+				if err := s.manager.RunCompact(sessionID, resumeID, sess.CWD, 2*time.Minute); err != nil {
+					log.Printf("session %s: compact failed: %v", sessionID, err)
+					_, _ = s.store.CreateMessage(sessionID, "system", fmt.Sprintf("Compact failed: %v, continuing without it.", err))
 				} else {
-					select {
-					case <-turnDone:
-						log.Printf("session %s: compact completed", sessionID)
-						_, _ = s.store.CreateMessage(sessionID, "system", "Compact complete.")
-					case <-proc.Done:
-						log.Printf("session %s: process died during compact", sessionID)
-					case <-time.After(2 * time.Minute):
-						log.Printf("session %s: compact timed out", sessionID)
-					}
+					log.Printf("session %s: compact completed", sessionID)
+					_, _ = s.store.CreateMessage(sessionID, "system", "Compact complete.")
 				}
 				compactCompleteMsg := fmt.Sprintf(`{"type":"compact_complete","continuation_count":%d}`, continuationCount)
 				broadcaster.Send(compactCompleteMsg)

--- a/server/managed/manager.go
+++ b/server/managed/manager.go
@@ -343,6 +343,41 @@ func (m *Manager) Teardown(sessionID string, timeout time.Duration) error {
 	}
 }
 
+// RunCompact spawns a one-shot `claude -p "/compact" --resume <id>` process
+// and waits for it to exit. This is separate from the warm persistent process
+// so it can run after the warm process has been interrupted.
+func (m *Manager) RunCompact(sessionID string, resumeID string, cwd string, timeout time.Duration) error {
+	m.mu.Lock()
+	cfg := m.cfg
+	m.mu.Unlock()
+
+	args := append([]string{}, cfg.ClaudeArgs...)
+	args = append(args, "-p", "/compact", "--resume", resumeID, "--output-format", "stream-json", "--verbose")
+
+	cmd := exec.Command(cfg.ClaudeBin, args...)
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), cfg.ClaudeEnv...)
+	cmd.Env = append(cmd.Env, "CLAUDE_CONTROLLER_MANAGED=1")
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("compact start: %w", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		cmd.Process.Kill()
+		<-done
+		return fmt.Errorf("compact timed out after %v", timeout)
+	}
+}
+
 // GracefulShutdown closes stdin to let the process exit naturally, then waits
 // up to timeout for it to finish. Falls back to SIGKILL if it doesn't exit.
 // No-op if no process is running for the session.

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -37,6 +37,8 @@ document.addEventListener('alpine:init', () => {
     pendingPermission: null,
     newSessionCWD: '',
     sessionSSE: null,
+    sseReconnectAttempts: 0,
+    sseReconnectTimer: null,
 
     // Directory browser state
     browsePath: '',
@@ -1376,6 +1378,9 @@ document.addEventListener('alpine:init', () => {
         try {
           const data = JSON.parse(event.data);
 
+          // Any successful message means connection is alive — reset reconnect counter
+          this.sseReconnectAttempts = 0;
+
           // Heartbeat: just reset the timer and return
           if (data.type === 'heartbeat') {
             this.resetHeartbeatTimer();
@@ -1569,11 +1574,64 @@ document.addEventListener('alpine:init', () => {
       };
 
       this.sessionSSE.onerror = () => {
-        this.stopSessionSSE();
+        this.attemptSSEReconnect(sessionId);
       };
     },
 
+    attemptSSEReconnect(sessionId) {
+      // Close the broken connection
+      if (this.sessionSSE) {
+        this.sessionSSE.close();
+        this.sessionSSE = null;
+      }
+      this.clearHeartbeatTimer();
+
+      // Don't reconnect if we've switched sessions
+      if (sessionId !== this.selectedSessionId) return;
+
+      // Cap reconnect attempts
+      if (this.sseReconnectAttempts >= 10) {
+        this.addActivityPill('Connection lost — reconnect failed', 'disconnected');
+        this.sseReconnectAttempts = 0;
+        return;
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s... capped at 15s
+      const delay = Math.min(1000 * Math.pow(2, this.sseReconnectAttempts), 15000);
+      this.sseReconnectAttempts++;
+
+      this.sseReconnectTimer = setTimeout(async () => {
+        // Check if session is still working before reconnecting
+        try {
+          const resp = await fetch(`/api/sessions/${sessionId}`, {
+            headers: { 'Authorization': `Bearer ${this.apiKey}` }
+          });
+          if (!resp.ok) return;
+          const session = await resp.json();
+          if (session.activity_state !== 'working') {
+            // Session finished while we were disconnected — reload messages
+            this.sseReconnectAttempts = 0;
+            await this.fetchManagedMessages(sessionId);
+            return;
+          }
+        } catch (e) {
+          // Server unreachable, try again later
+          this.attemptSSEReconnect(sessionId);
+          return;
+        }
+
+        // Session still working — reconnect SSE
+        this.startSessionSSE(sessionId);
+      }, delay);
+    },
+
     stopSessionSSE() {
+      // Clear any pending reconnect
+      if (this.sseReconnectTimer) {
+        clearTimeout(this.sseReconnectTimer);
+        this.sseReconnectTimer = null;
+      }
+      this.sseReconnectAttempts = 0;
       if (this.sessionSSE) {
         this.sessionSSE.close();
         this.sessionSSE = null;
@@ -2259,8 +2317,12 @@ Please review this PR and provide feedback.`;
     resetHeartbeatTimer() {
         this.clearHeartbeatTimer();
         this.heartbeatTimer = setTimeout(() => {
-            this.addActivityPill('Connection lost — server may be down', 'disconnected');
+            this.addActivityPill('Connection lost — reconnecting...', 'disconnected');
             this.clearStalenessTimer();
+            // Trigger reconnect instead of just showing a message
+            if (this.selectedSessionId && this.sessionSSE) {
+                this.attemptSSEReconnect(this.selectedSessionId);
+            }
         }, 30000);
     },
 


### PR DESCRIPTION
## Summary

Fixes #81 — Server connection lost when auto-continuing with a compact.

**Root cause:** The compact step was trying to SendTurn to the warm persistent process, but that process was already dead from the SIGINT that triggered auto-continue. So compact always failed silently.

**Three fixes:**

- **One-shot compact process** (manager.RunCompact): Spawns a separate claude -p /compact --resume process that compacts the session context on disk and exits. The next --resume picks up the compacted context.

- **SSE auto-reconnect with backoff**: When the EventSource connection drops, checks session activity_state. If still working, reconnects with exponential backoff (1s, 2s, 4s... capped at 15s, max 10 attempts). If finished while disconnected, reloads messages instead.

- **Heartbeat timeout triggers reconnect**: The 30s heartbeat timeout now triggers the reconnect flow instead of just showing a static connection lost pill.

## Files changed

- server/managed/manager.go — New RunCompact() method
- server/api/managed_sessions.go — Compact block uses RunCompact instead of SendTurn
- server/web/static/app.js — SSE auto-reconnect with exponential backoff

## Test plan

- [ ] Create a managed session with compact_every_n_continues: 1
- [ ] Run a long task that triggers auto-continue
- [ ] Verify compact actually runs (check server logs for compact completed)
- [ ] Verify SSE reconnects after compact and continues showing output
- [ ] Verify heartbeat timeout triggers reconnect
- [ ] Verify switching sessions during reconnect does not cause stale reconnects
- [ ] Verify go test ./... passes