### PR TITLE
feat(mobile): emoji-picker-style shortcut grid

### DIFF
--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -315,6 +315,8 @@
                           @click="showShortcutPicker = !showShortcutPicker"
                           :disabled="inputSending"
                           title="Shortcuts">😁</button>
+                  <div class="shortcut-picker-backdrop" x-show="showShortcutPicker" x-cloak
+                       @click="showShortcutPicker = false"></div>
                   <div class="shortcut-picker-popup" x-show="showShortcutPicker" x-cloak
                        @click.outside="showShortcutPicker = false">
                     <template x-if="shortcuts.length === 0">

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1845,6 +1845,69 @@ body {
   text-align: center;
 }
 
+/* Shortcut picker backdrop — hidden on desktop */
+.shortcut-picker-backdrop {
+  display: none;
+}
+
+/* Mobile shortcut picker — emoji-picker-style grid */
+@media (max-width: 768px) {
+  .shortcut-picker-backdrop {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.3);
+    z-index: 99;
+  }
+  .shortcut-picker-popup {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: auto;
+    max-width: 100%;
+    max-height: 45vh;
+    border-radius: 16px 16px 0 0;
+    padding: 12px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
+    gap: 6px;
+    z-index: 100;
+    box-shadow: 0 -4px 24px rgba(0,0,0,0.2);
+    border: 1px solid var(--border);
+    border-bottom: none;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0));
+  }
+  .shortcut-picker-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 4px;
+    min-width: 48px;
+    min-height: 48px;
+    border-radius: 10px;
+    font-size: 24px;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .shortcut-picker-item:active {
+    background: var(--bg-tertiary, #d1d5db);
+    transform: scale(0.92);
+  }
+  .shortcut-picker-key {
+    font-size: 24px;
+    min-width: auto;
+  }
+  .shortcut-picker-empty {
+    grid-column: 1 / -1;
+    padding: 24px;
+    font-size: 14px;
+  }
+}
+
 /* Settings accordion */
 .settings-accordion-header {
   display: flex;


### PR DESCRIPTION
## Summary
- Redesigns the mobile shortcut picker as an emoji-picker-style bottom sheet with a grid layout
- Adds a semi-transparent backdrop overlay for better UX
- Larger 48px touch targets with 24px emoji/text for easy selection on mobile

Closes #110

## Test plan
- [ ] Open web UI on mobile device or responsive mode (≤768px)
- [ ] Tap the 😁 shortcut button — picker should slide up as a bottom sheet
- [ ] Verify grid layout with large, easily tappable emoji buttons
- [ ] Verify backdrop overlay appears behind the picker
- [ ] Tap backdrop to dismiss
- [ ] Verify desktop picker is unchanged (still inline popup)
- [ ] Test with no shortcuts configured — empty state spans full width