### PR TITLE
fix: image upload breaks textarea layout (#94)

### DIFF
--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -306,20 +306,22 @@
                 </template>
               </div>
 
-              <!-- Image preview -->
-              <div class="image-preview-strip" x-show="pendingImagePreview" x-cloak>
-                <img :src="pendingImagePreview" class="image-preview-thumb">
-                <span class="image-preview-name" x-text="pendingImageFilename"></span>
-                <button class="image-preview-remove" @click="clearPendingImage()" title="Remove image">&times;</button>
-              </div>
+              <div class="input-wrapper">
+                <!-- Image preview -->
+                <div class="image-preview-strip" x-show="pendingImagePreview" x-cloak>
+                  <img :src="pendingImagePreview" class="image-preview-thumb">
+                  <span class="image-preview-name" x-text="pendingImageFilename"></span>
+                  <button class="image-preview-remove" @click="clearPendingImage()" title="Remove image">&times;</button>
+                </div>
 
-              <textarea x-model="inputText" rows="1"
-                     :placeholder="shellMode ? 'Run a command...' : (currentSession?.mode === 'managed' ? 'Send a message... (/ for commands)' : 'Send instruction (delivered on next stop)...')"
-                     :class="{ 'shell-input': shellMode }"
-                     @keydown="handleSlashKeydown($event)"
-                     @input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 150) + 'px'; onSlashInput()"
-                     @blur="setTimeout(() => showSlashMenu = false, 150)"
-                     :disabled="inputSending"></textarea>
+                <textarea x-model="inputText" rows="1"
+                       :placeholder="shellMode ? 'Run a command...' : (currentSession?.mode === 'managed' ? 'Send a message... (/ for commands)' : 'Send instruction (delivered on next stop)...')"
+                       :class="{ 'shell-input': shellMode }"
+                       @keydown="handleSlashKeydown($event)"
+                       @input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 150) + 'px'; onSlashInput()"
+                       @blur="setTimeout(() => showSlashMenu = false, 150)"
+                       :disabled="inputSending"></textarea>
+              </div>
               <button class="btn btn-primary btn-sm" :disabled="(!inputText.trim() && !pendingImageId) || inputSending"
                       @click="handleInput()" style="width:auto">
                 <span x-show="!inputSuccess">Send</span>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -531,8 +531,15 @@ body {
   background: var(--bg-secondary);
   font-size: 0.8125rem;
 }
-.instruction-bar textarea {
+.instruction-bar .input-wrapper {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.instruction-bar textarea {
+  width: 100%;
   padding: 0.375rem 0.625rem;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -545,6 +552,7 @@ body {
   min-height: 1.75rem;
   max-height: 150px;
   line-height: 1.4;
+  box-sizing: border-box;
 }
 .instruction-bar textarea:focus { outline: 2px solid var(--accent); border-color: transparent; }
 .instruction-bar .input-hint {
@@ -1153,6 +1161,8 @@ body {
   }
   .instruction-bar textarea {
     font-size: 16px; /* prevent iOS auto-zoom on focus */
+    min-height: 5rem;
+    max-height: 200px;
   }
 
   /* Mobile Menu Overlay */
@@ -1791,16 +1801,14 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 8px;
-  background: var(--bg-secondary);
+  padding: 4px 8px;
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;
-  margin-bottom: 4px;
-  width: 100%;
 }
 .image-preview-thumb {
-  width: 48px;
-  height: 48px;
+  width: 36px;
+  height: 36px;
   object-fit: cover;
   border-radius: 4px;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Wraps image preview strip + textarea in a vertical `.input-wrapper` container so the image thumbnail appears **above** the textarea instead of consuming its space
- Removes old `flex-basis: 100%` / `order: -1` hack on `.image-preview-strip` — no longer needed since the preview is structurally above the textarea
- Increases mobile textarea `min-height` from `2.75rem` to `5rem` for better usability on small screens (closer to GitHub Issues-style input)

Closes #94

## Test plan
- [ ] Upload an image in managed mode — verify thumbnail + filename appear above the textarea
- [ ] Confirm textarea remains fully visible and usable after attaching an image
- [ ] Remove the attached image — verify textarea returns to normal
- [ ] Test on mobile viewport (≤768px) — textarea should be taller and easier to type in
- [ ] Verify slash command menu still appears correctly above the input area
- [ ] Test sending a message with image attached — preview clears after send