### PR TITLE
fix: restart server stalls due to missing graceful HTTP shutdown

### DIFF
--- a/server/api/files_test.go
+++ b/server/api/files_test.go
@@ -20,7 +20,7 @@ func TestHandleGetFileRaw(t *testing.T) {
 	defer store.Close()
 
 	envPath := filepath.Join(dir, ".env")
-	router := NewRouter(store, "test-key", nil, envPath, nil)
+	router := NewRouter(store, "test-key", nil, envPath, nil, "test-server-id")
 
 	// Create a managed session with CWD set to dir
 	sess, err := store.CreateManagedSession(dir, "", 0, 0, 0)

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -27,7 +27,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *db.Store) {
 		ClaudeEnv:  []string{},
 	}
 	mgr := managed.NewManager(cfg)
-	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil)
+	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil, "test-server-id")
 	ts := httptest.NewServer(router)
 	return ts, store
 }

--- a/server/api/pairing.go
+++ b/server/api/pairing.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"encoding/json"
+	"net/http"
+)
 
 func (s *Server) handlePairing(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -9,5 +12,8 @@ func (s *Server) handlePairing(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"status":"ok"}`))
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":    "ok",
+		"server_id": s.serverID,
+	})
 }

--- a/server/api/restart.go
+++ b/server/api/restart.go
@@ -18,7 +18,7 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "restarting"})
+	json.NewEncoder(w).Encode(map[string]string{"status": "restarting", "server_id": s.serverID})
 
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -16,10 +16,11 @@ type Server struct {
 	permissions       *PermissionManager
 	shutdownFunc      func() // called to trigger server restart
 	restartInProgress atomic.Bool
+	serverID          string // unique ID per server instance, used by clients to detect restart
 }
 
-func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string, shutdownFunc func()) http.Handler {
-	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc}
+func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string, shutdownFunc func(), serverID string) http.Handler {
+	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc, serverID: serverID}
 
 	// API mux — all existing endpoints, behind auth middleware
 	apiMux := http.NewServeMux()

--- a/server/api/sessions_test.go
+++ b/server/api/sessions_test.go
@@ -19,7 +19,7 @@ func newTestServer(t *testing.T) (*httptest.Server, *db.Store) {
 	}
 	t.Cleanup(func() { store.Close() })
 
-	router := NewRouter(store, "test-key", nil, filepath.Join(t.TempDir(), ".env"), nil)
+	router := NewRouter(store, "test-key", nil, filepath.Join(t.TempDir(), ".env"), nil, "test-server-id")
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, store

--- a/server/api/settings_test.go
+++ b/server/api/settings_test.go
@@ -24,7 +24,7 @@ func newTestServerWithManager(t *testing.T) (*httptest.Server, *db.Store, *manag
 
 	mgr := managed.NewManager(managed.Config{ClaudeBin: "claude"})
 	envPath := filepath.Join(tmpDir, ".env")
-	router := NewRouter(store, "test-key", mgr, envPath, nil)
+	router := NewRouter(store, "test-key", mgr, envPath, nil, "test-server-id")
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, store, mgr, envPath

--- a/server/main.go
+++ b/server/main.go
@@ -102,7 +102,8 @@ func main() {
 		}
 	}
 
-	router := api.NewRouter(store, apiKey, mgr, envPath, shutdownFunc)
+	serverID := fmt.Sprintf("%d", time.Now().UnixNano())
+	router := api.NewRouter(store, apiKey, mgr, envPath, shutdownFunc, serverID)
 
 	// Start local server
 	bindHost := "localhost"
@@ -118,12 +119,14 @@ func main() {
 	fmt.Printf("Local server listening on %s\n", addr)
 	fmt.Printf("API key: %s\n", apiKey)
 
-	// Start serving HTTP immediately
-	go http.Serve(localListener, router)
+	// Start serving HTTP with http.Server for graceful shutdown
+	httpServer := &http.Server{Handler: router}
+	go httpServer.Serve(localListener)
 
 	// Start ngrok tunnel (may block if no auth token)
 	ctx, cancel := context.WithCancel(context.Background())
 
+	var ngrokServer *http.Server
 	tun, err := tunnel.Start(ctx)
 	if err != nil {
 		log.Printf("Warning: ngrok tunnel failed: %v", err)
@@ -140,7 +143,8 @@ func main() {
 		displayQRCode(ngrokURL, apiKey)
 
 		// Serve on ngrok listener too
-		go http.Serve(tun.Listener(), router)
+		ngrokServer = &http.Server{Handler: router}
+		go ngrokServer.Serve(tun.Listener())
 	}
 
 	// Handle shutdown via signal or restart request
@@ -156,11 +160,18 @@ func main() {
 		restartRequested = true
 	}
 
-	// Graceful shutdown sequence
+	// Graceful shutdown: stop HTTP first so clients see the server as down
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	httpServer.Shutdown(shutdownCtx)
+	if ngrokServer != nil {
+		ngrokServer.Shutdown(shutdownCtx)
+	}
+	shutdownCancel()
+
+	// Then shut down background services
 	mgr.ShutdownAll(5 * time.Second)
 	sched.Stop()
 	cancel()
-	localListener.Close()
 	store.Close()
 
 	if restartRequested {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -523,24 +523,34 @@ document.addEventListener('alpine:init', () => {
           this.serverRestarting = false;
           return;
         }
+        const data = await resp.json();
         this.showSettingsModal = false;
         this.toast('Server restarting...', 10000, 'info');
-        this.pollForRestart();
+        this.pollForRestart(data.server_id);
       } catch (e) {
         this.showSettingsModal = false;
         this.toast('Server restarting...', 10000, 'info');
-        this.pollForRestart();
+        this.pollForRestart(null);
       }
     },
 
-    pollForRestart() {
+    pollForRestart(oldServerID) {
       let attempts = 0;
-      const maxAttempts = 30;
+      const maxAttempts = 60;
       const poll = setInterval(async () => {
         attempts++;
         try {
-          const resp = await fetch(`/api/events?token=${encodeURIComponent(this.apiKey)}`);
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 3000);
+          const resp = await fetch('/api/status', {
+            headers: { 'Authorization': `Bearer ${this.apiKey}` },
+            signal: controller.signal
+          });
+          clearTimeout(timeout);
           if (resp.ok) {
+            const data = await resp.json();
+            // Wait until we see a DIFFERENT server_id (new process)
+            if (oldServerID && data.server_id === oldServerID) return;
             clearInterval(poll);
             this.serverRestarting = false;
             this.toast('Server restarted successfully', 3000, 'info');


### PR DESCRIPTION
## Summary

- Switches from bare `http.Serve` to `http.Server` with graceful `Shutdown()` so HTTP listeners close first during restart
- Adds `server_id` to `/api/status` and restart response so the client can distinguish old vs new server instances
- Rewrites `pollForRestart()` to poll `/api/status` (not SSE) with `AbortController` timeout, checking for a new `server_id`

## Root cause

Three compounding issues caused the stall:
1. No graceful HTTP shutdown — old server kept serving during the shutdown sequence
2. Client polled SSE endpoint (`/api/events`) which returned 200 immediately from the still-alive old server
3. Scheduler's 30s shutdown timeout kept the server alive long enough for the user to click restart again and get a 409 (restart already in progress)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [ ] Start server, click Restart Server in web UI — should show restarting state then reconnect
- [ ] Verify no 409 errors on restart
- [ ] Verify SSE reconnects after restart completes

Closes #87