### PR TITLE
fix: only auto-continue when Claude hits --max-turns, not on user input prompts

### DIFF
--- a/docs/superpowers/specs/2026-04-14-multi-platform-issues-tabs-design.md
+++ b/docs/superpowers/specs/2026-04-14-multi-platform-issues-tabs-design.md
@@ -1,0 +1,117 @@
+# Multi-Platform Project Management Tabs — Design Spec
+
+**Date:** 2026-04-14
+**Issue:** #90 — Add more project management tools
+
+## Overview
+
+Add support for multiple project management platforms (Jira, Asana, Google Tasks) alongside the existing GitHub integration in the issues panel. The panel gets a favicon-based tab bar that conditionally shows only configured platforms.
+
+## Requirements
+
+1. Tab bar at the top of the issues section with platform favicon icons
+2. Only show tabs for platforms that have credentials configured in Settings
+3. GitHub tab retains full existing functionality (issues, PRs, search, state filters, detail view)
+4. New platform tabs show a "connected" placeholder — no real API calls yet
+5. Settings panel gets configuration fields for each new platform
+6. Works on both desktop (right sidebar) and mobile (issues tab)
+
+## Settings Fields
+
+| Platform | Fields | Notes |
+|----------|--------|-------|
+| GitHub | (existing) token | Already implemented |
+| Jira | `jira_url`, `jira_token`, `jira_email` | Base URL needed for self-hosted instances |
+| Asana | `asana_token` | Personal access token |
+| Google Tasks | `google_tasks_token` | API key or OAuth token |
+
+Settings are stored in the existing server-side settings system (SQLite `settings` table, key-value pairs).
+
+## Tab Bar UI
+
+- Horizontal row of favicon icons (16×16) at the top of the issues section
+- Each icon is a clickable tab; active tab gets an underline/accent indicator
+- Icons: GitHub Octocat SVG, Jira blue diamond SVG, Asana coral dots SVG, Google Tasks checkmark SVG
+- All favicons are inline SVGs (no external fetches, works offline)
+- Tab bar only renders if at least one platform is configured
+- If only GitHub is configured, tab bar still shows (single tab) for consistency
+
+### Favicon Sources (inline SVGs)
+- **GitHub**: Octocat mark (monochrome, adapts to theme)
+- **Jira**: Blue diamond/gradient mark
+- **Asana**: Three coral/orange dots
+- **Google Tasks**: Blue checkmark with circle
+
+## Frontend State
+
+```javascript
+// New state fields
+issuesProvider: 'github',  // 'github' | 'jira' | 'asana' | 'google_tasks'
+
+// Computed from settings
+configuredProviders: [],   // Populated from settings on load
+```
+
+`configuredProviders` is derived by checking which platform tokens are non-empty in settings.
+
+## Tab Content Per Platform
+
+### GitHub (existing)
+- Issues list with open/closed toggle, search, pagination
+- Pull requests list with same controls
+- Detail view with markdown body rendering
+
+### Jira (placeholder)
+- Shows: "Connected to Jira at {jira_url}" with Jira icon
+- Message: "Issue browsing coming in a future update"
+
+### Asana (placeholder)
+- Shows: "Connected to Asana" with Asana icon
+- Message: "Task browsing coming in a future update"
+
+### Google Tasks (placeholder)
+- Shows: "Connected to Google Tasks" with Google Tasks icon
+- Message: "Task browsing coming in a future update"
+
+## API Changes
+
+### New Settings Endpoints (use existing settings infrastructure)
+No new endpoints needed — the existing `GET/PUT /api/settings` handles arbitrary key-value pairs.
+
+### New Keys
+- `jira_url`, `jira_token`, `jira_email`
+- `asana_token`
+- `google_tasks_token`
+
+## Desktop Layout
+
+```
+┌─────────────────────────────────┐
+│ [GH] [Jira] [Asana] [GT]       │  ← Tab bar (favicons only)
+│ ─────────────────────────────── │
+│ ▾ Issues (3 open)               │  ← Current issues UI (GitHub tab)
+│   #42 Fix login bug             │
+│   #38 Add dark mode             │
+│ ▾ Pull Requests (1 open)        │
+│   #41 Refactor auth             │
+└─────────────────────────────────┘
+```
+
+## Mobile Layout
+
+Same tab bar appears at the top of the mobile Issues tab content area, before the issues list.
+
+## Scope Boundaries
+
+**In scope:**
+- Tab bar UI with inline SVG favicons
+- Settings fields for Jira, Asana, Google Tasks
+- Conditional tab visibility
+- Placeholder content for new platforms
+- Both desktop and mobile layouts
+
+**Out of scope:**
+- Actual API integrations for Jira/Asana/Google Tasks
+- OAuth flows
+- Issue detail views for new platforms
+- Cross-platform issue search

--- a/server/api/auto_continue_test.go
+++ b/server/api/auto_continue_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -111,119 +112,154 @@ func countEvents(msgs []string, eventType string) int {
 	return count
 }
 
