### PR TITLE
feat(desktop): redesign shortcut picker as emoji-picker-style grid

### DIFF
--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1806,42 +1806,52 @@ body {
   left: 0;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 12px;
   box-shadow: 0 4px 16px rgba(0,0,0,0.15);
-  max-width: 320px;
-  max-height: 240px;
+  max-width: 400px;
+  max-height: 320px;
   overflow-y: auto;
   z-index: 50;
-  padding: 4px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2px;
+  padding: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
+  gap: 4px;
 }
 .shortcut-picker-empty {
-  padding: 12px;
-  font-size: 12px;
+  grid-column: 1 / -1;
+  padding: 16px;
+  font-size: 13px;
   color: var(--text-muted);
   text-align: center;
 }
 .shortcut-picker-item {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 6px 8px;
+  padding: 8px 4px;
+  min-width: 48px;
+  min-height: 48px;
   border: none;
   background: none;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
   color: var(--text);
-  font-size: 14px;
+  font-size: 20px;
+  transition: background 0.1s, transform 0.1s;
 }
 .shortcut-picker-item:hover {
   background: var(--bg-secondary);
 }
+.shortcut-picker-item:active {
+  background: var(--bg-tertiary, #d1d5db);
+  transform: scale(0.95);
+}
 .shortcut-picker-key {
   font-weight: 600;
   flex-shrink: 0;
-  min-width: 28px;
+  font-size: 20px;
+  min-width: auto;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Redesigns the desktop shortcut picker to use a CSS grid layout matching the mobile version
- Larger items (48x48px min), bigger font (20px), active state animation
- More usable selection experience that mirrors the emoji-picker-style mobile design

## Test plan
- [ ] Open web UI on desktop, verify shortcut picker displays as a grid
- [ ] Verify items are larger and easier to click
- [ ] Verify hover and active states work correctly
- [ ] Confirm mobile bottom-sheet picker is unchanged