### PR TITLE
feat: remote server restart via API and web UI

### DIFF
--- a/docs/superpowers/plans/2026-04-01-clear-command-reset.md
+++ b/docs/superpowers/plans/2026-04-01-clear-command-reset.md
@@ -1,0 +1,387 @@
+# `/clear` Command Session Reset — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/clear` reset the managed session in-place so it starts a fresh Claude CLI conversation, persisting across page refresh.
+
+**Architecture:** Add a `ClearSession` DB method that deletes messages and resets session state in a transaction. Add a `POST /api/sessions/{id}/clear` endpoint that calls it after tearing down any warm process. Update the frontend `/clear` handler to call the API instead of just clearing the array.
+
+**Tech Stack:** Go (server), SQLite (DB), Alpine.js (frontend)
+
+---
+
+### Task 1: DB layer — `ClearSession` method
+
+**Files:**
+- Modify: `server/db/sessions.go` (after `ResumeSession` at line 150)
+- Test: `server/db/sessions_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `server/db/sessions_test.go`:
+
+```go
+func TestClearSession(t *testing.T) {
+	store := newTestStore(t)
+	sess, err := store.CreateManagedSession("/tmp/test-clear", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate some usage: add messages, set initialized, increment turns
+	store.CreateMessage(sess.ID, "user", "hello")
+	store.CreateMessage(sess.ID, "assistant", "hi there")
+	store.SetInitialized(sess.ID)
+	store.IncrementTurnCount(sess.ID)
+	store.IncrementTurnCount(sess.ID)
+	store.UpdateActivityState(sess.ID, "waiting")
+
+	oldSessionID := sess.ClaudeSessionID
+
+	// Clear the session
+	if err := store.ClearSession(sess.ID); err != nil {
+		t.Fatalf("ClearSession: %v", err)
+	}
+
+	// Verify messages deleted
+	msgs, err := store.ListMessages(sess.ID)
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages after clear, got %d", len(msgs))
+	}
+
+	// Verify session state reset
+	updated, err := store.GetSessionByID(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionByID: %v", err)
+	}
+	if updated.Initialized {
+		t.Error("expected initialized=false after clear")
+	}
+	if updated.TurnCount != 0 {
+		t.Errorf("expected turn_count=0, got %d", updated.TurnCount)
+	}
+	if updated.ActivityState != "idle" {
+		t.Errorf("expected activity_state='idle', got %q", updated.ActivityState)
+	}
+	if updated.ClaudeSessionID == oldSessionID {
+		t.Error("expected new claude_session_id after clear")
+	}
+	if updated.ClaudeSessionID == "" {
+		t.Error("expected non-empty claude_session_id after clear")
+	}
+
+	// Verify settings preserved
+	if updated.CWD != "/tmp/test-clear" {
+		t.Errorf("expected cwd preserved, got %q", updated.CWD)
+	}
+	if updated.AllowedTools != `["Bash"]` {
+		t.Errorf("expected allowed_tools preserved, got %q", updated.AllowedTools)
+	}
+	if updated.MaxTurns != 50 {
+		t.Errorf("expected max_turns preserved, got %d", updated.MaxTurns)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && go test ./db/ -v -run TestClearSession`
+Expected: FAIL — `store.ClearSession` does not exist.
+
+- [ ] **Step 3: Implement `ClearSession`**
+
+Add to `server/db/sessions.go` after the `ResumeSession` method (line 150):
+
+```go
+func (s *Store) ClearSession(id string) error {
+	newClaudeSessionID := uuid.New().String()
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin clear transaction: %w", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(`DELETE FROM messages WHERE session_id = ?`, id); err != nil {
+		return fmt.Errorf("delete messages: %w", err)
+	}
+	if _, err := tx.Exec(`UPDATE sessions SET claude_session_id = ?, initialized = 0, turn_count = 0, activity_state = 'idle' WHERE id = ?`, newClaudeSessionID, id); err != nil {
+		return fmt.Errorf("reset session state: %w", err)
+	}
+	return tx.Commit()
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd server && go test ./db/ -v -run TestClearSession`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/db/sessions.go server/db/sessions_test.go
+git commit -m "feat: add ClearSession DB method for /clear command"
+```
+
+---
+
+### Task 2: API handler — `POST /api/sessions/{id}/clear`
+
+**Files:**
+- Modify: `server/api/managed_sessions.go` (add `handleClearSession` method)
+- Modify: `server/api/router.go:60` (add route)
+- Test: `server/api/managed_sessions_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/api/managed_sessions_test.go`:
+
+```go
+func TestClearSessionAPI(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test-clear-api", `["Read"]`, 50, 5.0, 0)
+	store.CreateMessage(sess.ID, "user", "hello")
+	store.CreateMessage(sess.ID, "assistant", "hi")
+	store.SetInitialized(sess.ID)
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/clear", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+
+	// Verify messages cleared
+	msgs, _ := store.ListMessages(sess.ID)
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(msgs))
+	}
+
+	// Verify session reset
+	updated, _ := store.GetSessionByID(sess.ID)
+	if updated.Initialized {
+		t.Error("expected initialized=false")
+	}
+	if updated.TurnCount != 0 {
+		t.Errorf("expected turn_count=0, got %d", updated.TurnCount)
+	}
+}
+
+func TestClearSessionAPI_RejectsWorking(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test-clear-working", `["Read"]`, 50, 5.0, 0)
+	store.UpdateActivityState(sess.ID, "working")
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/clear", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 409 {
+		t.Fatalf("status=%d, want 409 for working session", resp.StatusCode)
+	}
+}
+
+func TestClearSessionAPI_NotFound(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/nonexistent/clear", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Fatalf("status=%d, want 404", resp.StatusCode)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server && go test ./api/ -v -run TestClearSession`
+Expected: FAIL — handler does not exist, route not registered.
+
+- [ ] **Step 3: Add the route**
+
+In `server/api/router.go`, add after line 60 (`POST /api/sessions/{id}/resume`):
+
+```go
+	apiMux.HandleFunc("POST /api/sessions/{id}/clear", s.handleClearSession)
+```
+
+- [ ] **Step 4: Implement the handler**
+
+Add to `server/api/managed_sessions.go`:
+
+```go
+func (s *Server) handleClearSession(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	if sess.Mode != "managed" {
+		http.Error(w, "not a managed session", http.StatusBadRequest)
+		return
+	}
+	if sess.ActivityState == "working" {
+		http.Error(w, "cannot clear while session is working", http.StatusConflict)
+		return
+	}
+
+	// Tear down any warm process so the old CLI session doesn't linger
+	s.manager.Teardown(sessionID, 5*time.Second)
+
+	if err := s.store.ClearSession(sessionID); err != nil {
+		log.Printf("clear session %s: %v", sessionID, err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd server && go test ./api/ -v -run TestClearSession`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 6: Run all server tests to check for regressions**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/api/managed_sessions.go server/api/router.go server/api/managed_sessions_test.go
+git commit -m "feat: add POST /api/sessions/{id}/clear endpoint"
+```
+
+---
+
+### Task 3: Frontend — wire `/clear` to the API
+
+**Files:**
+- Modify: `server/web/static/app.js` (lines 874-876, the `/clear` case in `executeSlashCommand`)
+
+- [ ] **Step 1: Update the `/clear` command handler**
+
+In `server/web/static/app.js`, replace the existing `/clear` case (lines 874-876):
+
+```javascript
+        case '/clear':
+          this.chatMessages = [];
+          break;
+```
+
+With:
+
+```javascript
+        case '/clear': {
+          try {
+            const resp = await fetch(`/api/sessions/${this.selectedSessionId}/clear`, {
+              method: 'POST',
+              headers: { 'Authorization': 'Bearer ' + this.apiKey },
+            });
+            if (!resp.ok) {
+              const errText = await resp.text();
+              this.chatMessages.push({ role: 'system', content: `Clear failed: ${errText}`, msg_type: 'text', timestamp: new Date().toISOString() });
+            } else {
+              this.chatMessages = [];
+            }
+          } catch (e) {
+            this.chatMessages.push({ role: 'system', content: `Clear failed: ${e.message}`, msg_type: 'text', timestamp: new Date().toISOString() });
+          }
+          break;
+        }
+```
+
+- [ ] **Step 2: Update the `/clear` command description**
+
+In `server/api/commands.go`, line 22, update the description:
+
+```go
+	{Name: "/clear", Description: "Clear chat and start fresh conversation", Source: "builtin"},
+```
+
+- [ ] **Step 3: Manual test**
+
+1. Start the server: `cd server && go run .`
+2. Open the web UI, select a managed session with some messages
+3. Type `/clear` — chat should clear
+4. Refresh the page — chat should remain empty (no old messages)
+5. Send a new message — should start a fresh Claude CLI session
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/web/static/app.js server/api/commands.go
+git commit -m "feat: wire /clear to session reset API for persistent clear"
+```
+
+---
+
+### Task 4: Create feature branch and draft PR
+
+- [ ] **Step 1: Create feature branch from current state**
+
+```bash
+git checkout -b feat/clear-session-reset main
+```
+
+Note: If all commits were already made on the current branch, cherry-pick or rebase them onto the feature branch instead.
+
+- [ ] **Step 2: Push and create draft PR**
+
+```bash
+git push -u origin feat/clear-session-reset
+gh pr create --draft --title "feat: /clear resets session for fresh conversation" --body "$(cat <<'EOF'
+## Summary
+
+Fixes #78. `/clear` now resets the managed session in-place:
+
+- Deletes all messages from the database
+- Generates a new Claude CLI session ID (next turn uses `--session-id` instead of `--resume`)
+- Resets `initialized`, `turn_count`, and `activity_state`
+- Tears down any warm CLI process
+- Settings (cwd, allowed_tools, max_turns, budget) are preserved
+
+Previously, `/clear` only cleared the frontend array — messages reloaded on page refresh and Claude retained full conversation context.
+
+## Test plan
+
+- [ ] `go test ./db/ -run TestClearSession` passes
+- [ ] `go test ./api/ -run TestClearSession` passes (3 sub-tests: success, rejects working, not found)
+- [ ] `go test ./...` — no regressions
+- [ ] Manual: run `/clear`, refresh page — chat stays empty
+- [ ] Manual: send message after `/clear` — new conversation (no prior context)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-04-02-remote-restart.md
+++ b/docs/superpowers/plans/2026-04-02-remote-restart.md
@@ -1,0 +1,552 @@
+# Remote Server Restart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `POST /api/restart` endpoint that gracefully shuts down all managed sessions and re-execs the server binary, with a restart button in the settings modal.
+
+**Architecture:** New `restart.go` handler receives the restart request, orchestrates graceful shutdown (manager → scheduler → listener → DB), then calls `syscall.Exec` to replace the process. The frontend adds a restart button in the settings modal's new "Actions" section and handles reconnection via polling.
+
+**Tech Stack:** Go (net/http, syscall), Alpine.js, inline CSS
+
+---
+
+### Task 1: Add `ShutdownAll` to Manager
+
+**Files:**
+- Modify: `server/managed/manager.go:400-420` (after `GracefulShutdown`)
+- Test: `server/managed/manager_test.go` (create if needed)
+
+- [ ] **Step 1: Write the test for ShutdownAll**
+
+Create `server/managed/manager_test.go`:
+
+```go
+package managed
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShutdownAll_NoProcesses(t *testing.T) {
+	mgr := NewManager(Config{})
+	mgr.ShutdownAll(5 * time.Second)
+	// Should not panic or hang
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && go test ./managed/ -v -run TestShutdownAll`
+Expected: FAIL — `ShutdownAll` not defined
+
+- [ ] **Step 3: Implement ShutdownAll**
+
+Add to the end of `server/managed/manager.go`:
+
+```go
+// ShutdownAll gracefully shuts down all running processes.
+// Closes stdin and waits up to timeout for each to exit, then kills.
+func (m *Manager) ShutdownAll(timeout time.Duration) {
+	m.mu.Lock()
+	ids := make([]string, 0, len(m.procs))
+	for id := range m.procs {
+		ids = append(ids, id)
+	}
+	m.mu.Unlock()
+
+	for _, id := range ids {
+		log.Printf("shutting down process for session %s", id)
+		m.GracefulShutdown(id, timeout)
+	}
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd server && go test ./managed/ -v -run TestShutdownAll`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/managed/manager.go server/managed/manager_test.go
+git commit -m "feat: add ShutdownAll to managed session manager"
+```
+
+---
+
+### Task 2: Add shutdown dependencies to Server struct
+
+**Files:**
+- Modify: `server/api/router.go:11-19` (Server struct and NewRouter)
+- Modify: `server/main.go:97` (pass new deps)
+
+- [ ] **Step 1: Add ShutdownFunc field to Server struct**
+
+In `server/api/router.go`, change the `Server` struct:
+
+```go
+type Server struct {
+	store        *db.Store
+	manager      *managed.Manager
+	envPath      string
+	permissions  *PermissionManager
+	shutdownFunc func() // called to trigger server restart
+}
+```
+
+- [ ] **Step 2: Update NewRouter to accept shutdownFunc**
+
+Change the `NewRouter` signature and constructor:
+
+```go
+func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string, shutdownFunc func()) http.Handler {
+	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc}
+```
+
+- [ ] **Step 3: Update main.go to pass shutdownFunc**
+
+In `server/main.go`, replace the current router creation and shutdown handling. First, create a channel and shutdown function before `NewRouter`:
+
+```go
+restartCh := make(chan struct{}, 1)
+shutdownFunc := func() {
+	select {
+	case restartCh <- struct{}{}:
+	default:
+	}
+}
+
+router := api.NewRouter(store, apiKey, mgr, envPath, shutdownFunc)
+```
+
+Then replace the signal handling block (lines 139-145) with:
+
+```go
+// Handle shutdown via signal or restart request
+sigCh := make(chan os.Signal, 1)
+signal.Notify(sigCh, os.Interrupt)
+
+restartRequested := false
+select {
+case <-sigCh:
+	fmt.Println("\nShutting down...")
+case <-restartCh:
+	fmt.Println("\nRestarting server...")
+	restartRequested = true
+}
+
+// Graceful shutdown sequence
+mgr.ShutdownAll(5 * time.Second)
+sched.Stop()
+cancel()
+localListener.Close()
+store.Close()
+
+if restartRequested {
+	exe, err := os.Executable()
+	if err != nil {
+		log.Printf("Failed to find executable path: %v", err)
+		os.Exit(0)
+	}
+	log.Printf("Re-execing %s %v", exe, os.Args)
+	execErr := syscall.Exec(exe, os.Args, os.Environ())
+	if execErr != nil {
+		log.Printf("syscall.Exec failed: %v — exiting for wrapper to restart", execErr)
+		os.Exit(0)
+	}
+}
+```
+
+Add `"syscall"` to the imports in main.go.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd server && go build -o /dev/null .`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/api/router.go server/main.go
+git commit -m "feat: wire shutdown dependencies through Server struct for restart"
+```
+
+---
+
+### Task 3: Add `POST /api/restart` handler
+
+**Files:**
+- Create: `server/api/restart.go`
+- Modify: `server/api/router.go` (add route)
+- Test: `server/api/restart_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Create `server/api/restart_test.go`:
+
+```go
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestHandleRestart_Success(t *testing.T) {
+	var called atomic.Bool
+	s := &Server{
+		shutdownFunc: func() { called.Store(true) },
+	}
+
+	req := httptest.NewRequest("POST", "/api/restart", nil)
+	w := httptest.NewRecorder()
+	s.handleRestart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !called.Load() {
+		t.Fatal("expected shutdownFunc to be called")
+	}
+}
+
+func TestHandleRestart_ConcurrentBlocked(t *testing.T) {
+	s := &Server{
+		shutdownFunc: func() {},
+	}
+	s.restartInProgress.Store(true)
+
+	req := httptest.NewRequest("POST", "/api/restart", nil)
+	w := httptest.NewRecorder()
+	s.handleRestart(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd server && go test ./api/ -v -run TestHandleRestart`
+Expected: FAIL — `handleRestart` and `restartInProgress` not defined
+
+- [ ] **Step 3: Add restartInProgress to Server struct**
+
+In `server/api/router.go`, add to imports:
+
+```go
+"sync/atomic"
+```
+
+Update the Server struct:
+
+```go
+type Server struct {
+	store             *db.Store
+	manager           *managed.Manager
+	envPath           string
+	permissions       *PermissionManager
+	shutdownFunc      func()
+	restartInProgress atomic.Bool
+}
+```
+
+- [ ] **Step 4: Create the restart handler**
+
+Create `server/api/restart.go`:
+
+```go
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
+	if !s.restartInProgress.CompareAndSwap(false, true) {
+		http.Error(w, "restart already in progress", http.StatusConflict)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "restarting"})
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		s.shutdownFunc()
+	}()
+}
+```
+
+- [ ] **Step 5: Add route to router**
+
+In `server/api/router.go`, add after the settings endpoints (after line 85):
+
+```go
+// Server management
+apiMux.HandleFunc("POST /api/restart", s.handleRestart)
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd server && go test ./api/ -v -run TestHandleRestart`
+Expected: PASS (both tests)
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/api/restart.go server/api/restart_test.go server/api/router.go
+git commit -m "feat: add POST /api/restart endpoint with concurrent-request guard"
+```
+
+---
+
+### Task 4: Update activity states on restart
+
+**Files:**
+- Modify: `server/api/restart.go` (add DB update before shutdown)
+- Modify: `server/api/restart_test.go` (test with mock store)
+
+- [ ] **Step 1: Write the test**
+
+Add to `server/api/restart_test.go`:
+
+```go
+func TestHandleRestart_SetsActivityStatesToWaiting(t *testing.T) {
+	store := setupTestDB(t)
+	defer store.Close()
+
+	// Create a managed session with working state
+	store.RegisterSession("sess1", "host", "/tmp", "managed")
+	store.UpdateActivityState("sess1", "working")
+
+	var called atomic.Bool
+	s := &Server{
+		store:        store,
+		shutdownFunc: func() { called.Store(true) },
+	}
+
+	req := httptest.NewRequest("POST", "/api/restart", nil)
+	w := httptest.NewRecorder()
+	s.handleRestart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Give the goroutine time to execute
+	time.Sleep(100 * time.Millisecond)
+
+	// Check that activity state was set to waiting
+	sess, _ := store.GetSession("sess1")
+	if sess.ActivityState != "waiting" {
+		t.Fatalf("expected activity_state 'waiting', got '%s'", sess.ActivityState)
+	}
+}
+```
+
+Note: Check if `setupTestDB` already exists in the test package. If so, use it. If not, create a helper:
+
+```go
+func setupTestDB(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./api/ -v -run TestHandleRestart_SetsActivityStates`
+Expected: FAIL — activity state not being set
+
+- [ ] **Step 3: Add SetWorkingToWaiting DB method**
+
+Check if a method like this exists in `server/db/sessions.go`. If not, add:
+
+```go
+// SetWorkingToWaiting updates all sessions with activity_state='working' to 'waiting'.
+// Used during graceful restart to preserve conversation continuity.
+func (s *Store) SetWorkingToWaiting() error {
+	_, err := s.db.Exec("UPDATE sessions SET activity_state = 'waiting' WHERE activity_state = 'working'")
+	return err
+}
+```
+
+- [ ] **Step 4: Update restart handler to set activity states**
+
+In `server/api/restart.go`, update the goroutine:
+
+```go
+go func() {
+	time.Sleep(500 * time.Millisecond)
+	if s.store != nil {
+		s.store.SetWorkingToWaiting()
+	}
+	s.shutdownFunc()
+}()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd server && go test ./api/ -v -run TestHandleRestart`
+Expected: PASS (all three tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/api/restart.go server/api/restart_test.go server/db/sessions.go
+git commit -m "feat: set working sessions to waiting state before restart"
+```
+
+---
+
+### Task 5: Add restart button to settings modal
+
+**Files:**
+- Modify: `server/web/static/index.html:1130-1141` (settings modal, before closing div)
+- Modify: `server/web/static/app.js` (add `restartServer` method and `serverRestarting` state)
+
+- [ ] **Step 1: Add Actions section to settings modal HTML**
+
+In `server/web/static/index.html`, insert the Actions section between the error message and the button row. Replace lines 1132-1140 with:
+
+```html
+      <p class="error-msg" x-show="settingsError" x-text="settingsError" style="margin-top:8px;"></p>
+
+      <!-- Actions -->
+      <div x-show="!settingsFirstRun" style="margin-top:20px; padding-top:16px; border-top:1px solid var(--border);">
+        <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:8px;">ACTIONS</label>
+        <button class="btn btn-sm" @click="restartServer()" :disabled="serverRestarting"
+                style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer; font-size:13px;">
+          <span x-show="!serverRestarting">Restart Server</span>
+          <span x-show="serverRestarting">Restarting...</span>
+        </button>
+        <div style="font-size:11px; color:var(--text-muted); margin-top:4px;">Gracefully restarts the server, preserving all session state</div>
+      </div>
+
+      <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:16px;">
+        <button class="btn btn-sm" @click="showSettingsModal = false; settingsFirstRun = false;" x-text="settingsFirstRun ? 'Skip' : 'Cancel'"></button>
+        <button class="btn btn-sm btn-primary" @click="saveSettings()" :disabled="settingsSaving">
+          <span x-show="!settingsSaving" x-text="settingsFirstRun ? 'Save & Continue' : 'Save'"></span>
+          <span x-show="settingsSaving">Saving...</span>
+        </button>
+      </div>
+```
+
+- [ ] **Step 2: Add state and method to app.js**
+
+Find the Alpine.js data initialization (look for `return {` at the top of the app data function). Add `serverRestarting: false` to the state.
+
+Then add the `restartServer` method near the settings-related methods:
+
+```javascript
+async restartServer() {
+  if (!confirm('Restart the server? All sessions will be briefly disconnected.')) return;
+  this.serverRestarting = true;
+  try {
+    const resp = await fetch('/api/restart', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${this.apiKey}` }
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      this.toast(text || 'Restart failed', 4000, 'error');
+      this.serverRestarting = false;
+      return;
+    }
+    this.showSettingsModal = false;
+    this.toast('Server restarting...', 10000, 'info');
+    // Poll until server is back
+    this.pollForRestart();
+  } catch (e) {
+    // Network error likely means server already shutting down — start polling
+    this.showSettingsModal = false;
+    this.toast('Server restarting...', 10000, 'info');
+    this.pollForRestart();
+  }
+},
+
+pollForRestart() {
+  let attempts = 0;
+  const maxAttempts = 30;
+  const poll = setInterval(async () => {
+    attempts++;
+    try {
+      const resp = await fetch(`/api/events?token=${encodeURIComponent(this.apiKey)}`);
+      if (resp.ok) {
+        clearInterval(poll);
+        this.serverRestarting = false;
+        this.toast('Server restarted successfully', 3000, 'info');
+        // Reconnect SSE streams
+        this.startSSE();
+        if (this.selectedSessionId) {
+          this.startSessionSSE(this.selectedSessionId);
+        }
+      }
+    } catch (e) {
+      // Server still down, keep polling
+    }
+    if (attempts >= maxAttempts) {
+      clearInterval(poll);
+      this.serverRestarting = false;
+      this.toast('Could not reconnect to server', 5000, 'error');
+    }
+  }, 1000);
+},
+```
+
+- [ ] **Step 3: Verify the server builds cleanly**
+
+Run: `cd server && go build -o /dev/null .`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/web/static/index.html server/web/static/app.js
+git commit -m "feat: add restart button to settings modal with auto-reconnect"
+```
+
+---
+
+### Task 6: End-to-end verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass
+
+- [ ] **Step 2: Build the server**
+
+Run: `cd server && go build -o claude-controller .`
+Expected: Build succeeds, binary produced
+
+- [ ] **Step 3: Clean up build artifact**
+
+Run: `rm server/claude-controller`
+
+- [ ] **Step 4: Commit any remaining changes**
+
+Only if there are fixups needed from the test run.

--- a/docs/superpowers/specs/2026-04-02-remote-restart-design.md
+++ b/docs/superpowers/specs/2026-04-02-remote-restart-design.md
@@ -1,0 +1,111 @@
+# Remote Server Restart — Design Spec
+
+## Problem
+
+When the Go server gets into a bad state (stuck sessions, errors), the only way to restart it is physically at the machine. Users controlling sessions from a phone via the web UI have no way to bounce the server remotely.
+
+The most common symptom is the "Error: session is currently processing" message, which occurs when `activity_state='working'` but the underlying process is stuck or the state is stale.
+
+## Solution
+
+A `POST /api/restart` endpoint that triggers graceful shutdown of all managed sessions, then self-re-execs the binary. The frontend provides a restart button and handles reconnection automatically.
+
+## API
+
+### `POST /api/restart`
+
+Authenticated endpoint (same Bearer token auth as all API routes).
+
+**Response:** `200 {"status": "restarting"}`
+
+The 200 is sent and flushed before shutdown begins (with a ~500ms delay) so the client receives confirmation.
+
+**Error responses:**
+- `409 Conflict` — restart already in progress
+- `401 Unauthorized` — missing/invalid auth token
+
+## Shutdown Sequence
+
+1. **Set restart flag** — prevents concurrent restart requests (atomic bool)
+2. **Send 200 response** — confirm to client, flush, wait ~500ms
+3. **Stop scheduler** — `sched.Stop()` to prevent new task execution
+4. **Graceful shutdown of managed sessions:**
+   - For each session with a running process: close stdin, wait up to 5s for exit, SIGKILL if timeout
+   - Set all `working` activity states to `waiting` in the database (not `idle` — preserves conversation continuity so users can re-send their last message)
+5. **Close HTTP listener** — stop accepting new connections
+6. **Close database** — flush WAL, close connection
+7. **Self-re-exec** — `syscall.Exec(os.Args[0], os.Args, os.Environ())`
+8. **Fallback** — if re-exec fails, `os.Exit(0)` for wrapper script / process supervisor to handle
+
+## Self-Re-Exec
+
+Uses `syscall.Exec` to replace the current process with a fresh instance of the same binary, preserving the original command-line arguments and environment. This is an in-place replacement (same PID on Unix).
+
+If `syscall.Exec` fails (e.g., binary was deleted, permission issue), falls back to `os.Exit(0)`. A wrapper script like:
+
+```bash
+#!/bin/bash
+while true; do
+    ./claude-controller "$@"
+    echo "Server exited, restarting in 1s..."
+    sleep 1
+done
+```
+
+can catch this and restart the process.
+
+## Frontend Changes
+
+### Restart Button
+
+Add a restart button to the web UI settings/header area. Simple icon button with confirmation.
+
+### Restart Flow
+
+1. User clicks restart button
+2. Frontend sends `POST /api/restart`
+3. On 200 response: show "Server restarting..." banner/toast
+4. SSE connections will drop — this is expected
+5. Frontend polls `GET /api/events` every 1s until it responds
+6. On successful response: dismiss banner, reconnect SSE streams
+7. Optional: full page reload if SSE reconnect doesn't recover cleanly
+
+### SSE Reconnection
+
+The existing SSE streams (`/api/events` and `/api/sessions/{id}/stream`) already have reconnect logic with exponential backoff. The restart banner provides visual feedback during the reconnect window.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `server/api/restart.go` | New file: restart handler with shutdown orchestration |
+| `server/api/router.go` | Add `POST /api/restart` route |
+| `server/api/server.go` | Add shutdown dependencies (listener, DB closer, scheduler) to Server struct |
+| `server/managed/manager.go` | Add `ShutdownAll()` method to gracefully stop all processes |
+| `server/main.go` | Pass shutdown dependencies to API server; refactor signal handling |
+| `server/web/static/app.js` | Restart button, restart banner, reconnect polling |
+| `server/web/static/index.html` | Restart button markup (if not purely JS-driven) |
+
+## Edge Cases
+
+### Restart during active processing
+Graceful shutdown sends SIGINT to running Claude processes, waits up to 5s, then kills. Activity states are set to `waiting` so the user can re-send their message after restart.
+
+### Re-exec fails
+Falls back to `os.Exit(0)`. If no wrapper script is running, user needs to manually restart — same as today. The frontend will show "Server restarting..." and eventually timeout with a "Could not reconnect" message.
+
+### Concurrent restart requests
+First request wins. Subsequent requests receive `409 Conflict` while restart is in progress.
+
+### Binary changed on disk
+If the binary has been rebuilt before restart is triggered, `syscall.Exec` will load the new binary. This is a feature — it means code changes can be picked up via restart even though the primary use case is bouncing bad state.
+
+### Scheduler running tasks
+`sched.Stop()` signals the scheduler to stop. If a task is currently executing, the shutdown proceeds without waiting for it to complete — the task's context will be cancelled, and it can be retried after restart via the existing `ReconcileMissed()` call on startup.
+
+## Out of Scope
+
+- Rebuilding the Go binary remotely (code changes + `go build`)
+- Rolling restarts or zero-downtime restart
+- Automatic restart on crash detection
+- Health check endpoint (could be added separately)

--- a/docs/superpowers/specs/2026-04-02-remote-restart-design.md
+++ b/docs/superpowers/specs/2026-04-02-remote-restart-design.md
@@ -58,7 +58,7 @@ can catch this and restart the process.
 
 ### Restart Button
 
-Add a restart button to the web UI settings/header area. Simple icon button with confirmation.
+Add an "Actions" section to the bottom of the settings modal, near the save button. This section contains a "Restart Server" button with a confirmation prompt ("Are you sure? This will restart the server and briefly disconnect all sessions.").
 
 ### Restart Flow
 

--- a/server/api/files_test.go
+++ b/server/api/files_test.go
@@ -20,7 +20,7 @@ func TestHandleGetFileRaw(t *testing.T) {
 	defer store.Close()
 
 	envPath := filepath.Join(dir, ".env")
-	router := NewRouter(store, "test-key", nil, envPath)
+	router := NewRouter(store, "test-key", nil, envPath, nil)
 
 	// Create a managed session with CWD set to dir
 	sess, err := store.CreateManagedSession(dir, "", 0, 0, 0)

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -27,7 +27,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *db.Store) {
 		ClaudeEnv:  []string{},
 	}
 	mgr := managed.NewManager(cfg)
-	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"))
+	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil)
 	ts := httptest.NewServer(router)
 	return ts, store
 }

--- a/server/api/restart.go
+++ b/server/api/restart.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
+	if !s.restartInProgress.CompareAndSwap(false, true) {
+		http.Error(w, "restart already in progress", http.StatusConflict)
+		return
+	}
+
+	// Set working sessions to waiting before shutdown
+	if s.store != nil {
+		s.store.SetWorkingToWaiting()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "restarting"})
+
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		s.shutdownFunc()
+	}()
+}

--- a/server/api/restart_test.go
+++ b/server/api/restart_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jaychinthrajah/claude-controller/server/db"
+)
+
+func TestHandleRestart_Success(t *testing.T) {
+	var called atomic.Bool
+	s := &Server{
+		shutdownFunc: func() { called.Store(true) },
+	}
+
+	req := httptest.NewRequest("POST", "/api/restart", nil)
+	w := httptest.NewRecorder()
+	s.handleRestart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Give goroutine time to call shutdownFunc
+	time.Sleep(600 * time.Millisecond)
+	if !called.Load() {
+		t.Fatal("expected shutdownFunc to be called")
+	}
+}
+
+func TestHandleRestart_ConcurrentBlocked(t *testing.T) {
+	s := &Server{
+		shutdownFunc: func() {},
+	}
+	s.restartInProgress.Store(true)
+
+	req := httptest.NewRequest("POST", "/api/restart", nil)
+	w := httptest.NewRecorder()
+	s.handleRestart(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestHandleRestart_SetsActivityStatesToWaiting(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// Create a managed session with working state
+	sess, err := store.CreateManagedSession("/tmp", "", 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.UpdateActivityState(sess.ID, "working")
+
+	var called atomic.Bool
+	s := &Server{
+		store:        store,
+		shutdownFunc: func() { called.Store(true) },
+	}
+
+	req := httptest.NewRequest("POST", "/api/restart", nil)
+	w := httptest.NewRecorder()
+	s.handleRestart(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Activity state update happens synchronously before response
+	updated, err := store.GetSessionByID(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.ActivityState != "waiting" {
+		t.Fatalf("expected activity_state 'waiting', got '%s'", updated.ActivityState)
+	}
+}

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"sync/atomic"
 
 	"github.com/jaychinthrajah/claude-controller/server/db"
 	"github.com/jaychinthrajah/claude-controller/server/managed"
@@ -9,11 +10,12 @@ import (
 )
 
 type Server struct {
-	store        *db.Store
-	manager      *managed.Manager
-	envPath      string
-	permissions  *PermissionManager
-	shutdownFunc func() // called to trigger server restart
+	store             *db.Store
+	manager           *managed.Manager
+	envPath           string
+	permissions       *PermissionManager
+	shutdownFunc      func() // called to trigger server restart
+	restartInProgress atomic.Bool
 }
 
 func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string, shutdownFunc func()) http.Handler {
@@ -84,6 +86,9 @@ func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath str
 	apiMux.HandleFunc("GET /api/settings/exists", s.handleSettingsExists)
 	apiMux.HandleFunc("GET /api/settings", s.handleGetSettings)
 	apiMux.HandleFunc("PUT /api/settings", s.handlePutSettings)
+
+	// Server management
+	apiMux.HandleFunc("POST /api/restart", s.handleRestart)
 
 	// Scheduled task endpoints
 	apiMux.HandleFunc("POST /api/tasks", s.handleCreateTask)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -9,14 +9,15 @@ import (
 )
 
 type Server struct {
-	store       *db.Store
-	manager     *managed.Manager
-	envPath     string
-	permissions *PermissionManager
+	store        *db.Store
+	manager      *managed.Manager
+	envPath      string
+	permissions  *PermissionManager
+	shutdownFunc func() // called to trigger server restart
 }
 
-func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string) http.Handler {
-	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager()}
+func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string, shutdownFunc func()) http.Handler {
+	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc}
 
 	// API mux — all existing endpoints, behind auth middleware
 	apiMux := http.NewServeMux()

--- a/server/api/sessions_test.go
+++ b/server/api/sessions_test.go
@@ -19,7 +19,7 @@ func newTestServer(t *testing.T) (*httptest.Server, *db.Store) {
 	}
 	t.Cleanup(func() { store.Close() })
 
-	router := NewRouter(store, "test-key", nil, filepath.Join(t.TempDir(), ".env"))
+	router := NewRouter(store, "test-key", nil, filepath.Join(t.TempDir(), ".env"), nil)
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, store

--- a/server/api/settings_test.go
+++ b/server/api/settings_test.go
@@ -24,7 +24,7 @@ func newTestServerWithManager(t *testing.T) (*httptest.Server, *db.Store, *manag
 
 	mgr := managed.NewManager(managed.Config{ClaudeBin: "claude"})
 	envPath := filepath.Join(tmpDir, ".env")
-	router := NewRouter(store, "test-key", mgr, envPath)
+	router := NewRouter(store, "test-key", mgr, envPath, nil)
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, store, mgr, envPath

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -225,6 +225,13 @@ func (s *Store) ResetStaleActivityStates() error {
 	return err
 }
 
+// SetWorkingToWaiting updates all sessions with activity_state='working' to 'waiting'.
+// Used during graceful restart to preserve conversation continuity.
+func (s *Store) SetWorkingToWaiting() error {
+	_, err := s.db.Exec("UPDATE sessions SET activity_state = 'waiting' WHERE activity_state = 'working'")
+	return err
+}
+
 func (s *Store) IncrementTurnCount(id string) (int, error) {
 	var count int
 	err := s.db.QueryRow(

--- a/server/main.go
+++ b/server/main.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	qrcode "github.com/skip2/go-qrcode"
 
@@ -68,7 +70,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to open database: %v", err)
 	}
-	defer store.Close()
 
 	if err := store.ResetStaleActivityStates(); err != nil {
 		log.Printf("Warning: failed to reset stale activity states: %v", err)
@@ -77,7 +78,6 @@ func main() {
 	sched := scheduler.New(store)
 	sched.Reconcile()
 	sched.Start()
-	defer sched.Stop()
 
 	apiKey := loadOrCreateAPIKey(*dbPath)
 
@@ -94,7 +94,15 @@ func main() {
 	mgr := managed.NewManager(managedCfg)
 	mgr.StartReaper()
 
-	router := api.NewRouter(store, apiKey, mgr, envPath)
+	restartCh := make(chan struct{}, 1)
+	shutdownFunc := func() {
+		select {
+		case restartCh <- struct{}{}:
+		default:
+		}
+	}
+
+	router := api.NewRouter(store, apiKey, mgr, envPath, shutdownFunc)
 
 	// Start local server
 	bindHost := "localhost"
@@ -115,7 +123,6 @@ func main() {
 
 	// Start ngrok tunnel (may block if no auth token)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	tun, err := tunnel.Start(ctx)
 	if err != nil {
@@ -136,13 +143,39 @@ func main() {
 		go http.Serve(tun.Listener(), router)
 	}
 
-	// Handle shutdown
+	// Handle shutdown via signal or restart request
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
-	<-sigCh
-	fmt.Println("\nShutting down...")
+
+	restartRequested := false
+	select {
+	case <-sigCh:
+		fmt.Println("\nShutting down...")
+	case <-restartCh:
+		fmt.Println("\nRestarting server...")
+		restartRequested = true
+	}
+
+	// Graceful shutdown sequence
+	mgr.ShutdownAll(5 * time.Second)
+	sched.Stop()
 	cancel()
 	localListener.Close()
+	store.Close()
+
+	if restartRequested {
+		exe, err := os.Executable()
+		if err != nil {
+			log.Printf("Failed to find executable path: %v", err)
+			os.Exit(0)
+		}
+		log.Printf("Re-execing %s %v", exe, os.Args)
+		execErr := syscall.Exec(exe, os.Args, os.Environ())
+		if execErr != nil {
+			log.Printf("syscall.Exec failed: %v — exiting for wrapper to restart", execErr)
+			os.Exit(0)
+		}
+	}
 }
 
 func findAvailablePort(preferred int) int {

--- a/server/managed/manager.go
+++ b/server/managed/manager.go
@@ -394,6 +394,22 @@ func (m *Manager) RunCompact(sessionID string, resumeID string, cwd string, time
 	}
 }
 
+// ShutdownAll gracefully shuts down all running processes.
+// Closes stdin and waits up to timeout for each to exit, then kills.
+func (m *Manager) ShutdownAll(timeout time.Duration) {
+	m.mu.Lock()
+	ids := make([]string, 0, len(m.procs))
+	for id := range m.procs {
+		ids = append(ids, id)
+	}
+	m.mu.Unlock()
+
+	for _, id := range ids {
+		log.Printf("shutting down process for session %s", id)
+		m.GracefulShutdown(id, timeout)
+	}
+}
+
 // GracefulShutdown closes stdin to let the process exit naturally, then waits
 // up to timeout for it to finish. Falls back to SIGKILL if it doesn't exit.
 // No-op if no process is running for the session.

--- a/server/managed/manager_test.go
+++ b/server/managed/manager_test.go
@@ -322,6 +322,12 @@ func TestGracefulShutdownNoProcess(t *testing.T) {
 	}
 }
 
+func TestShutdownAll_NoProcesses(t *testing.T) {
+	mgr := NewManager(Config{})
+	mgr.ShutdownAll(5 * time.Second)
+	// Should not panic or hang
+}
+
 func TestUpdateConfig(t *testing.T) {
 	mgr := NewManager(Config{ClaudeBin: "old-bin", ClaudeArgs: []string{"--old"}, ClaudeEnv: []string{"OLD=1"}})
 

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -125,6 +125,7 @@ document.addEventListener('alpine:init', () => {
     settingsError: '',
     settingsSaving: false,
     settingsRestartRequired: false,
+    serverRestarting: false,
 
     // Usage tracking
     lastTurnThreshold: 0,
@@ -506,6 +507,57 @@ document.addEventListener('alpine:init', () => {
         this.settingsError = 'Error: ' + e.message;
       }
       this.settingsSaving = false;
+    },
+
+    async restartServer() {
+      if (!confirm('Restart the server? All sessions will be briefly disconnected.')) return;
+      this.serverRestarting = true;
+      try {
+        const resp = await fetch('/api/restart', {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${this.apiKey}` }
+        });
+        if (!resp.ok) {
+          const text = await resp.text();
+          this.toast(text || 'Restart failed', 4000, 'error');
+          this.serverRestarting = false;
+          return;
+        }
+        this.showSettingsModal = false;
+        this.toast('Server restarting...', 10000, 'info');
+        this.pollForRestart();
+      } catch (e) {
+        this.showSettingsModal = false;
+        this.toast('Server restarting...', 10000, 'info');
+        this.pollForRestart();
+      }
+    },
+
+    pollForRestart() {
+      let attempts = 0;
+      const maxAttempts = 30;
+      const poll = setInterval(async () => {
+        attempts++;
+        try {
+          const resp = await fetch(`/api/events?token=${encodeURIComponent(this.apiKey)}`);
+          if (resp.ok) {
+            clearInterval(poll);
+            this.serverRestarting = false;
+            this.toast('Server restarted successfully', 3000, 'info');
+            this.startSSE();
+            if (this.selectedSessionId) {
+              this.startSessionSSE(this.selectedSessionId);
+            }
+          }
+        } catch (e) {
+          // Server still down, keep polling
+        }
+        if (attempts >= maxAttempts) {
+          clearInterval(poll);
+          this.serverRestarting = false;
+          this.toast('Could not reconnect to server', 5000, 'error');
+        }
+      }, 1000);
     },
 
     // Browser notifications

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1131,6 +1131,17 @@
 
       <p class="error-msg" x-show="settingsError" x-text="settingsError" style="margin-top:8px;"></p>
 
+      <!-- Actions -->
+      <div x-show="!settingsFirstRun" style="margin-top:20px; padding-top:16px; border-top:1px solid var(--border);">
+        <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:8px;">ACTIONS</label>
+        <button class="btn btn-sm" @click="restartServer()" :disabled="serverRestarting"
+                style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer; font-size:13px;">
+          <span x-show="!serverRestarting">Restart Server</span>
+          <span x-show="serverRestarting">Restarting...</span>
+        </button>
+        <div style="font-size:11px; color:var(--text-muted); margin-top:4px;">Gracefully restarts the server, preserving all session state</div>
+      </div>
+
       <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:16px;">
         <button class="btn btn-sm" @click="showSettingsModal = false; settingsFirstRun = false;" x-text="settingsFirstRun ? 'Skip' : 'Cancel'"></button>
         <button class="btn btn-sm btn-primary" @click="saveSettings()" :disabled="settingsSaving">


### PR DESCRIPTION
Closes #87

## Summary
- Adds `POST /api/restart` endpoint with atomic concurrent-request guard (`CompareAndSwap`)
- Graceful shutdown sequence: sets working sessions to "waiting" state (preserving conversation continuity), shuts down all managed processes, stops scheduler, closes listener/DB, then `syscall.Exec` re-execs the binary (with `os.Exit(0)` fallback for wrapper scripts)
- Adds "Actions" section in settings modal with a red "Restart Server" button
- Frontend auto-reconnects SSE after restart via polling

## Test Plan
- [x] `TestHandleRestart_Success` — verifies 200 response and shutdownFunc called
- [x] `TestHandleRestart_ConcurrentBlocked` — verifies 409 when restart already in progress
- [x] `TestHandleRestart_SetsActivityStatesToWaiting` — verifies working sessions transition to waiting
- [x] Full test suite passes (`go test ./...`)
- [ ] Manual: click restart button in settings modal, verify server restarts and UI reconnects