### PR TITLE
fix: full-width mobile textarea

### DIFF
--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1154,15 +1154,29 @@ body {
     max-width: 90%;
   }
 
-  /* Input bar sticky */
+  /* Input bar sticky — stack vertically on mobile */
   .instruction-bar {
     position: sticky;
     bottom: 0;
+    flex-wrap: wrap;
+    padding: 0.5rem 0.75rem;
+    padding-bottom: calc(0.5rem + env(safe-area-inset-bottom, 0));
+  }
+  .instruction-bar .input-wrapper {
+    order: -1;
+    flex-basis: 100%;
+    margin-bottom: 0.375rem;
   }
   .instruction-bar textarea {
     font-size: 16px; /* prevent iOS auto-zoom on focus */
     min-height: 5rem;
     max-height: 200px;
+  }
+  .instruction-bar .input-hint {
+    display: none;
+  }
+  .instruction-bar .btn-primary {
+    margin-left: auto;
   }
 
   /* Mobile Menu Overlay */


### PR DESCRIPTION
## Summary
- Restructures the mobile instruction bar layout so the textarea occupies its own full-width row, with action buttons (👍, $, 📷, Send) in a row below
- Hides the `⌘↵ to send` keyboard hint on mobile (not relevant for touch)
- Adds `safe-area-inset-bottom` padding for notched devices

Fixes #97

## Test plan
- [ ] Open the web UI on a mobile device or Chrome DevTools mobile emulator (≤768px)
- [ ] Verify the textarea spans full width above the button row
- [ ] Verify tapping the textarea does not trigger iOS zoom (font-size: 16px)
- [ ] Verify the slash command menu still appears correctly above the textarea
- [ ] Verify image preview strip renders above the textarea