-// interruptableProcess creates a mock process where writing stops when interruptCh is closed.
-// It writes numTurns assistant lines + a result line, then exits.
-// If interrupted mid-write, it stops and exits immediately.
-func interruptableProcess(numTurns int, exitCode int) (*managed.Process, chan struct{}) {
+// --- Persistent process simulation ---
+//
+// turnSpec describes what the process should output for a single turn.
+type turnSpec struct {
+	assistantCount int    // number of assistant lines to emit
+	result         string // result line (resultLine, maxTurnsResultLine, or errorResultLine)
+}
+
+// persistentProc simulates a persistent Claude process that stays alive across turns.
+// SendTurn triggers the next pre-configured turn output. GracefulShutdown exits.
+type persistentProc struct {
+	proc       *managed.Process
+	pw         *io.PipeWriter
+	triggerCh  chan struct{} // SendTurn signals this to produce next turn
+	shutdownCh chan struct{} // GracefulShutdown signals this to exit
+}
+
+func newPersistentProc(turns []turnSpec) *persistentProc {
 	proc, pw := makeProcess()
-	interruptCh := make(chan struct{})
+	pp := &persistentProc{
+		proc:       proc,
+		pw:         pw,
+		triggerCh:  make(chan struct{}, 10),
+		shutdownCh: make(chan struct{}),
+	}
 
 	go func() {
 		defer func() {
 			pw.Close()
-			proc.ExitCode = exitCode
+			proc.ExitCode = 0
 			close(proc.Done)
 		}()
-		for i := 0; i < numTurns; i++ {
+		turnIdx := 0
+		for {
 			select {
-			case <-interruptCh:
+			case <-pp.shutdownCh:
 				return
-			default:
+			case <-pp.triggerCh:
+				if turnIdx >= len(turns) {
+					// No more turns configured, just emit a natural result
+					writeLine(pw, resultLine)
+					time.Sleep(20 * time.Millisecond)
+					continue
+				}
+				turn := turns[turnIdx]
+				turnIdx++
+				for i := 0; i < turn.assistantCount; i++ {
+					writeLine(pw, assistantLine)
+					time.Sleep(10 * time.Millisecond)
+				}
+				writeLine(pw, turn.result)
+				time.Sleep(20 * time.Millisecond)
 			}
-			writeLine(pw, assistantLine)
-			// Give StreamNDJSON time to process
-			select {
-			case <-interruptCh:
-				return
-			case <-time.After(15 * time.Millisecond):
-			}
-		}
-		writeLine(pw, resultLine)
-		// Give StreamNDJSON time to process result
-		select {
-		case <-interruptCh:
-			return
-		case <-time.After(50 * time.Millisecond):
 		}
 	}()
 
-	return proc, interruptCh
+	return pp
 }
 
-// interruptCloser is a helper that safely closes the most recent interrupt channel.
-type interruptCloser struct {
-	mu   sync.Mutex
-	chs  []chan struct{}
-}
+// --- Auto-Continue Tests (persistent process model) ---
 
-func (ic *interruptCloser) add(ch chan struct{}) {
-	ic.mu.Lock()
-	defer ic.mu.Unlock()
-	ic.chs = append(ic.chs, ch)
-}
-
-func (ic *interruptCloser) closeLast() {
-	ic.mu.Lock()
-	defer ic.mu.Unlock()
-	if len(ic.chs) > 0 {
-		ch := ic.chs[len(ic.chs)-1]
-		select {
-		case <-ch: // already closed
-		default:
-			close(ch)
-		}
-	}
-}
-
-// --- Auto-Continue Core Loop Tests ---
-
-func TestAutoContinue_HappyPath(t *testing.T) {
+// TestNaturalCompletion_NoAutoContinue verifies that when Claude finishes
+// naturally (subtype "success"), no auto-continue is triggered even if
+// max_continuations > 0.
+func TestNaturalCompletion_NoAutoContinue(t *testing.T) {
 	old := managed.HeartbeatInterval
 	managed.HeartbeatInterval = 100 * time.Millisecond
 	defer func() { managed.HeartbeatInterval = old }()
 
 	ts, store, mock := setupMockTestServer(t)
-	// maxTurns=5, threshold=0.8 → trigger at turn 4
-	sess, _ := store.CreateManagedSession("/tmp/test-ac-happy", `["Bash"]`, 5, 5.0, 0)
+	sess, _ := store.CreateManagedSession("/tmp/test-nat-no-ac", `["Bash"]`, 50, 5.0, 0)
 
-	var ensureCount int32
-	ic := &interruptCloser{}
+	pp := newPersistentProc([]turnSpec{
+		{assistantCount: 3, result: resultLine}, // Natural completion (success)
+	})
 
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call == 1 {
-			proc, ich := interruptableProcess(5, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		// Second process: 2 turns, exits normally
-		proc, ich := interruptableProcess(2, 0)
-		ic.add(ich)
-		return proc, nil
+		return pp.proc, nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnSendTurn = func(sessionID, msg string) error {
+		pp.triggerCh <- struct{}{}
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		close(pp.shutdownCh)
+		return nil
+	}
+
+	broadcaster := mock.GetBroadcaster(sess.ID)
+	broadcastsCh := make(chan []string, 1)
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 10*time.Second) }()
+
+	resp, _ := sendMessage(ts, sess.ID, "What framework should I use?")
+	resp.Body.Close()
+
+	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
+
+	msgs := <-broadcastsCh
+	if hasEvent(msgs, "auto_continuing") {
+		t.Error("should NOT auto-continue when Claude finishes naturally")
+	}
+	if !hasEvent(msgs, "done") {
+		t.Error("missing done event")
+	}
+}
+
+// TestMaxTurnsHit_AutoContinues verifies that when Claude hits --max-turns
+// (subtype "error_max_turns"), auto-continue triggers and sends a continuation.
+func TestMaxTurnsHit_AutoContinues(t *testing.T) {
+	old := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 100 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = old }()
+
+	ts, store, mock := setupMockTestServer(t)
+	sess, _ := store.CreateManagedSession("/tmp/test-maxturns-ac", `["Bash"]`, 50, 5.0, 0)
+
+	pp := newPersistentProc([]turnSpec{
+		{assistantCount: 5, result: maxTurnsResultLine}, // Hit max_turns → auto-continue
+		{assistantCount: 2, result: resultLine},          // Natural completion → stop
+	})
+
+	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
+		return pp.proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error {
+		pp.triggerCh <- struct{}{}
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		close(pp.shutdownCh)
+		return nil
+	}
 
 	broadcaster := mock.GetBroadcaster(sess.ID)
 	broadcastsCh := make(chan []string, 1)
 	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 15*time.Second) }()
 
-	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp, _ := sendMessage(ts, sess.ID, "Build a feature")
 	resp.Body.Close()
 
 	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
 
-	if got := atomic.LoadInt32(&ensureCount); got != 2 {
-		t.Errorf("EnsureProcess called %d times, want 2", got)
-	}
-
 	msgs := <-broadcastsCh
 	if !hasEvent(msgs, "auto_continuing") {
-		t.Error("missing auto_continuing SSE event")
+		t.Error("missing auto_continuing event — should auto-continue on max_turns")
 	}
 	if !hasEvent(msgs, "done") {
-		t.Error("missing done SSE event")
+		t.Error("missing done event")
 	}
 	evt := getEvent(msgs, "auto_continuing")
 	if evt != nil && int(evt["continuation_count"].(float64)) != 1 {
@@ -231,81 +267,49 @@ func TestAutoContinue_HappyPath(t *testing.T) {
 	}
 }
 
-func TestAutoContinue_MultipleContinuations(t *testing.T) {
-	old := managed.HeartbeatInterval
-	managed.HeartbeatInterval = 100 * time.Millisecond
-	defer func() { managed.HeartbeatInterval = old }()
-
-	ts, store, mock := setupMockTestServer(t)
-	// maxTurns=3, threshold=0.8 → trigger at 2
-	sess, _ := store.CreateManagedSession("/tmp/test-ac-multi", `["Bash"]`, 3, 5.0, 0)
-
-	var ensureCount int32
-	ic := &interruptCloser{}
-
-	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call <= 3 {
-			proc, ich := interruptableProcess(3, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		// Process 4: 1 turn, exits normally
-		proc, ich := interruptableProcess(1, 0)
-		ic.add(ich)
-		return proc, nil
-	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
-
-	broadcaster := mock.GetBroadcaster(sess.ID)
-	broadcastsCh := make(chan []string, 1)
-	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 25*time.Second) }()
-
-	resp, _ := sendMessage(ts, sess.ID, "hello")
-	resp.Body.Close()
-
-	pollActivityState(t, store, sess.ID, "waiting", 25*time.Second)
-
-	msgs := <-broadcastsCh
-	if c := countEvents(msgs, "auto_continuing"); c < 3 {
-		t.Errorf("got %d auto_continuing events, want >= 3", c)
-	}
-}
-
+// TestAutoContinue_Exhaustion verifies that auto-continue stops after
+// max_continuations is reached.
 func TestAutoContinue_Exhaustion(t *testing.T) {
 	old := managed.HeartbeatInterval
 	managed.HeartbeatInterval = 100 * time.Millisecond
 	defer func() { managed.HeartbeatInterval = old }()
 
 	ts, store, mock := setupMockTestServer(t)
-	// maxTurns=5, threshold=0.8 → trigger at 4. Default maxContinuations=5.
-	sess, _ := store.CreateManagedSession("/tmp/test-ac-exhaust", `["Bash"]`, 5, 5.0, 0)
+	// max_continuations defaults to 5
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-exhaust", `["Bash"]`, 50, 5.0, 0)
 
-	ic := &interruptCloser{}
+	// All turns hit max_turns — should exhaust after 5 continuations
+	turns := make([]turnSpec, 7)
+	for i := range turns {
+		turns[i] = turnSpec{assistantCount: 3, result: maxTurnsResultLine}
+	}
+
+	pp := newPersistentProc(turns)
 
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		proc, ich := interruptableProcess(5, 0)
-		ic.add(ich)
-		return proc, nil
+		return pp.proc, nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnSendTurn = func(sessionID, msg string) error {
+		pp.triggerCh <- struct{}{}
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		close(pp.shutdownCh)
+		return nil
+	}
 
 	broadcaster := mock.GetBroadcaster(sess.ID)
 	broadcastsCh := make(chan []string, 1)
-	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 45*time.Second) }()
+	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 30*time.Second) }()
 
