### PR TITLE
feat: highlight recently active sessions in sidebar

### DIFF
--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -201,6 +201,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		displayMsg = formatImageUploadMessage(req.Message, req.ImageID)
 	}
 	_, _ = s.store.CreateMessage(sessionID, "user", displayMsg)
+	_ = s.store.Heartbeat(sessionID) // Update last_seen_at so sidebar highlights recently active sessions
 	_ = s.store.UpdateActivityState(sessionID, "working")
 
 	broadcaster := s.manager.GetBroadcaster(sessionID)

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -796,6 +796,12 @@ document.addEventListener('alpine:init', () => {
       this.editingSessionName = null;
     },
 
+    isRecentlyActive(session) {
+      const lastSeen = new Date(session.last_seen_at);
+      const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000);
+      return lastSeen > thirtyMinAgo;
+    },
+
     sessionStatus(session) {
       if (session.mode === 'managed') {
         const state = session.activity_state || 'idle';

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -76,7 +76,7 @@
             + New Session
           </button>
           <template x-for="session in sessions" :key="session.id">
-            <div class="session-item" :class="{ active: selectedSessionId === session.id }"
+            <div class="session-item" :class="{ active: selectedSessionId === session.id, 'recently-active': selectedSessionId !== session.id && isRecentlyActive(session) }"
                  @click="selectSession(session.id)">
               <span class="status-dot" :class="sessionStatus(session)"
                     :title="sessionStatus(session) === 'active' ? 'Working' : sessionStatus(session) === 'waiting' ? 'Waiting for input' : sessionStatus(session) === 'input_needed' ? 'Permission needed' : 'Idle'"></span>
@@ -684,7 +684,7 @@
           <button class="btn btn-sm" @click="mobileMenuOpen=false;openResumePicker()" style="flex:1;font-size:13px;">Resume</button>
         </div>
         <template x-for="session in sessions" :key="session.id">
-          <div class="session-item" :class="{ active: selectedSessionId === session.id }"
+          <div class="session-item" :class="{ active: selectedSessionId === session.id, 'recently-active': selectedSessionId !== session.id && isRecentlyActive(session) }"
                @click="selectSession(session.id)">
             <span class="status-dot" :class="sessionStatus(session)"></span>
             <span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -26,6 +26,7 @@
     --border: #333333;
     --card-pending-bg: #0a2614;
   }
+  .session-item.recently-active { background: rgba(37, 99, 235, 0.15); }
 }
 
 body {
@@ -150,8 +151,9 @@ body {
   transition: background 0.1s;
   background: rgba(255, 255, 255, 0.7);
 }
+.session-item.recently-active { background: rgba(37, 99, 235, 0.08); border-left: 3px solid var(--accent); }
 .session-item:hover { background: var(--border); }
-.session-item.active { background: var(--accent); color: #fff; }
+.session-item.active { background: var(--accent); color: #fff; border-left: none; }
 
 .session-delete {
   display: none;


### PR DESCRIPTION
## Summary
- Sessions active in the last 30 minutes get a subtle blue background with a left accent border in the sidebar
- Applied to both desktop and mobile session lists
- Dark mode support with slightly stronger opacity for visibility
- Sessions are already sorted by `last_seen_at DESC` from the DB, so recently active ones appear at the top

Closes #115

## Test plan
- [ ] Verify sessions active within 30 minutes show blue highlight + left border
- [ ] Verify the selected (active) session does NOT show the highlight (accent background takes precedence)
- [ ] Verify sessions older than 30 minutes have default white/transparent background
- [ ] Test in dark mode — highlight should be visible but not overpowering
- [ ] Test mobile session list has the same highlight behavior