### PR TITLE
fix: prevent server crashes from unrecovered goroutine panics

### DIFF
--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -328,10 +328,10 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			// Start the stdout reader only once per process
 			if !procStarted {
 				procStarted = true
-				go func() {
+				SafeGo("StreamNDJSON:"+sessionID, func() {
 					defer close(streamDone)
 					managed.StreamNDJSON(proc.Stdout, broadcaster, onLine, turnDone)
-				}()
+				})
 			}
 
 			// Send the user message via stdin
@@ -714,12 +714,12 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 		jsonString(req.Command), jsonString(commandID), jsonString(sess.CWD))
 	broadcaster.Send(startMsg)
 
-	go func() {
+	SafeGo("shell:"+commandID, func() {
 		var stdout, stderr strings.Builder
 		const maxOutput = 1024 * 1024
 
 		stdoutDone := make(chan struct{})
-		go func() {
+		SafeGo("shell-stdout:"+commandID, func() {
 			defer close(stdoutDone)
 			scanner := bufio.NewScanner(proc.Stdout)
 			scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -732,10 +732,10 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 					jsonString(line+"\n"), jsonString(commandID))
 				broadcaster.Send(msg)
 			}
-		}()
+		})
 
 		stderrDone := make(chan struct{})
-		go func() {
+		SafeGo("shell-stderr:"+commandID, func() {
 			defer close(stderrDone)
 			scanner := bufio.NewScanner(proc.Stderr)
 			scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -748,7 +748,7 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 					jsonString(line+"\n"), jsonString(commandID))
 				broadcaster.Send(msg)
 			}
-		}()
+		})
 
 		<-stdoutDone
 		<-stderrDone
@@ -778,7 +778,7 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 		} else {
 			_ = s.store.UpdateActivityState(sessionID, "idle")
 		}
-	}()
+	})
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"id": commandID})

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
+	"log"
 	"net/http"
+	"runtime/debug"
 	"sync/atomic"
 
 	"github.com/jaychinthrajah/claude-controller/server/db"
@@ -131,11 +135,42 @@ func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath str
 	// All other /api/ routes — through auth middleware
 	root.Handle("/api/", authedAPI)
 
+	// Health check — no auth required, used by Claude to verify server is alive
+	root.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok", "server_id": s.serverID})
+	})
+
 	// Visual file server — no auth required
 	root.HandleFunc("/visual/", s.handleVisual)
 
 	// Static files — no auth required
 	root.Handle("/", web.Handler())
 
-	return root
+	return RecoveryMiddleware(root)
+}
+
+// RecoveryMiddleware catches panics in HTTP handlers, logs the stack trace,
+// and returns a 500 response instead of crashing the server process.
+// Go's net/http already recovers handler panics, but this middleware provides
+// structured logging with full stack traces for debugging.
+func RecoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				stack := debug.Stack()
+				log.Printf("PANIC recovered in %s %s: %v\n%s", r.Method, r.URL.Path, err, stack)
+				if !headerWritten(w) {
+					http.Error(w, fmt.Sprintf("Internal Server Error: %v", err), http.StatusInternalServerError)
+				}
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// headerWritten is a best-effort check; ResponseWriter doesn't expose this directly.
+func headerWritten(w http.ResponseWriter) bool {
+	// If Content-Type is already set, headers were likely written
+	return w.Header().Get("Content-Type") != ""
 }

--- a/server/api/safego.go
+++ b/server/api/safego.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"log"
+	"runtime/debug"
+)
+
+// SafeGo runs fn in a new goroutine with panic recovery.
+// If the goroutine panics, the panic is logged with a full stack trace
+// instead of crashing the server process.
+func SafeGo(label string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("PANIC recovered in goroutine %q: %v\n%s", label, r, debug.Stack())
+			}
+		}()
+		fn()
+	}()
+}


### PR DESCRIPTION
## Summary
- Adds `RecoveryMiddleware` wrapping the root HTTP handler for defense-in-depth panic recovery
- Adds `SafeGo` utility that wraps background goroutines with panic recovery and labeled stack trace logging
- Protects `StreamNDJSON` and shell execute goroutines (stdout/stderr readers) with `SafeGo`
- Adds `/health` endpoint (no auth) for server liveness checks

## Root cause
Go's `net/http` recovers panics in HTTP handlers, but goroutines spawned FROM handlers are unprotected. A panic in any background goroutine (NDJSON streaming, shell I/O) kills the entire server process, making `/visual/` and all routes unreachable.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [ ] Manual: start server, send messages in managed mode, verify /visual/ stays reachable
- [ ] Manual: verify /health endpoint returns `{"status":"ok"}`

Fixes #31