### PR TITLE
fix: SSE reconnect survives compact and auto-continue gaps

### DIFF
--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -407,6 +407,11 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				turnDone = make(chan struct{}, 4)
 				streamDone = make(chan struct{})
 
+				// Send heartbeat to keep SSE clients alive during the gap between
+				// the old process dying and the next process (or compact) starting.
+				hb := fmt.Sprintf(`{"type":"heartbeat","ts":%d}`, time.Now().UnixMilli())
+				broadcaster.Send(hb)
+
 			default:
 				// Process still alive — turn completed normally
 				if !interrupted {
@@ -477,6 +482,11 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				}
 				compactCompleteMsg := fmt.Sprintf(`{"type":"compact_complete","continuation_count":%d}`, continuationCount)
 				broadcaster.Send(compactCompleteMsg)
+
+				// Send a heartbeat after compact to keep SSE clients alive during the
+				// gap between compact finishing and the new process starting.
+				hb := fmt.Sprintf(`{"type":"heartbeat","ts":%d}`, time.Now().UnixMilli())
+				broadcaster.Send(hb)
 			}
 
 			currentMessage = "You were interrupted due to turn limits. Continue where you left off."

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1595,6 +1595,10 @@ document.addEventListener('alpine:init', () => {
           }
 
           if (data.type === 'done' || data.type === 'result') {
+            // Skip result events from compact process — they'd pollute cost/pill state
+            if (data.type === 'result' && this.isCompacting) {
+              return;
+            }
             // Track cost from result events
             if (data.type === 'result' && data.cost != null) {
               this.sessionCost = (this.sessionCost || 0) + data.cost;
@@ -1707,8 +1711,8 @@ document.addEventListener('alpine:init', () => {
       // Don't reconnect if we've switched sessions
       if (sessionId !== this.selectedSessionId) return;
 
-      // Cap reconnect attempts
-      if (this.sseReconnectAttempts >= 10) {
+      // Cap reconnect attempts — higher limit to survive long compacts
+      if (this.sseReconnectAttempts >= 20) {
         this.addActivityPill('Connection lost — reconnect failed', 'disconnected');
         this.sseReconnectAttempts = 0;
         return;
@@ -1719,7 +1723,7 @@ document.addEventListener('alpine:init', () => {
       this.sseReconnectAttempts++;
 
       this.sseReconnectTimer = setTimeout(async () => {
-        // Check if session is still working before reconnecting
+        // Check session state to decide reconnect strategy
         try {
           const resp = await fetch(`/api/sessions/${sessionId}`, {
             headers: { 'Authorization': `Bearer ${this.apiKey}` }
@@ -1727,9 +1731,11 @@ document.addEventListener('alpine:init', () => {
           if (!resp.ok) return;
           const session = await resp.json();
           if (session.activity_state !== 'working') {
-            // Session finished while we were disconnected — reload messages
-            this.sseReconnectAttempts = 0;
+            // Session not currently working — reload messages to catch anything missed
             await this.fetchManagedMessages(sessionId);
+            // Still reconnect SSE so we're listening if the session resumes
+            // (e.g., after compact finishes and new process starts)
+            this.startSessionSSE(sessionId);
             return;
           }
         } catch (e) {


### PR DESCRIPTION
## Summary

Fixes #81 — Server connection lost when auto-continuing with a compact.

- **Browser SSE reconnect**: `attemptSSEReconnect()` now always reconnects SSE even when session state isn't `working`, so the browser is listening when the session resumes after compact
- **Server heartbeats**: Sends heartbeat after `compact_complete` and after auto-interrupt cleanup to bridge the gap before the next process starts, preventing browser timeout
- **Compact result filtering**: Skips `result` events from the compact process so they don't pollute cost/pill tracking in the UI

## Test plan

- [ ] Start a managed session, send enough messages to trigger auto-continue with compact
- [ ] Verify the browser SSE connection survives the compact and shows continued output
- [ ] Verify session cost display is not polluted by compact result events
- [ ] Run `cd server && go test ./... -v` — all passing