### PR TITLE
fix: resolve shell mode SSE race condition causing stale UI

### DIFF
--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -554,6 +554,11 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request, api
 	ch := broadcaster.Subscribe()
 	defer broadcaster.Unsubscribe(ch)
 
+	// Flush headers immediately so the browser's EventSource fires onopen
+	// before any shell commands are sent. Without this, fast shell commands
+	// can broadcast events before the SSE subscriber is ready.
+	flusher.Flush()
+
 	for {
 		select {
 		case msg, ok := <-ch:
@@ -665,6 +670,7 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Command string `json:"command"`
 		Timeout int    `json:"timeout"`
+		ID      string `json:"id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -699,7 +705,12 @@ func (s *Server) handleShellExecute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	commandID := fmt.Sprintf("shell-%d", time.Now().UnixNano())
+	// Allow client-provided ID so frontend can set up SSE listener and
+	// placeholder messages before sending the command (avoids race condition).
+	commandID := req.ID
+	if commandID == "" {
+		commandID = fmt.Sprintf("shell-%d", time.Now().UnixNano())
+	}
 
 	proc, err := s.manager.SpawnShell(sessionID, managed.ShellOpts{
 		Command: req.Command,

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bufio"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -253,6 +254,136 @@ func TestShellExecutePersistsMessages(t *testing.T) {
 	}
 }
 
+func TestShellExecuteUsesClientID(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0, 0)
+
+	body := `{"command": "echo hi", "id": "my-custom-id-123"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/shell", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["id"] != "my-custom-id-123" {
+		t.Errorf("id=%v, want my-custom-id-123", result["id"])
+	}
+}
+
+// TestShellSSE_EventsDeliveredToPreconnectedSubscriber verifies that when an SSE
+// subscriber is connected BEFORE a shell command is executed, all events
+// (shell_start, shell_output, shell_exit) are received. This is the regression
+// test for the bug where switching to shell mode would stall because the frontend
+// connected SSE AFTER posting the command, causing fast commands to complete
+// before events could be captured.
+func TestShellSSE_EventsDeliveredToPreconnectedSubscriber(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp", `["Read"]`, 50, 5.0, 0)
+
+	// Connect SSE BEFORE sending the shell command (the fix)
+	sseURL := ts.URL + "/api/sessions/" + sess.ID + "/stream?token=test-api-key"
+	sseResp, err := http.Get(sseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sseResp.Body.Close()
+
+	if ct := sseResp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("expected text/event-stream, got %s", ct)
+	}
+
+	// Read SSE events in background goroutine
+	type sseEvent struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Text string `json:"text"`
+		Code *int   `json:"code"`
+	}
+	eventsCh := make(chan sseEvent, 32)
+	go func() {
+		scanner := bufio.NewScanner(sseResp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := strings.TrimPrefix(line, "data: ")
+			var evt sseEvent
+			if json.Unmarshal([]byte(data), &evt) == nil && strings.HasPrefix(evt.Type, "shell_") {
+				eventsCh <- evt
+			}
+		}
+		close(eventsCh)
+	}()
+
+	// Small delay to ensure SSE handler has subscribed to broadcaster
+	time.Sleep(50 * time.Millisecond)
+
+	// Now send a fast shell command
+	body := `{"command": "echo hello-from-shell", "timeout": 5, "id": "test-shell-sse"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/shell", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// Collect events with timeout
+	hasStart, hasOutput, hasExit := false, false, false
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case evt, ok := <-eventsCh:
+			if !ok {
+				if !hasStart || !hasOutput || !hasExit {
+					t.Fatalf("SSE channel closed; start=%v output=%v exit=%v", hasStart, hasOutput, hasExit)
+				}
+				return
+			}
+			switch evt.Type {
+			case "shell_start":
+				hasStart = true
+				if evt.ID != "test-shell-sse" {
+					t.Errorf("shell_start id=%q, want test-shell-sse", evt.ID)
+				}
+			case "shell_output":
+				hasOutput = true
+				if !strings.Contains(evt.Text, "hello-from-shell") {
+					t.Errorf("shell_output text=%q, want to contain hello-from-shell", evt.Text)
+				}
+			case "shell_exit":
+				hasExit = true
+				if evt.Code == nil || *evt.Code != 0 {
+					t.Errorf("shell_exit code=%v, want 0", evt.Code)
+				}
+			}
+			if hasStart && hasOutput && hasExit {
+				return // Success — all events received
+			}
+		case <-timeout:
+			t.Fatalf("timed out; start=%v output=%v exit=%v", hasStart, hasOutput, hasExit)
+		}
+	}
+}
 
 func TestClearSessionAPI(t *testing.T) {
 	ts, store := setupTestServer(t)

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1517,39 +1517,47 @@ document.addEventListener('alpine:init', () => {
       this.inputText = '';
       this.inputSending = true;
 
+      // Generate ID client-side so placeholders and SSE are ready before
+      // the backend starts broadcasting events (fixes stale UI on fast commands).
+      const commandId = 'shell-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+      this.activeShellId = commandId;
+
+      // Create placeholder messages immediately so SSE events have targets
+      this.chatMessages.push({
+        role: 'shell',
+        content: cmd,
+        shellId: commandId,
+        cwd: this.currentSession?.cwd || '',
+        timestamp: new Date().toISOString()
+      });
+
+      this.chatMessages.push({
+        role: 'shell_output',
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        shellId: commandId,
+        complete: false,
+        timestamp: new Date().toISOString()
+      });
+
+      this.$nextTick(() => this.scrollToBottom(true));
+
       try {
+        // Ensure SSE is connected BEFORE sending the command
+        await this.ensureSSEConnected(this.selectedSessionId);
+
         const res = await fetch(`/api/sessions/${this.selectedSessionId}/shell`, {
           method: 'POST',
           headers: { 'Authorization': 'Bearer ' + this.apiKey, 'Content-Type': 'application/json' },
-          body: JSON.stringify({ command: cmd, timeout: 30 })
+          body: JSON.stringify({ command: cmd, timeout: 30, id: commandId })
         });
         if (!res.ok) throw new Error(await res.text());
-
-        const data = await res.json();
-        this.activeShellId = data.id;
-
-        this.chatMessages.push({
-          role: 'shell',
-          content: cmd,
-          shellId: data.id,
-          cwd: this.currentSession?.cwd || '',
-          timestamp: new Date().toISOString()
-        });
-
-        this.chatMessages.push({
-          role: 'shell_output',
-          stdout: '',
-          stderr: '',
-          exitCode: null,
-          timedOut: false,
-          shellId: data.id,
-          complete: false,
-          timestamp: new Date().toISOString()
-        });
-
-        this.$nextTick(() => this.scrollToBottom(true));
-        this.startSessionSSE(this.selectedSessionId);
       } catch (e) {
+        // Remove placeholder messages on error
+        this.chatMessages = this.chatMessages.filter(m => m.shellId !== commandId);
+        this.activeShellId = null;
         this.toast('Error: ' + e.message);
       }
       this.inputSending = false;
@@ -1700,6 +1708,25 @@ document.addEventListener('alpine:init', () => {
         }
       };
       window.speechSynthesis.speak(utterance);
+    },
+
+    ensureSSEConnected(sessionId) {
+      // If already connected to this session, resolve immediately
+      if (this.sessionSSE && this.sessionSSE.readyState === EventSource.OPEN) {
+        return Promise.resolve();
+      }
+      this.startSessionSSE(sessionId);
+      return new Promise((resolve) => {
+        if (!this.sessionSSE) { resolve(); return; }
+        if (this.sessionSSE.readyState === EventSource.OPEN) { resolve(); return; }
+        const onOpen = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        this.sessionSSE.addEventListener('open', onOpen, { once: true });
+        // Timeout fallback — don't block forever if connection fails
+        const timer = setTimeout(resolve, 3000);
+      });
     },
 
     startSessionSSE(sessionId) {


### PR DESCRIPTION
## Summary

- **Root cause**: `executeShell()` POSTed the shell command first, then connected SSE after receiving the response. Fast commands (`echo`, `ls`, `pwd`) completed and broadcast all events before the SSE subscriber was registered, causing the UI to stall until page refresh.
- **Backend fix**: Flush SSE headers immediately after subscribing (ensures `EventSource.onopen` fires promptly), and accept client-provided command IDs so the frontend can set up placeholders before sending the command.
- **Frontend fix**: Generate command ID client-side, create placeholder messages, connect SSE via new `ensureSSEConnected()` helper (waits for `onopen`), then POST — ensuring events always have both a subscriber and matching placeholders.

## Test plan

- [x] `TestShellExecuteUsesClientID` — verifies backend respects client-provided IDs
- [x] `TestShellSSE_EventsDeliveredToPreconnectedSubscriber` — integration test: connects SSE first, sends fast `echo` command, asserts all 3 event types (`shell_start`, `shell_output`, `shell_exit`) arrive with correct IDs and content
- [x] All existing shell tests continue to pass
- [x] Full test suite passes (`go test ./...`)