### PR TITLE
test: add auto-continue integration test suite

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,7 +4,8 @@
 # Install with: git config core.hooksPath .githooks
 
 echo "Running server tests before push..."
-cd server && go test ./... -count=1 -timeout 120s
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT/server" && go test ./... -count=1 -timeout 120s
 EXIT_CODE=$?
 
 if [ $EXIT_CODE -ne 0 ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Pre-push hook: runs Go tests before allowing a push.
+# Install with: git config core.hooksPath .githooks
+
+echo "Running server tests before push..."
+cd server && go test ./... -count=1 -timeout 120s
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo ""
+    echo "Push blocked: tests failed. Fix the failures and try again."
+    exit 1
+fi
+
+echo "All tests passed."
+exit 0

--- a/server/api/auto_continue_test.go
+++ b/server/api/auto_continue_test.go
@@ -1,0 +1,853 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jaychinthrajah/claude-controller/server/db"
+	"github.com/jaychinthrajah/claude-controller/server/managed"
+)
+
+// --- Test helpers ---
+
+func setupMockTestServer(t *testing.T) (*httptest.Server, *db.Store, *MockManager) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	mock := NewMockManager()
+	envPath := filepath.Join(dir, ".env")
+	router := NewRouter(store, "test-api-key", mock, envPath, nil, "test-server-id")
+	ts := httptest.NewServer(router)
+	t.Cleanup(ts.Close)
+	return ts, store, mock
+}
+
+func sendMessage(ts *httptest.Server, sessionID, message string) (*http.Response, error) {
+	body := fmt.Sprintf(`{"message": %q}`, message)
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sessionID+"/message", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req)
+}
+
+func collectBroadcasts(b *managed.Broadcaster, timeout time.Duration) []string {
+	ch := b.Subscribe()
+	var msgs []string
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return msgs
+			}
+			msgs = append(msgs, msg)
+			var obj map[string]interface{}
+			if json.Unmarshal([]byte(msg), &obj) == nil && obj["type"] == "done" {
+				b.Unsubscribe(ch)
+				return msgs
+			}
+		case <-deadline:
+			b.Unsubscribe(ch)
+			return msgs
+		}
+	}
+}
+
+func pollActivityState(t *testing.T, store *db.Store, sessionID, expected string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		sess, err := store.GetSessionByID(sessionID)
+		if err == nil && sess.ActivityState == expected {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	sess, _ := store.GetSessionByID(sessionID)
+	t.Fatalf("activity_state=%q after %v, want %q", sess.ActivityState, timeout, expected)
+}
+
+func hasEvent(msgs []string, eventType string) bool {
+	for _, msg := range msgs {
+		var obj map[string]interface{}
+		if json.Unmarshal([]byte(msg), &obj) == nil && obj["type"] == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func getEvent(msgs []string, eventType string) map[string]interface{} {
+	for _, msg := range msgs {
+		var obj map[string]interface{}
+		if json.Unmarshal([]byte(msg), &obj) == nil && obj["type"] == eventType {
+			return obj
+		}
+	}
+	return nil
+}
+
+func countEvents(msgs []string, eventType string) int {
+	count := 0
+	for _, msg := range msgs {
+		var obj map[string]interface{}
+		if json.Unmarshal([]byte(msg), &obj) == nil && obj["type"] == eventType {
+			count++
+		}
+	}
+	return count
+}
+
+// interruptableProcess creates a mock process where writing stops when interruptCh is closed.
+// It writes numTurns assistant lines + a result line, then exits.
+// If interrupted mid-write, it stops and exits immediately.
+func interruptableProcess(numTurns int, exitCode int) (*managed.Process, chan struct{}) {
+	proc, pw := makeProcess()
+	interruptCh := make(chan struct{})
+
+	go func() {
+		defer func() {
+			pw.Close()
+			proc.ExitCode = exitCode
+			close(proc.Done)
+		}()
+		for i := 0; i < numTurns; i++ {
+			select {
+			case <-interruptCh:
+				return
+			default:
+			}
+			writeLine(pw, assistantLine)
+			// Give StreamNDJSON time to process
+			select {
+			case <-interruptCh:
+				return
+			case <-time.After(15 * time.Millisecond):
+			}
+		}
+		writeLine(pw, resultLine)
+		// Give StreamNDJSON time to process result
+		select {
+		case <-interruptCh:
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+	}()
+
+	return proc, interruptCh
+}
+
+// interruptCloser is a helper that safely closes the most recent interrupt channel.
+type interruptCloser struct {
+	mu   sync.Mutex
+	chs  []chan struct{}
+}
+
+func (ic *interruptCloser) add(ch chan struct{}) {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+	ic.chs = append(ic.chs, ch)
+}
+
+func (ic *interruptCloser) closeLast() {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+	if len(ic.chs) > 0 {
+		ch := ic.chs[len(ic.chs)-1]
+		select {
+		case <-ch: // already closed
+		default:
+			close(ch)
+		}
+	}
+}
+
+// --- Auto-Continue Core Loop Tests ---
+
+func TestAutoContinue_HappyPath(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	// maxTurns=5, threshold=0.8 → trigger at turn 4
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-happy", `["Bash"]`, 5, 5.0, 0)
+
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call == 1 {
+			proc, ich := interruptableProcess(5, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		// Second process: 2 turns, exits normally
+		proc, ich := interruptableProcess(2, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 15*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
+
+	if got := atomic.LoadInt32(&ensureCount); got != 2 {
+		t.Errorf("EnsureProcess called %d times, want 2", got)
+	}
+
+	msgs := <-broadcastsCh
+	if !hasEvent(msgs, "auto_continuing") {
+		t.Error("missing auto_continuing SSE event")
+	}
+	if !hasEvent(msgs, "done") {
+		t.Error("missing done SSE event")
+	}
+	evt := getEvent(msgs, "auto_continuing")
+	if evt != nil && int(evt["continuation_count"].(float64)) != 1 {
+		t.Errorf("continuation_count=%v, want 1", evt["continuation_count"])
+	}
+}
+
+func TestAutoContinue_MultipleContinuations(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	// maxTurns=3, threshold=0.8 → trigger at 2
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-multi", `["Bash"]`, 3, 5.0, 0)
+
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call <= 3 {
+			proc, ich := interruptableProcess(3, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		// Process 4: 1 turn, exits normally
+		proc, ich := interruptableProcess(1, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 25*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 25*time.Second)
+
+	msgs := <-broadcastsCh
+	if c := countEvents(msgs, "auto_continuing"); c < 3 {
+		t.Errorf("got %d auto_continuing events, want >= 3", c)
+	}
+}
+
+func TestAutoContinue_Exhaustion(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	// maxTurns=5, threshold=0.8 → trigger at 4. Default maxContinuations=5.
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-exhaust", `["Bash"]`, 5, 5.0, 0)
+
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		proc, ich := interruptableProcess(5, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 45*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 45*time.Second)
+
+	msgs := <-broadcastsCh
+	if !hasEvent(msgs, "auto_continue_exhausted") {
+		t.Error("missing auto_continue_exhausted SSE event")
+	}
+	evt := getEvent(msgs, "auto_continue_exhausted")
+	if evt != nil {
+		if _, has := evt["reason"]; has {
+			t.Errorf("exhausted event should not have reason field, got %v", evt["reason"])
+		}
+	}
+}
+
+func TestAutoContinue_NoProgress(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	// maxTurns=2, threshold=0.8 → floor(0.8*2)=1 → trigger at 1 assistant turn.
+	// First process: 2 turns (>=2, passes progress check).
+	// Second process: 1 turn (triggers at 1, but turnsSinceLastContinue=1 < 2 → no progress).
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-noprog", `["Bash"]`, 2, 5.0, 0)
+
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call == 1 {
+			// 3 turns: threshold fires at 1, turnsSinceLastContinue=3 >= 2 → continues
+			proc, ich := interruptableProcess(3, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		// Second: 1 turn, threshold fires at 1, turnsSinceLastContinue=1 < 2 → no progress
+		proc, ich := interruptableProcess(1, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 15*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
+
+	msgs := <-broadcastsCh
+	evt := getEvent(msgs, "auto_continue_exhausted")
+	if evt == nil {
+		t.Fatal("missing auto_continue_exhausted event")
+	}
+	if evt["reason"] != "no_progress" {
+		t.Errorf("reason=%v, want no_progress", evt["reason"])
+	}
+}
+
+func TestAutoContinue_ExecutionError(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-err", `["Bash"]`, 5, 5.0, 0)
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		proc, pw := makeProcess()
+		go func() {
+			writeLine(pw, assistantLine)
+			time.Sleep(15 * time.Millisecond)
+			writeLine(pw, errorResultLine)
+			time.Sleep(50 * time.Millisecond)
+			pw.Close()
+			proc.ExitCode = 1
+			close(proc.Done)
+		}()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	// Execution errors with a natural exit (turnDone fires, process still alive)
+	// go through the GracefulShutdown path → "waiting". The executionErrored flag
+	// prevents auto-continue but doesn't change the normal exit state.
+	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
+
+	dbMsgs, _ := store.ListMessages(sess.ID)
+	var found bool
+	for _, m := range dbMsgs {
+		if m.Role == "assistant" && strings.Contains(m.Content, "something failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected execution error message to be persisted")
+	}
+}
+
+// --- Manual Interrupt Tests ---
+
+func TestManualInterrupt_NaturalExit(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-nat-exit", `["Bash"]`, 50, 5.0, 0)
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		proc, pw := makeProcess()
+		go func() {
+			writeLine(pw, assistantLine)
+			time.Sleep(15 * time.Millisecond)
+			writeLine(pw, assistantLine)
+			time.Sleep(15 * time.Millisecond)
+			writeLine(pw, resultLine)
+			time.Sleep(50 * time.Millisecond)
+			pw.Close()
+			proc.ExitCode = 0
+			close(proc.Done)
+		}()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 10*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
+
+	msgs := <-broadcastsCh
+	if hasEvent(msgs, "auto_continuing") {
+		t.Error("should not have auto_continuing event for natural exit")
+	}
+}
+
+func TestManualInterrupt_ProcessDeath(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-proc-death", `["Bash"]`, 50, 5.0, 0)
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		proc, pw := makeProcess()
+		go func() {
+			writeLine(pw, assistantLine)
+			time.Sleep(15 * time.Millisecond)
+			// Process crashes without emitting result — simulates unexpected death
+			pw.Close()
+			proc.ExitCode = 1
+			close(proc.Done)
+		}()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 10*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "idle", 10*time.Second)
+
+	msgs := <-broadcastsCh
+	if !hasEvent(msgs, "done") {
+		t.Error("missing done event")
+	}
+	if hasEvent(msgs, "auto_continuing") {
+		t.Error("should not auto-continue after non-zero exit")
+	}
+}
+
+// --- Compact Integration Tests ---
+
+func TestCompact_RunsAtInterval(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-compact-int", `["Bash"]`, 3, 5.0, 1)
+
+	var compactCalls int32
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call == 1 {
+			proc, ich := interruptableProcess(3, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		proc, ich := interruptableProcess(1, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnRunCompact = func(sessionID, resumeID, cwd string, timeout time.Duration) error {
+		atomic.AddInt32(&compactCalls, 1)
+		return nil
+	}
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
+
+	if got := atomic.LoadInt32(&compactCalls); got < 1 {
+		t.Errorf("RunCompact called %d times, want >= 1", got)
+	}
+}
+
+func TestCompact_FailureContinues(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-compact-fail", `["Bash"]`, 3, 5.0, 1)
+
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call == 1 {
+			proc, ich := interruptableProcess(3, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		proc, ich := interruptableProcess(1, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnRunCompact = func(sessionID, resumeID, cwd string, timeout time.Duration) error {
+		return fmt.Errorf("compact failed: out of memory")
+	}
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
+
+	dbMsgs, _ := store.ListMessages(sess.ID)
+	var found bool
+	for _, m := range dbMsgs {
+		if m.Role == "system" && strings.Contains(m.Content, "Compact failed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("missing compact failure warning message")
+	}
+	if got := atomic.LoadInt32(&ensureCount); got < 2 {
+		t.Errorf("EnsureProcess called %d times, want >= 2", got)
+	}
+}
+
+func TestCompact_SSEEvents(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-compact-sse", `["Bash"]`, 3, 5.0, 1)
+
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call == 1 {
+			proc, ich := interruptableProcess(3, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		proc, ich := interruptableProcess(1, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnRunCompact = func(sessionID, resumeID, cwd string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 15*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
+
+	msgs := <-broadcastsCh
+	if !hasEvent(msgs, "compacting") {
+		t.Error("missing compacting SSE event")
+	}
+	if !hasEvent(msgs, "compact_complete") {
+		t.Error("missing compact_complete SSE event")
+	}
+}
+
+// --- Message Persistence Tests ---
+
+func TestPersistence_AssistantText(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-persist-text", `["Bash"]`, 50, 5.0, 0)
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		proc, pw := makeProcess()
+		go func() {
+			writeLine(pw, `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First response"}]}}`)
+			time.Sleep(15 * time.Millisecond)
+			writeLine(pw, `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second response"}]}}`)
+			time.Sleep(15 * time.Millisecond)
+			writeLine(pw, resultLine)
+			time.Sleep(50 * time.Millisecond)
+			pw.Close()
+			proc.ExitCode = 0
+			close(proc.Done)
+		}()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
+
+	dbMsgs, _ := store.ListMessages(sess.ID)
+	var texts []string
+	for _, m := range dbMsgs {
+		if m.Role == "assistant" {
+			texts = append(texts, m.Content)
+		}
+	}
+	if len(texts) < 2 {
+		t.Fatalf("got %d assistant messages, want >= 2", len(texts))
+	}
+	if texts[0] != "First response" {
+		t.Errorf("first=%q, want 'First response'", texts[0])
+	}
+	if texts[1] != "Second response" {
+		t.Errorf("second=%q, want 'Second response'", texts[1])
+	}
+}
+
+func TestPersistence_SystemMessages(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-persist-sys", `["Bash"]`, 5, 5.0, 0)
+
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call == 1 {
+			proc, ich := interruptableProcess(5, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		proc, ich := interruptableProcess(1, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
+
+	dbMsgs, _ := store.ListMessages(sess.ID)
+	var found bool
+	for _, m := range dbMsgs {
+		if m.Role == "system" && strings.Contains(m.Content, "Auto-continuing (1/5)") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("missing 'Auto-continuing (1/5)...' system message")
+	}
+}
+
+func TestPersistence_ToolActivity(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-persist-tool", `["Bash"]`, 50, 5.0, 0)
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		proc, pw := makeProcess()
+		go func() {
+			writeLine(pw, toolUseLine)
+			time.Sleep(15 * time.Millisecond)
+			writeLine(pw, resultLine)
+			time.Sleep(50 * time.Millisecond)
+			pw.Close()
+			proc.ExitCode = 0
+			close(proc.Done)
+		}()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
+
+	dbMsgs, _ := store.ListMessages(sess.ID)
+	var found bool
+	for _, m := range dbMsgs {
+		if m.Role == "activity" && strings.Contains(m.Content, "Read") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("missing tool activity message for Read tool")
+	}
+}
+
+// --- SSE Event Delivery Tests ---
+
+func TestSSE_DoneEvent(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-sse-done", `["Bash"]`, 50, 5.0, 0)
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		proc, pw := makeProcess()
+		go func() {
+			writeLine(pw, assistantLine)
+			time.Sleep(15 * time.Millisecond)
+			writeLine(pw, resultLine)
+			time.Sleep(50 * time.Millisecond)
+			pw.Close()
+			proc.ExitCode = 0
+			close(proc.Done)
+		}()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 10*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
+
+	msgs := <-broadcastsCh
+	evt := getEvent(msgs, "done")
+	if evt == nil {
+		t.Fatal("missing done SSE event")
+	}
+	if int(evt["exit_code"].(float64)) != 0 {
+		t.Errorf("exit_code=%v, want 0", evt["exit_code"])
+	}
+}
+
+func TestSSE_HeartbeatBetweenProcesses(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-sse-hb", `["Bash"]`, 5, 5.0, 0)
+
+	var ensureCount int32
+	ic := &interruptCloser{}
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		call := atomic.AddInt32(&ensureCount, 1)
+		if call == 1 {
+			proc, ich := interruptableProcess(5, 0)
+			ic.add(ich)
+			return proc, nil
+		}
+		proc, ich := interruptableProcess(1, 0)
+		ic.add(ich)
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
+	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 15*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
+
+	msgs := <-broadcastsCh
+	if !hasEvent(msgs, "heartbeat") {
+		t.Error("missing heartbeat SSE event between process cycles")
+	}
+}

--- a/server/api/interfaces.go
+++ b/server/api/interfaces.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"time"
+
+	"github.com/jaychinthrajah/claude-controller/server/managed"
+)
+
+// SessionManager abstracts the managed.Manager for testability.
+// The real *managed.Manager satisfies this interface.
+type SessionManager interface {
+	EnsureProcess(sessionID string, opts managed.SpawnOpts) (*managed.Process, error)
+	SendTurn(sessionID string, messageJSON string) error
+	Interrupt(sessionID string) error
+	IsRunning(sessionID string) bool
+	GetBroadcaster(sessionID string) *managed.Broadcaster
+	GracefulShutdown(sessionID string, timeout time.Duration) error
+	RunCompact(sessionID string, resumeID string, cwd string, timeout time.Duration) error
+	Teardown(sessionID string, timeout time.Duration) error
+	SpawnShell(sessionID string, opts managed.ShellOpts) (*managed.Process, error)
+	Config() managed.Config
+	UpdateConfig(cfg managed.Config)
+}

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -475,3 +475,50 @@ func TestRecentDirsAPI(t *testing.T) {
 		t.Errorf("first name = %s, want project-b", result.Directories[0].Name)
 	}
 }
+
+func TestStaleState_ServerRestart(t *testing.T) {
+	dir := t.TempDir()
+	store, err := db.Open(dir + "/test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// Create sessions in various states
+	s1, _ := store.CreateManagedSession("/tmp/stale-working1", `["Bash"]`, 50, 5.0, 0)
+	s2, _ := store.CreateManagedSession("/tmp/stale-working2", `["Bash"]`, 50, 5.0, 0)
+	s3, _ := store.CreateManagedSession("/tmp/stale-waiting", `["Bash"]`, 50, 5.0, 0)
+	s4, _ := store.CreateManagedSession("/tmp/stale-idle", `["Bash"]`, 50, 5.0, 0)
+
+	store.UpdateActivityState(s1.ID, "working")
+	store.UpdateActivityState(s2.ID, "working")
+	store.UpdateActivityState(s3.ID, "waiting")
+	store.UpdateActivityState(s4.ID, "idle")
+
+	// Simulate server restart: reset stale states
+	if err := store.ResetStaleActivityStates(); err != nil {
+		t.Fatalf("ResetStaleActivityStates: %v", err)
+	}
+
+	// Verify "working" sessions became "idle"
+	got1, _ := store.GetSessionByID(s1.ID)
+	if got1.ActivityState != "idle" {
+		t.Errorf("s1 activity_state = %q, want idle", got1.ActivityState)
+	}
+	got2, _ := store.GetSessionByID(s2.ID)
+	if got2.ActivityState != "idle" {
+		t.Errorf("s2 activity_state = %q, want idle", got2.ActivityState)
+	}
+
+	// Verify "waiting" sessions are NOT changed
+	got3, _ := store.GetSessionByID(s3.ID)
+	if got3.ActivityState != "waiting" {
+		t.Errorf("s3 activity_state = %q, want waiting (should not be changed)", got3.ActivityState)
+	}
+
+	// Verify "idle" sessions are NOT changed
+	got4, _ := store.GetSessionByID(s4.ID)
+	if got4.ActivityState != "idle" {
+		t.Errorf("s4 activity_state = %q, want idle", got4.ActivityState)
+	}
+}

--- a/server/api/mock_manager_test.go
+++ b/server/api/mock_manager_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/jaychinthrajah/claude-controller/server/managed"
+)
+
+// --- NDJSON test fixtures ---
+
+const assistantLine = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}]}}`
+const resultLine = `{"type":"result","subtype":"success","cost":0.01}`
+const errorResultLine = `{"type":"result","subtype":"error_during_execution","is_error":true,"errors":["something failed"]}`
+const toolUseLine = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/test.go"}}]}}`
+
+// --- MockManager ---
+
+type MockManager struct {
+	mu           sync.Mutex
+	broadcasters map[string]*managed.Broadcaster
+	running      map[string]bool
+
+	OnEnsureProcess    func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error)
+	OnSendTurn         func(sessionID string, messageJSON string) error
+	OnInterrupt        func(sessionID string) error
+	OnGracefulShutdown func(sessionID string, timeout time.Duration) error
+	OnRunCompact       func(sessionID string, resumeID string, cwd string, timeout time.Duration) error
+	OnTeardown         func(sessionID string, timeout time.Duration) error
+	OnSpawnShell       func(sessionID string, opts managed.ShellOpts) (*managed.Process, error)
+	ConfigValue        managed.Config
+}
+
+func NewMockManager() *MockManager {
+	return &MockManager{
+		broadcasters: make(map[string]*managed.Broadcaster),
+		running:      make(map[string]bool),
+	}
+}
+
+func (m *MockManager) GetBroadcaster(sessionID string) *managed.Broadcaster {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if b, ok := m.broadcasters[sessionID]; ok {
+		return b
+	}
+	b := managed.NewBroadcaster()
+	m.broadcasters[sessionID] = b
+	return b
+}
+
+func (m *MockManager) EnsureProcess(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+	if m.OnEnsureProcess != nil {
+		return m.OnEnsureProcess(sessionID, opts)
+	}
+	return nil, fmt.Errorf("EnsureProcess not configured")
+}
+
+func (m *MockManager) SendTurn(sessionID string, messageJSON string) error {
+	if m.OnSendTurn != nil {
+		return m.OnSendTurn(sessionID, messageJSON)
+	}
+	return nil
+}
+
+func (m *MockManager) Interrupt(sessionID string) error {
+	if m.OnInterrupt != nil {
+		return m.OnInterrupt(sessionID)
+	}
+	return nil
+}
+
+func (m *MockManager) IsRunning(sessionID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running[sessionID]
+}
+
+func (m *MockManager) SetRunning(sessionID string, running bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.running[sessionID] = running
+}
+
+func (m *MockManager) GracefulShutdown(sessionID string, timeout time.Duration) error {
+	if m.OnGracefulShutdown != nil {
+		return m.OnGracefulShutdown(sessionID, timeout)
+	}
+	return nil
+}
+
+func (m *MockManager) RunCompact(sessionID string, resumeID string, cwd string, timeout time.Duration) error {
+	if m.OnRunCompact != nil {
+		return m.OnRunCompact(sessionID, resumeID, cwd, timeout)
+	}
+	return nil
+}
+
+func (m *MockManager) Teardown(sessionID string, timeout time.Duration) error {
+	if m.OnTeardown != nil {
+		return m.OnTeardown(sessionID, timeout)
+	}
+	return nil
+}
+
+func (m *MockManager) SpawnShell(sessionID string, opts managed.ShellOpts) (*managed.Process, error) {
+	if m.OnSpawnShell != nil {
+		return m.OnSpawnShell(sessionID, opts)
+	}
+	return nil, fmt.Errorf("SpawnShell not configured")
+}
+
+func (m *MockManager) Config() managed.Config {
+	return m.ConfigValue
+}
+
+func (m *MockManager) UpdateConfig(cfg managed.Config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ConfigValue = cfg
+}
+
+// --- Process simulation helpers ---
+
+func makeProcess() (*managed.Process, *io.PipeWriter) {
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	proc := &managed.Process{
+		Stdout: pr,
+		Stderr: io.NopCloser(&nopReader{}),
+		Done:   done,
+	}
+	return proc, pw
+}
+
+func writeLine(pw *io.PipeWriter, line string) {
+	pw.Write([]byte(line + "\n"))
+}
+
+type nopReader struct{}
+
+func (nopReader) Read(p []byte) (int, error) { return 0, io.EOF }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -9,13 +9,12 @@ import (
 	"sync/atomic"
 
 	"github.com/jaychinthrajah/claude-controller/server/db"
-	"github.com/jaychinthrajah/claude-controller/server/managed"
 	"github.com/jaychinthrajah/claude-controller/server/web"
 )
 
 type Server struct {
 	store             *db.Store
-	manager           *managed.Manager
+	manager           SessionManager
 	envPath           string
 	permissions       *PermissionManager
 	shutdownFunc      func() // called to trigger server restart
@@ -23,7 +22,7 @@ type Server struct {
 	serverID          string // unique ID per server instance, used by clients to detect restart
 }
 
-func NewRouter(store *db.Store, apiKey string, mgr *managed.Manager, envPath string, shutdownFunc func(), serverID string) http.Handler {
+func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath string, shutdownFunc func(), serverID string) http.Handler {
 	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc, serverID: serverID}
 
 	// API mux — all existing endpoints, behind auth middleware


### PR DESCRIPTION
## Summary
- Extract `SessionManager` interface from `*managed.Manager` for testability (no production behavior changes)
- Add `MockManager` with callback fields + `interruptableProcess()` helper for simulating Claude CLI process behavior via `io.Pipe` with proper SIGINT coordination
- Add 16 integration tests covering the auto-continue orchestration loop end-to-end

## Test Coverage

| Category | Tests |
|----------|-------|
| Auto-continue core loop | HappyPath, MultipleContinuations, Exhaustion, NoProgress, ExecutionError |
| Manual interrupt | NaturalExit, ProcessDeath |
| Compact integration | RunsAtInterval, FailureContinues, SSEEvents |
| Message persistence | AssistantText, SystemMessages, ToolActivity |
| SSE event delivery | DoneEvent, HeartbeatBetweenProcesses |
| Stale state recovery | ServerRestart |

## Test Plan
- [x] All 16 new tests pass (`go test ./api/ -v -count=1`)
- [x] All existing tests pass (`go test ./... -count=1`)
- [x] No compilation errors after interface extraction