-	resp, _ := sendMessage(ts, sess.ID, "hello")
+	resp, _ := sendMessage(ts, sess.ID, "Build everything")
 	resp.Body.Close()
 
-	pollActivityState(t, store, sess.ID, "waiting", 45*time.Second)
+	pollActivityState(t, store, sess.ID, "waiting", 30*time.Second)
 
 	msgs := <-broadcastsCh
 	if !hasEvent(msgs, "auto_continue_exhausted") {
-		t.Error("missing auto_continue_exhausted SSE event")
+		t.Error("missing auto_continue_exhausted event")
 	}
 	evt := getEvent(msgs, "auto_continue_exhausted")
 	if evt != nil {
@@ -315,36 +319,32 @@ func TestAutoContinue_Exhaustion(t *testing.T) {
 	}
 }
 
+// TestAutoContinue_NoProgress verifies that auto-continue stops when
+// Claude makes no progress (< 2 assistant events on a continuation turn).
 func TestAutoContinue_NoProgress(t *testing.T) {
 	old := managed.HeartbeatInterval
 	managed.HeartbeatInterval = 100 * time.Millisecond
 	defer func() { managed.HeartbeatInterval = old }()
 
 	ts, store, mock := setupMockTestServer(t)
-	// maxTurns=2, threshold=0.8 → floor(0.8*2)=1 → trigger at 1 assistant turn.
-	// First process: 2 turns (>=2, passes progress check).
-	// Second process: 1 turn (triggers at 1, but turnsSinceLastContinue=1 < 2 → no progress).
-	sess, _ := store.CreateManagedSession("/tmp/test-ac-noprog", `["Bash"]`, 2, 5.0, 0)
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-noprog", `["Bash"]`, 50, 5.0, 0)
 
-	var ensureCount int32
-	ic := &interruptCloser{}
+	pp := newPersistentProc([]turnSpec{
+		{assistantCount: 5, result: maxTurnsResultLine}, // First turn: hit max_turns, good progress
+		{assistantCount: 1, result: maxTurnsResultLine}, // Second turn: only 1 event → no progress
+	})
 
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call == 1 {
-			// 3 turns: threshold fires at 1, turnsSinceLastContinue=3 >= 2 → continues
-			proc, ich := interruptableProcess(3, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		// Second: 1 turn, threshold fires at 1, turnsSinceLastContinue=1 < 2 → no progress
-		proc, ich := interruptableProcess(1, 0)
-		ic.add(ich)
-		return proc, nil
+		return pp.proc, nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnSendTurn = func(sessionID, msg string) error {
+		pp.triggerCh <- struct{}{}
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		close(pp.shutdownCh)
+		return nil
+	}
 
 	broadcaster := mock.GetBroadcaster(sess.ID)
 	broadcastsCh := make(chan []string, 1)
@@ -365,37 +365,35 @@ func TestAutoContinue_NoProgress(t *testing.T) {
 	}
 }
 
+// TestAutoContinue_ExecutionError verifies that execution errors don't
+// trigger auto-continue.
 func TestAutoContinue_ExecutionError(t *testing.T) {
 	old := managed.HeartbeatInterval
 	managed.HeartbeatInterval = 100 * time.Millisecond
 	defer func() { managed.HeartbeatInterval = old }()
 
 	ts, store, mock := setupMockTestServer(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-ac-err", `["Bash"]`, 5, 5.0, 0)
+	sess, _ := store.CreateManagedSession("/tmp/test-ac-err", `["Bash"]`, 50, 5.0, 0)
+
+	pp := newPersistentProc([]turnSpec{
+		{assistantCount: 1, result: errorResultLine},
+	})
 
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		proc, pw := makeProcess()
-		go func() {
-			writeLine(pw, assistantLine)
-			time.Sleep(15 * time.Millisecond)
-			writeLine(pw, errorResultLine)
-			time.Sleep(50 * time.Millisecond)
-			pw.Close()
-			proc.ExitCode = 1
-			close(proc.Done)
-		}()
-		return proc, nil
+		return pp.proc, nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnSendTurn = func(sessionID, msg string) error {
+		pp.triggerCh <- struct{}{}
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		close(pp.shutdownCh)
+		return nil
+	}
 
 	resp, _ := sendMessage(ts, sess.ID, "hello")
 	resp.Body.Close()
 
-	// Execution errors with a natural exit (turnDone fires, process still alive)
-	// go through the GracefulShutdown path → "waiting". The executionErrored flag
-	// prevents auto-continue but doesn't change the normal exit state.
 	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
 
 	dbMsgs, _ := store.ListMessages(sess.ID)
@@ -410,50 +408,9 @@ func TestAutoContinue_ExecutionError(t *testing.T) {
 	}
 }
 
-// --- Manual Interrupt Tests ---
-
-func TestManualInterrupt_NaturalExit(t *testing.T) {
-	old := managed.HeartbeatInterval
-	managed.HeartbeatInterval = 100 * time.Millisecond
-	defer func() { managed.HeartbeatInterval = old }()
-
-	ts, store, mock := setupMockTestServer(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-nat-exit", `["Bash"]`, 50, 5.0, 0)
-
-	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		proc, pw := makeProcess()
-		go func() {
-			writeLine(pw, assistantLine)
-			time.Sleep(15 * time.Millisecond)
-			writeLine(pw, assistantLine)
-			time.Sleep(15 * time.Millisecond)
-			writeLine(pw, resultLine)
-			time.Sleep(50 * time.Millisecond)
-			pw.Close()
-			proc.ExitCode = 0
-			close(proc.Done)
-		}()
-		return proc, nil
-	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
-
-	broadcaster := mock.GetBroadcaster(sess.ID)
-	broadcastsCh := make(chan []string, 1)
-	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 10*time.Second) }()
-
-	resp, _ := sendMessage(ts, sess.ID, "hello")
-	resp.Body.Close()
-
-	pollActivityState(t, store, sess.ID, "waiting", 10*time.Second)
-
-	msgs := <-broadcastsCh
-	if hasEvent(msgs, "auto_continuing") {
-		t.Error("should not have auto_continuing event for natural exit")
-	}
-}
-
-func TestManualInterrupt_ProcessDeath(t *testing.T) {
+// TestProcessDeath_NoAutoContinue verifies that unexpected process death
+// (non-zero exit) doesn't trigger auto-continue.
+func TestProcessDeath_NoAutoContinue(t *testing.T) {
 	old := managed.HeartbeatInterval
 	managed.HeartbeatInterval = 100 * time.Millisecond
 	defer func() { managed.HeartbeatInterval = old }()
@@ -461,12 +418,12 @@ func TestManualInterrupt_ProcessDeath(t *testing.T) {
 	ts, store, mock := setupMockTestServer(t)
 	sess, _ := store.CreateManagedSession("/tmp/test-proc-death", `["Bash"]`, 50, 5.0, 0)
 
+	proc, pw := makeProcess()
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		proc, pw := makeProcess()
+		// Simulate process crash after one assistant line
 		go func() {
 			writeLine(pw, assistantLine)
 			time.Sleep(15 * time.Millisecond)
-			// Process crashes without emitting result — simulates unexpected death
 			pw.Close()
 			proc.ExitCode = 1
 			close(proc.Done)
@@ -494,143 +451,6 @@ func TestManualInterrupt_ProcessDeath(t *testing.T) {
 	}
 }
 
-// --- Compact Integration Tests ---
-
-func TestCompact_RunsAtInterval(t *testing.T) {
-	old := managed.HeartbeatInterval
-	managed.HeartbeatInterval = 100 * time.Millisecond
-	defer func() { managed.HeartbeatInterval = old }()
-
-	ts, store, mock := setupMockTestServer(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-compact-int", `["Bash"]`, 3, 5.0, 1)
-
-	var compactCalls int32
-	var ensureCount int32
-	ic := &interruptCloser{}
-
-	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call == 1 {
-			proc, ich := interruptableProcess(3, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		proc, ich := interruptableProcess(1, 0)
-		ic.add(ich)
-		return proc, nil
-	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
-	mock.OnRunCompact = func(sessionID, resumeID, cwd string, timeout time.Duration) error {
-		atomic.AddInt32(&compactCalls, 1)
-		return nil
-	}
-
-	resp, _ := sendMessage(ts, sess.ID, "hello")
-	resp.Body.Close()
-
-	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
-
-	if got := atomic.LoadInt32(&compactCalls); got < 1 {
-		t.Errorf("RunCompact called %d times, want >= 1", got)
-	}
-}
-
-func TestCompact_FailureContinues(t *testing.T) {
-	old := managed.HeartbeatInterval
-	managed.HeartbeatInterval = 100 * time.Millisecond
-	defer func() { managed.HeartbeatInterval = old }()
-
-	ts, store, mock := setupMockTestServer(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-compact-fail", `["Bash"]`, 3, 5.0, 1)
-
-	var ensureCount int32
-	ic := &interruptCloser{}
-
-	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call == 1 {
-			proc, ich := interruptableProcess(3, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		proc, ich := interruptableProcess(1, 0)
-		ic.add(ich)
-		return proc, nil
-	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
-	mock.OnRunCompact = func(sessionID, resumeID, cwd string, timeout time.Duration) error {
-		return fmt.Errorf("compact failed: out of memory")
-	}
-
-	resp, _ := sendMessage(ts, sess.ID, "hello")
-	resp.Body.Close()
-
-	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
-
-	dbMsgs, _ := store.ListMessages(sess.ID)
-	var found bool
-	for _, m := range dbMsgs {
-		if m.Role == "system" && strings.Contains(m.Content, "Compact failed") {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("missing compact failure warning message")
-	}
-	if got := atomic.LoadInt32(&ensureCount); got < 2 {
-		t.Errorf("EnsureProcess called %d times, want >= 2", got)
-	}
-}
-
-func TestCompact_SSEEvents(t *testing.T) {
-	old := managed.HeartbeatInterval
-	managed.HeartbeatInterval = 100 * time.Millisecond
-	defer func() { managed.HeartbeatInterval = old }()
-
-	ts, store, mock := setupMockTestServer(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-compact-sse", `["Bash"]`, 3, 5.0, 1)
-
-	var ensureCount int32
-	ic := &interruptCloser{}
-
-	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call == 1 {
-			proc, ich := interruptableProcess(3, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		proc, ich := interruptableProcess(1, 0)
-		ic.add(ich)
-		return proc, nil
-	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
-	mock.OnRunCompact = func(sessionID, resumeID, cwd string, timeout time.Duration) error { return nil }
-
-	broadcaster := mock.GetBroadcaster(sess.ID)
-	broadcastsCh := make(chan []string, 1)
-	go func() { broadcastsCh <- collectBroadcasts(broadcaster, 15*time.Second) }()
-
-	resp, _ := sendMessage(ts, sess.ID, "hello")
-	resp.Body.Close()
-
-	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
-
-	msgs := <-broadcastsCh
-	if !hasEvent(msgs, "compacting") {
-		t.Error("missing compacting SSE event")
-	}
-	if !hasEvent(msgs, "compact_complete") {
-		t.Error("missing compact_complete SSE event")
-	}
-}
-
 // --- Message Persistence Tests ---
 
 func TestPersistence_AssistantText(t *testing.T) {
@@ -641,23 +461,29 @@ func TestPersistence_AssistantText(t *testing.T) {
 	ts, store, mock := setupMockTestServer(t)
 	sess, _ := store.CreateManagedSession("/tmp/test-persist-text", `["Bash"]`, 50, 5.0, 0)
 
+	proc, pw := makeProcess()
+	var shutdownOnce sync.Once
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		proc, pw := makeProcess()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error {
 		go func() {
 			writeLine(pw, `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"First response"}]}}`)
 			time.Sleep(15 * time.Millisecond)
 			writeLine(pw, `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Second response"}]}}`)
 			time.Sleep(15 * time.Millisecond)
 			writeLine(pw, resultLine)
-			time.Sleep(50 * time.Millisecond)
+		}()
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		shutdownOnce.Do(func() {
 			pw.Close()
 			proc.ExitCode = 0
 			close(proc.Done)
-		}()
-		return proc, nil
+		})
+		return nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
 
 	resp, _ := sendMessage(ts, sess.ID, "hello")
 	resp.Body.Close()
@@ -688,25 +514,24 @@ func TestPersistence_SystemMessages(t *testing.T) {
 	defer func() { managed.HeartbeatInterval = old }()
 
 	ts, store, mock := setupMockTestServer(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-persist-sys", `["Bash"]`, 5, 5.0, 0)
+	sess, _ := store.CreateManagedSession("/tmp/test-persist-sys", `["Bash"]`, 50, 5.0, 0)
 
-	var ensureCount int32
-	ic := &interruptCloser{}
+	pp := newPersistentProc([]turnSpec{
+		{assistantCount: 5, result: maxTurnsResultLine}, // Hit max_turns
+		{assistantCount: 2, result: resultLine},          // Natural completion
+	})
 
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call == 1 {
-			proc, ich := interruptableProcess(5, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		proc, ich := interruptableProcess(1, 0)
-		ic.add(ich)
-		return proc, nil
+		return pp.proc, nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnSendTurn = func(sessionID, msg string) error {
+		pp.triggerCh <- struct{}{}
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		close(pp.shutdownCh)
+		return nil
+	}
 
 	resp, _ := sendMessage(ts, sess.ID, "hello")
 	resp.Body.Close()
@@ -733,21 +558,27 @@ func TestPersistence_ToolActivity(t *testing.T) {
 	ts, store, mock := setupMockTestServer(t)
 	sess, _ := store.CreateManagedSession("/tmp/test-persist-tool", `["Bash"]`, 50, 5.0, 0)
 
+	proc, pw := makeProcess()
+	var shutdownOnce sync.Once
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		proc, pw := makeProcess()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error {
 		go func() {
 			writeLine(pw, toolUseLine)
 			time.Sleep(15 * time.Millisecond)
 			writeLine(pw, resultLine)
-			time.Sleep(50 * time.Millisecond)
+		}()
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		shutdownOnce.Do(func() {
 			pw.Close()
 			proc.ExitCode = 0
 			close(proc.Done)
-		}()
-		return proc, nil
+		})
+		return nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
 
 	resp, _ := sendMessage(ts, sess.ID, "hello")
 	resp.Body.Close()
@@ -776,21 +607,27 @@ func TestSSE_DoneEvent(t *testing.T) {
 	ts, store, mock := setupMockTestServer(t)
 	sess, _ := store.CreateManagedSession("/tmp/test-sse-done", `["Bash"]`, 50, 5.0, 0)
 
+	proc, pw := makeProcess()
+	var shutdownOnce sync.Once
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		proc, pw := makeProcess()
+		return proc, nil
+	}
+	mock.OnSendTurn = func(sessionID, msg string) error {
 		go func() {
 			writeLine(pw, assistantLine)
 			time.Sleep(15 * time.Millisecond)
 			writeLine(pw, resultLine)
-			time.Sleep(50 * time.Millisecond)
+		}()
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		shutdownOnce.Do(func() {
 			pw.Close()
 			proc.ExitCode = 0
 			close(proc.Done)
-		}()
-		return proc, nil
+		})
+		return nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
 
 	broadcaster := mock.GetBroadcaster(sess.ID)
 	broadcastsCh := make(chan []string, 1)
@@ -811,31 +648,38 @@ func TestSSE_DoneEvent(t *testing.T) {
 	}
 }
 
-func TestSSE_HeartbeatBetweenProcesses(t *testing.T) {
+// --- Compact Integration Tests ---
+
+func TestCompact_RunsAtInterval(t *testing.T) {
 	old := managed.HeartbeatInterval
 	managed.HeartbeatInterval = 100 * time.Millisecond
 	defer func() { managed.HeartbeatInterval = old }()
 
 	ts, store, mock := setupMockTestServer(t)
-	sess, _ := store.CreateManagedSession("/tmp/test-sse-hb", `["Bash"]`, 5, 5.0, 0)
+	sess, _ := store.CreateManagedSession("/tmp/test-compact-int", `["Bash"]`, 50, 5.0, 1)
 
-	var ensureCount int32
-	ic := &interruptCloser{}
+	// Turn 1: max_turns (triggers auto-continue)
+	// Turn 2 (/compact): emits result (compact turn)
+	// Turn 3 (continuation): natural completion
+	pp := newPersistentProc([]turnSpec{
+		{assistantCount: 3, result: maxTurnsResultLine}, // User turn → max_turns
+		{assistantCount: 0, result: resultLine},          // /compact turn
+		{assistantCount: 2, result: resultLine},          // Continuation → natural end
+	})
 
+	var sendCount int32
 	mock.OnEnsureProcess = func(sessionID string, opts managed.SpawnOpts) (*managed.Process, error) {
-		call := atomic.AddInt32(&ensureCount, 1)
-		if call == 1 {
-			proc, ich := interruptableProcess(5, 0)
-			ic.add(ich)
-			return proc, nil
-		}
-		proc, ich := interruptableProcess(1, 0)
-		ic.add(ich)
-		return proc, nil
+		return pp.proc, nil
 	}
-	mock.OnSendTurn = func(sessionID, msg string) error { return nil }
-	mock.OnInterrupt = func(sessionID string) error { ic.closeLast(); return nil }
-	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error { return nil }
+	mock.OnSendTurn = func(sessionID, msg string) error {
+		atomic.AddInt32(&sendCount, 1)
+		pp.triggerCh <- struct{}{}
+		return nil
+	}
+	mock.OnGracefulShutdown = func(sessionID string, timeout time.Duration) error {
+		close(pp.shutdownCh)
+		return nil
+	}
 
 	broadcaster := mock.GetBroadcaster(sess.ID)
 	broadcastsCh := make(chan []string, 1)
@@ -847,7 +691,10 @@ func TestSSE_HeartbeatBetweenProcesses(t *testing.T) {
 	pollActivityState(t, store, sess.ID, "waiting", 15*time.Second)
 
 	msgs := <-broadcastsCh
-	if !hasEvent(msgs, "heartbeat") {
-		t.Error("missing heartbeat SSE event between process cycles")
+	if !hasEvent(msgs, "compacting") {
+		t.Error("missing compacting SSE event")
+	}
+	if !hasEvent(msgs, "compact_complete") {
+		t.Error("missing compact_complete SSE event")
 	}
 }

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -225,6 +225,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		var mu sync.Mutex
 		var assistantEventCount int
 		var executionErrored bool
+		var hitMaxTurns bool
 
 		// turnDone is signaled by StreamNDJSON on each "result" message.
 		// Buffered so the signal isn't lost if we're between select calls.
@@ -245,13 +246,20 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 					IsError bool     `json:"is_error"`
 					Errors  []string `json:"errors"`
 				}
-				if json.Unmarshal([]byte(line), &res) == nil && res.Subtype == "error_during_execution" {
-					mu.Lock()
-					executionErrored = true
-					mu.Unlock()
-					if len(res.Errors) > 0 {
-						errText := strings.Join(res.Errors, "; ")
-						_, _ = s.store.CreateMessage(sessionID, "assistant", errText)
+				if json.Unmarshal([]byte(line), &res) == nil {
+					if res.Subtype == "error_during_execution" {
+						mu.Lock()
+						executionErrored = true
+						mu.Unlock()
+						if len(res.Errors) > 0 {
+							errText := strings.Join(res.Errors, "; ")
+							_, _ = s.store.CreateMessage(sessionID, "assistant", errText)
+						}
+					}
+					if res.Subtype == "error_max_turns" {
+						mu.Lock()
+						hitMaxTurns = true
+						mu.Unlock()
 					}
 				}
 			}
@@ -289,6 +297,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			assistantEventCount = 0
 			executionErrored = false
+			hitMaxTurns = false
 			mu.Unlock()
 
 			// Drain any stale turnDone signals from previous turns
@@ -353,6 +362,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			errored := executionErrored
 			events := assistantEventCount
+			reachedMaxTurns := hitMaxTurns
 			mu.Unlock()
 
 			if !sess.Initialized && !errored {
@@ -396,8 +406,20 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 			// --- Auto-continue decision ---
 			// The process is still alive. Claude completed a turn (hit --max-turns
-			// or finished naturally). If auto-continuations are configured, we
-			// continue by sending another message via stdin on the warm process.
+			// or finished naturally). Only auto-continue when Claude was interrupted
+			// by --max-turns (subtype "error_max_turns"). If Claude finished
+			// naturally (subtype "success"), it may be asking for user input —
+			// don't auto-continue in that case.
+
+			if !reachedMaxTurns {
+				log.Printf("session %s: Claude finished naturally (not max_turns), waiting for user input", sessionID)
+				_ = s.manager.GracefulShutdown(sessionID, 10*time.Second)
+				<-streamDone
+				_ = s.store.UpdateActivityState(sessionID, "waiting")
+				doneMsg := fmt.Sprintf(`{"type":"done","exit_code":%d}`, 0)
+				broadcaster.Send(doneMsg)
+				return
+			}
 
 			// First turn (user's original message) — if max_continuations is 0, just finish
 			if continuationCount == 0 && sess.MaxContinuations <= 0 {

--- a/server/api/mock_manager_test.go
+++ b/server/api/mock_manager_test.go
@@ -13,6 +13,7 @@ import (
 
 const assistantLine = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}]}}`
 const resultLine = `{"type":"result","subtype":"success","cost":0.01}`
+const maxTurnsResultLine = `{"type":"result","subtype":"error_max_turns","cost":0.01}`
 const errorResultLine = `{"type":"result","subtype":"error_during_execution","is_error":true,"errors":["something failed"]}`
 const toolUseLine = `{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/tmp/test.go"}}]}}`
 

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -24,6 +24,11 @@ type settingsPayload struct {
 	ClaudeEnv              string     `json:"claude_env"`
 	CompactEveryNContinues string     `json:"compact_every_n_continues"`
 	GithubToken            string     `json:"github_token"`
+	JiraURL                string     `json:"jira_url"`
+	JiraToken              string     `json:"jira_token"`
+	JiraEmail              string     `json:"jira_email"`
+	AsanaToken             string     `json:"asana_token"`
+	GoogleTasksToken       string     `json:"google_tasks_token"`
 	Shortcuts              []Shortcut `json:"shortcuts"`
 }
 
@@ -64,7 +69,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	vals := readEnvFile(s.envPath)
 
 	// Mask secrets
-	for _, key := range []string{"NGROK_AUTHTOKEN", "GITHUB_TOKEN"} {
+	for _, key := range []string{"NGROK_AUTHTOKEN", "GITHUB_TOKEN", "JIRA_TOKEN", "ASANA_TOKEN", "GOOGLE_TASKS_TOKEN"} {
 		if tok := vals[key]; len(tok) > 4 {
 			vals[key] = "****" + tok[len(tok)-4:]
 		} else if tok != "" {
@@ -80,6 +85,11 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		ClaudeEnv:              vals["CLAUDE_ENV"],
 		CompactEveryNContinues: vals["COMPACT_EVERY_N_CONTINUES"],
 		GithubToken:            vals["GITHUB_TOKEN"],
+		JiraURL:                vals["JIRA_URL"],
+		JiraToken:              vals["JIRA_TOKEN"],
+		JiraEmail:              vals["JIRA_EMAIL"],
+		AsanaToken:             vals["ASANA_TOKEN"],
+		GoogleTasksToken:       vals["GOOGLE_TASKS_TOKEN"],
 	}
 	resp.Shortcuts = readShortcuts(s.envPath)
 	w.Header().Set("Content-Type", "application/json")
@@ -111,6 +121,15 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.HasPrefix(payload.GithubToken, "****") {
 		payload.GithubToken = current["GITHUB_TOKEN"]
+	}
+	if strings.HasPrefix(payload.JiraToken, "****") {
+		payload.JiraToken = current["JIRA_TOKEN"]
+	}
+	if strings.HasPrefix(payload.AsanaToken, "****") {
+		payload.AsanaToken = current["ASANA_TOKEN"]
+	}
+	if strings.HasPrefix(payload.GoogleTasksToken, "****") {
+		payload.GoogleTasksToken = current["GOOGLE_TASKS_TOKEN"]
 	}
 
 	// Check if restart-requiring fields changed
@@ -197,6 +216,24 @@ func formatEnvFile(p settingsPayload) string {
 	b.WriteString("\n# GitHub\n")
 	if p.GithubToken != "" {
 		b.WriteString("GITHUB_TOKEN=" + p.GithubToken + "\n")
+	}
+	b.WriteString("\n# Jira\n")
+	if p.JiraURL != "" {
+		b.WriteString("JIRA_URL=" + p.JiraURL + "\n")
+	}
+	if p.JiraToken != "" {
+		b.WriteString("JIRA_TOKEN=" + p.JiraToken + "\n")
+	}
+	if p.JiraEmail != "" {
+		b.WriteString("JIRA_EMAIL=" + p.JiraEmail + "\n")
+	}
+	b.WriteString("\n# Asana\n")
+	if p.AsanaToken != "" {
+		b.WriteString("ASANA_TOKEN=" + p.AsanaToken + "\n")
+	}
+	b.WriteString("\n# Google Tasks\n")
+	if p.GoogleTasksToken != "" {
+		b.WriteString("GOOGLE_TASKS_TOKEN=" + p.GoogleTasksToken + "\n")
 	}
 	return b.String()
 }

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -61,6 +61,9 @@ document.addEventListener('alpine:init', () => {
     fileTreeData: [],
     gitInfo: null,
 
+    // Issues provider tabs
+    issuesProvider: 'github', // 'github' | 'jira' | 'asana' | 'google_tasks'
+
     // GitHub Issues state
     githubRepo: null,
     githubIssues: [],
@@ -121,7 +124,7 @@ document.addEventListener('alpine:init', () => {
     // Settings state
     showSettingsModal: false,
     settingsFirstRun: false,
-    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', github_token: '', shortcuts: [] },
+    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] },
     settingsError: '',
     settingsSaving: false,
     settingsRestartRequired: false,
@@ -130,7 +133,7 @@ document.addEventListener('alpine:init', () => {
     // Shortcuts state
     shortcuts: [],
     showShortcutPicker: false,
-    settingsAccordion: { server: false, shortcuts: false },
+    settingsAccordion: { server: false, integrations: false, shortcuts: false },
 
     // Usage tracking
     lastTurnThreshold: 0,
@@ -492,10 +495,15 @@ document.addEventListener('alpine:init', () => {
           claude_env: data.claude_env || '',
           compact_every_n_continues: data.compact_every_n_continues || '',
           github_token: data.github_token || '',
+          jira_url: data.jira_url || '',
+          jira_token: data.jira_token || '',
+          jira_email: data.jira_email || '',
+          asana_token: data.asana_token || '',
+          google_tasks_token: data.google_tasks_token || '',
           shortcuts: data.shortcuts || [],
         };
       } catch (e) {
-        this.settingsForm = { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', github_token: '', shortcuts: [] };
+        this.settingsForm = { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] };
       }
       this.showSettingsModal = true;
     },
@@ -527,6 +535,15 @@ document.addEventListener('alpine:init', () => {
         this.settingsError = 'Error: ' + e.message;
       }
       this.settingsSaving = false;
+    },
+
+    getConfiguredProviders() {
+      const providers = [];
+      if (this.settingsForm.github_token) providers.push('github');
+      if (this.settingsForm.jira_url && this.settingsForm.jira_token) providers.push('jira');
+      if (this.settingsForm.asana_token) providers.push('asana');
+      if (this.settingsForm.google_tasks_token) providers.push('google_tasks');
+      return providers;
     },
 
     async loadShortcuts() {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -525,8 +525,32 @@
           </div>
         </div>
 
+        <!-- Provider Tab Bar -->
+        <div class="provider-tab-bar" x-show="sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+          <button class="provider-tab" :class="{ active: issuesProvider === 'github' }"
+                  @click="issuesProvider = 'github'" title="GitHub"
+                  x-show="settingsForm.github_token">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          </button>
+          <button class="provider-tab" :class="{ active: issuesProvider === 'jira' }"
+                  @click="issuesProvider = 'jira'" title="Jira"
+                  x-show="settingsForm.jira_url && settingsForm.jira_token">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/><path d="M8 4.47a3.93 3.93 0 01-.01-5.56l-5.08 5.1 2.83 2.83L8 4.47z" fill="url(#jira-grad-a)"/><path d="M10.84 7.29L8 10.13a3.93 3.93 0 010 5.56l5.1-5.1-2.84-2.83-.42.53z" fill="url(#jira-grad-b)"/><defs><linearGradient id="jira-grad-a" x1="7.53" y1="2.56" x2="4.28" y2="5.62" gradientUnits="userSpaceOnUse"><stop stop-color="#0052CC" stop-opacity=".4"/><stop offset="1" stop-color="#2684FF"/></linearGradient><linearGradient id="jira-grad-b" x1="8.49" y1="10.05" x2="11.74" y2="6.99" gradientUnits="userSpaceOnUse"><stop stop-color="#0052CC" stop-opacity=".4"/><stop offset="1" stop-color="#2684FF"/></linearGradient></defs></svg>
+          </button>
+          <button class="provider-tab" :class="{ active: issuesProvider === 'asana' }"
+                  @click="issuesProvider = 'asana'" title="Asana"
+                  x-show="settingsForm.asana_token">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
+          </button>
+          <button class="provider-tab" :class="{ active: issuesProvider === 'google_tasks' }"
+                  @click="issuesProvider = 'google_tasks'" title="Google Tasks"
+                  x-show="settingsForm.google_tasks_token">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+          </button>
+        </div>
+
         <!-- GitHub Issues Section -->
-        <div class="issues-section" x-show="gitInfo && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+        <div class="issues-section" x-show="issuesProvider === 'github' && gitInfo && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
           <div class="issues-header" @click="issuesExpanded = !issuesExpanded" style="cursor:pointer">
             <span class="issues-title">
               <span class="issues-toggle" x-text="issuesExpanded ? '▼' : '▶'"></span>
@@ -567,7 +591,7 @@
         </div>
 
         <!-- GitHub Pull Requests Section -->
-        <div class="issues-section" x-show="gitInfo && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+        <div class="issues-section" x-show="issuesProvider === 'github' && gitInfo && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
           <div class="issues-header" @click="pullsExpanded = !pullsExpanded" style="cursor:pointer">
             <span class="issues-title">
               <span class="issues-toggle" x-text="pullsExpanded ? '▼' : '▶'"></span>
@@ -605,6 +629,34 @@
                     class="issues-show-more"
                     @click="loadMorePulls()">Show more</button>
           </div>
+        </div>
+
+        <!-- Jira Placeholder -->
+        <div class="issues-section provider-placeholder" x-show="issuesProvider === 'jira' && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+          <div class="provider-placeholder-icon">
+            <svg width="24" height="24" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/><path d="M8 4.47a3.93 3.93 0 01-.01-5.56l-5.08 5.1 2.83 2.83L8 4.47z" fill="#0052CC"/><path d="M10.84 7.29L8 10.13a3.93 3.93 0 010 5.56l5.1-5.1-2.84-2.83-.42.53z" fill="#0052CC"/></svg>
+          </div>
+          <div class="provider-placeholder-title">Connected to Jira</div>
+          <div class="provider-placeholder-url" x-text="settingsForm.jira_url"></div>
+          <div class="provider-placeholder-msg">Issue browsing coming in a future update</div>
+        </div>
+
+        <!-- Asana Placeholder -->
+        <div class="issues-section provider-placeholder" x-show="issuesProvider === 'asana' && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+          <div class="provider-placeholder-icon">
+            <svg width="24" height="24" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
+          </div>
+          <div class="provider-placeholder-title">Connected to Asana</div>
+          <div class="provider-placeholder-msg">Task browsing coming in a future update</div>
+        </div>
+
+        <!-- Google Tasks Placeholder -->
+        <div class="issues-section provider-placeholder" x-show="issuesProvider === 'google_tasks' && sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
+          <div class="provider-placeholder-icon">
+            <svg width="24" height="24" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+          </div>
+          <div class="provider-placeholder-title">Connected to Google Tasks</div>
+          <div class="provider-placeholder-msg">Task browsing coming in a future update</div>
         </div>
       </div>
     </div>
@@ -700,33 +752,88 @@
         </template>
         <template x-if="selectedSessionId">
           <div>
-            <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
-              <span style="font-weight:600;font-size:14px;">Issues</span>
-              <div class="issue-state-toggles" @click.stop>
-                <button class="issue-state-toggle" :class="{ 'active-open': githubIssuesState === 'open' }"
-                        @click="toggleIssueState('open')">Open</button>
-                <button class="issue-state-toggle" :class="{ 'active-closed': githubIssuesState === 'closed' }"
-                        @click="toggleIssueState('closed')">Closed</button>
-              </div>
+            <!-- Mobile Provider Tab Bar -->
+            <div class="provider-tab-bar" style="margin-bottom:8px;">
+              <button class="provider-tab" :class="{ active: issuesProvider === 'github' }"
+                      @click="issuesProvider = 'github'" title="GitHub"
+                      x-show="settingsForm.github_token">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+              </button>
+              <button class="provider-tab" :class="{ active: issuesProvider === 'jira' }"
+                      @click="issuesProvider = 'jira'" title="Jira"
+                      x-show="settingsForm.jira_url && settingsForm.jira_token">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/><path d="M8 4.47a3.93 3.93 0 01-.01-5.56l-5.08 5.1 2.83 2.83L8 4.47z" fill="#0052CC"/><path d="M10.84 7.29L8 10.13a3.93 3.93 0 010 5.56l5.1-5.1-2.84-2.83-.42.53z" fill="#0052CC"/></svg>
+              </button>
+              <button class="provider-tab" :class="{ active: issuesProvider === 'asana' }"
+                      @click="issuesProvider = 'asana'" title="Asana"
+                      x-show="settingsForm.asana_token">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
+              </button>
+              <button class="provider-tab" :class="{ active: issuesProvider === 'google_tasks' }"
+                      @click="issuesProvider = 'google_tasks'" title="Google Tasks"
+                      x-show="settingsForm.google_tasks_token">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+              </button>
             </div>
-            <input type="text" class="issues-search" placeholder="Search issues..."
-                   x-model="githubIssuesSearch" @input="searchIssues()">
-            <div x-show="githubIssuesLoading" class="issues-loading">Loading...</div>
-            <div x-show="!githubIssuesLoading && githubIssuesError" class="issues-error" x-text="githubIssuesError"></div>
-            <div x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length === 0" class="issues-empty">No issues found</div>
-            <div class="issue-list" x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length > 0">
-              <template x-for="issue in githubIssues" :key="issue.number">
-                <div class="issue-row" @click="fetchIssueDetail(selectedSessionId, issue.number)">
-                  <div class="issue-dot" :class="issue.state"></div>
-                  <div class="issue-row-content">
-                    <div class="issue-row-title" x-text="issue.title"></div>
-                    <div class="issue-row-meta" x-text="'#' + issue.number + ' &middot; ' + issueTimeAgo(issue.updated_at)"></div>
-                  </div>
+
+            <!-- GitHub Issues (mobile) -->
+            <div x-show="issuesProvider === 'github'">
+              <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+                <span style="font-weight:600;font-size:14px;">Issues</span>
+                <div class="issue-state-toggles" @click.stop>
+                  <button class="issue-state-toggle" :class="{ 'active-open': githubIssuesState === 'open' }"
+                          @click="toggleIssueState('open')">Open</button>
+                  <button class="issue-state-toggle" :class="{ 'active-closed': githubIssuesState === 'closed' }"
+                          @click="toggleIssueState('closed')">Closed</button>
                 </div>
-              </template>
+              </div>
+              <input type="text" class="issues-search" placeholder="Search issues..."
+                     x-model="githubIssuesSearch" @input="searchIssues()">
+              <div x-show="githubIssuesLoading" class="issues-loading">Loading...</div>
+              <div x-show="!githubIssuesLoading && githubIssuesError" class="issues-error" x-text="githubIssuesError"></div>
+              <div x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length === 0" class="issues-empty">No issues found</div>
+              <div class="issue-list" x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length > 0">
+                <template x-for="issue in githubIssues" :key="issue.number">
+                  <div class="issue-row" @click="fetchIssueDetail(selectedSessionId, issue.number)">
+                    <div class="issue-dot" :class="issue.state"></div>
+                    <div class="issue-row-content">
+                      <div class="issue-row-title" x-text="issue.title"></div>
+                      <div class="issue-row-meta" x-text="'#' + issue.number + ' &middot; ' + issueTimeAgo(issue.updated_at)"></div>
+                    </div>
+                  </div>
+                </template>
+              </div>
+              <button x-show="githubIssuesHasMore && !githubIssuesLoading"
+                      class="issues-show-more" @click="loadMoreIssues()">Show more</button>
             </div>
-            <button x-show="githubIssuesHasMore && !githubIssuesLoading"
-                    class="issues-show-more" @click="loadMoreIssues()">Show more</button>
+
+            <!-- Jira Placeholder (mobile) -->
+            <div class="provider-placeholder" x-show="issuesProvider === 'jira'">
+              <div class="provider-placeholder-icon">
+                <svg width="24" height="24" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/><path d="M8 4.47a3.93 3.93 0 01-.01-5.56l-5.08 5.1 2.83 2.83L8 4.47z" fill="#0052CC"/><path d="M10.84 7.29L8 10.13a3.93 3.93 0 010 5.56l5.1-5.1-2.84-2.83-.42.53z" fill="#0052CC"/></svg>
+              </div>
+              <div class="provider-placeholder-title">Connected to Jira</div>
+              <div class="provider-placeholder-url" x-text="settingsForm.jira_url"></div>
+              <div class="provider-placeholder-msg">Issue browsing coming in a future update</div>
+            </div>
+
+            <!-- Asana Placeholder (mobile) -->
+            <div class="provider-placeholder" x-show="issuesProvider === 'asana'">
+              <div class="provider-placeholder-icon">
+                <svg width="24" height="24" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
+              </div>
+              <div class="provider-placeholder-title">Connected to Asana</div>
+              <div class="provider-placeholder-msg">Task browsing coming in a future update</div>
+            </div>
+
+            <!-- Google Tasks Placeholder (mobile) -->
+            <div class="provider-placeholder" x-show="issuesProvider === 'google_tasks'">
+              <div class="provider-placeholder-icon">
+                <svg width="24" height="24" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+              </div>
+              <div class="provider-placeholder-title">Connected to Google Tasks</div>
+              <div class="provider-placeholder-msg">Task browsing coming in a future update</div>
+            </div>
           </div>
         </template>
       </div>
@@ -1172,6 +1279,65 @@
             <input x-model="settingsForm.github_token" type="password" placeholder="ghp_..."
                    style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
             <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Personal access token for GitHub issue tracking (needs repo scope)</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Integrations accordion -->
+      <div>
+        <div class="settings-accordion-header" @click="settingsAccordion.integrations = !settingsAccordion.integrations">
+          <h4>Integrations</h4>
+          <span class="settings-accordion-chevron" :class="{ open: settingsAccordion.integrations }">&#9654;</span>
+        </div>
+        <div class="settings-accordion-body" x-show="settingsAccordion.integrations">
+          <div style="font-size:12px; color:var(--text-muted); margin-bottom:8px;">
+            Connect project management tools to browse issues and tasks alongside GitHub.
+          </div>
+
+          <div style="border:1px solid var(--border); border-radius:8px; padding:12px; margin-bottom:12px;">
+            <div style="font-size:12px; font-weight:600; margin-bottom:8px; display:flex; align-items:center; gap:6px;">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/></svg>
+              Jira
+            </div>
+            <div>
+              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">BASE URL</label>
+              <input x-model="settingsForm.jira_url" type="text" placeholder="https://yourorg.atlassian.net"
+                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box; margin-bottom:6px;">
+            </div>
+            <div>
+              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">API TOKEN</label>
+              <input x-model="settingsForm.jira_token" type="password" placeholder="Jira API token"
+                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box; margin-bottom:6px;">
+            </div>
+            <div>
+              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">EMAIL</label>
+              <input x-model="settingsForm.jira_email" type="email" placeholder="you@company.com"
+                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box;">
+            </div>
+          </div>
+
+          <div style="border:1px solid var(--border); border-radius:8px; padding:12px; margin-bottom:12px;">
+            <div style="font-size:12px; font-weight:600; margin-bottom:8px; display:flex; align-items:center; gap:6px;">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
+              Asana
+            </div>
+            <div>
+              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">PERSONAL ACCESS TOKEN</label>
+              <input x-model="settingsForm.asana_token" type="password" placeholder="Asana personal access token"
+                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box;">
+            </div>
+          </div>
+
+          <div style="border:1px solid var(--border); border-radius:8px; padding:12px;">
+            <div style="font-size:12px; font-weight:600; margin-bottom:8px; display:flex; align-items:center; gap:6px;">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+              Google Tasks
+            </div>
+            <div>
+              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">API KEY</label>
+              <input x-model="settingsForm.google_tasks_token" type="password" placeholder="Google Tasks API key"
+                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box;">
+            </div>
           </div>
         </div>
       </div>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -721,6 +721,86 @@ body {
 .git-clean { color: var(--text-muted); font-size: 11px; }
 .git-clean-text { font-style: italic; }
 
+/* Provider Tab Bar */
+.provider-tab-bar {
+  display: flex;
+  gap: 2px;
+  padding: 6px 12px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.provider-tab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text-muted);
+  opacity: 0.5;
+  transition: opacity 0.15s, background 0.15s;
+  position: relative;
+}
+
+.provider-tab:hover {
+  opacity: 0.8;
+  background: var(--bg-secondary);
+}
+
+.provider-tab.active {
+  opacity: 1;
+  background: var(--bg-secondary);
+}
+
+.provider-tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+}
+
+/* Provider Placeholder */
+.provider-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 12px;
+  text-align: center;
+  gap: 8px;
+}
+
+.provider-placeholder-icon {
+  opacity: 0.6;
+}
+
+.provider-placeholder-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.provider-placeholder-url {
+  font-size: 11px;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.provider-placeholder-msg {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* GitHub Issues Section */
 .issues-section {
   padding: 8px 12px;


### PR DESCRIPTION
## Summary
- When Claude finishes naturally (result subtype `"success"`), it may be asking the user a clarifying question. Previously this was incorrectly treated as a turn completion and auto-continued, overriding the user's input prompt.
- Now tracks the `"error_max_turns"` subtype from Claude's result events. Auto-continue only triggers when Claude was actually interrupted by the `--max-turns` limit.
- Refactored test suite to use a persistent process simulation (`persistentProc`) that accurately models the warm-process stdin/stdout pattern, replacing the old `interruptableProcess` approach.

## Test plan
- [x] `TestNaturalCompletion_NoAutoContinue` — verifies no auto-continue on natural finish
- [x] `TestMaxTurnsHit_AutoContinues` — verifies auto-continue triggers on max_turns
- [x] `TestAutoContinue_Exhaustion` — verifies continuation limit is respected
- [x] `TestAutoContinue_NoProgress` — verifies stalled progress stops continuation
- [x] `TestAutoContinue_ExecutionError` — verifies errors don't trigger continuation
- [x] `TestProcessDeath_NoAutoContinue` — verifies process crash doesn't trigger continuation
- [x] Full test suite passes (`go test ./...`)