### PR TITLE
feat: redesign modal system for better UX (#119)

### DIFF
--- a/docs/superpowers/plans/2026-04-19-modal-redesign.md
+++ b/docs/superpowers/plans/2026-04-19-modal-redesign.md
@@ -1,0 +1,1170 @@
+# Modal Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the modal system to be larger, centered, less cluttered, with unified CSS classes replacing inline styles.
+
+**Architecture:** Add shared modal CSS classes (`.modal-backdrop`, `.modal-sm/md/lg`, `.modal-header/body/footer`) to `style.css`. Refactor each modal's HTML in `index.html` to use these classes instead of inline styles. Restructure the New Session modal into a two-column layout and the Settings modal into a tabbed sidebar layout. Add minimal Alpine.js state for new UI elements (`showNewFolderInput`, `settingsActiveTab`, `settingsOriginal` for change tracking).
+
+**Tech Stack:** CSS, HTML, Alpine.js (existing stack — no new dependencies)
+
+---
+
+### File Map
+
+- **Modify:** `server/web/static/style.css` — Add modal CSS classes (~100 lines), update mobile overrides
+- **Modify:** `server/web/static/index.html` — Refactor all 5 modal HTML blocks (lines 975-1427)
+- **Modify:** `server/web/static/app.js` — Add `settingsActiveTab`, `showNewFolderInput`, `settingsOriginal` state + change tracking logic
+
+---
+
+### Task 1: Add Unified Modal CSS Classes
+
+**Files:**
+- Modify: `server/web/static/style.css` (append before the mobile `@media` block around line 1195)
+
+- [ ] **Step 1: Add the modal base classes to style.css**
+
+Insert the following CSS before the existing `@media (max-width: 768px)` block (around line 1195 in style.css). Find the comment `/* ===== Mobile layout ===== */` or the first `@media (max-width: 768px)` and insert before it:
+
+```css
+/* ===== Modal System ===== */
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-sm,
+.modal-md,
+.modal-lg {
+  background: var(--bg);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  max-height: 85vh;
+  max-width: 90vw;
+}
+
+.modal-sm { width: 480px; }
+.modal-md { width: 560px; }
+.modal-lg { width: 640px; }
+
+.modal-header {
+  padding: 20px 24px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.modal-close-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.modal-close-btn:hover {
+  background: var(--border);
+}
+
+.modal-body {
+  padding: 0 24px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Modal form input — shared style for all modal inputs */
+.modal-input {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--input-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.modal-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.modal-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.modal-hint {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 3px;
+}
+
+/* ===== New Session Modal ===== */
+.modal-columns {
+  display: flex;
+  min-height: 280px;
+  border-top: 1px solid var(--border);
+}
+
+.modal-columns-left {
+  width: 45%;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.modal-columns-right {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.modal-section-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.new-folder-toggle {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.new-folder-toggle:hover {
+  text-decoration: underline;
+}
+
+/* ===== Settings Modal ===== */
+.settings-layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  border-top: 1px solid var(--border);
+}
+
+.settings-tabs {
+  width: 160px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  padding: 12px 0;
+  background: var(--bg-secondary);
+}
+
+.settings-tab {
+  padding: 8px 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-left: 2px solid transparent;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+  background: var(--bg);
+}
+
+.settings-tab.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: var(--bg);
+  font-weight: 500;
+}
+
+.settings-tab-divider {
+  border-top: 1px solid var(--border);
+  margin: 8px 16px;
+}
+
+.settings-tab.danger {
+  color: var(--red);
+}
+
+.settings-tab.danger:hover {
+  background: var(--bg);
+}
+
+.settings-content {
+  flex: 1;
+  padding: 20px 24px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.settings-section-header {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-field {
+  margin-bottom: 16px;
+}
+
+.settings-change-badge {
+  font-size: 9px;
+  background: var(--yellow);
+  color: #000;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+  margin-left: 6px;
+}
+
+.modal-footer-status {
+  margin-right: auto;
+  font-size: 12px;
+  color: var(--yellow);
+  font-weight: 500;
+}
+```
+
+- [ ] **Step 2: Update the mobile `@media` block to add modal responsive overrides**
+
+Find the existing mobile `@media (max-width: 768px)` block that contains the current modal overrides (around line 1400). Replace the old modal selectors (`.mobile-menu-overlay ~ div[x-show=...] > div`) with the new class-based ones. Add these rules inside the `@media (max-width: 768px)` block:
+
+```css
+  /* Modal full-screen on mobile */
+  .modal-sm,
+  .modal-md,
+  .modal-lg {
+    width: 100vw !important;
+    height: 100vh !important;
+    height: 100dvh !important;
+    max-width: none !important;
+    max-height: none !important;
+    border-radius: 0 !important;
+  }
+
+  .modal-header {
+    padding: 12px 16px;
+  }
+
+  .modal-body {
+    padding: 0 16px;
+  }
+
+  .modal-footer {
+    padding: 12px 16px;
+  }
+
+  /* New Session: stack columns vertically on mobile */
+  .modal-columns {
+    flex-direction: column;
+  }
+
+  .modal-columns-left {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    max-height: 200px;
+  }
+
+  .modal-columns-right {
+    flex: 1;
+  }
+
+  /* Settings: horizontal tab bar on mobile */
+  .settings-layout {
+    flex-direction: column;
+  }
+
+  .settings-tabs {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    overflow-x: auto;
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  .settings-tab {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    white-space: nowrap;
+    padding: 10px 16px;
+  }
+
+  .settings-tab.active {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent);
+  }
+
+  .settings-tab-divider {
+    display: none;
+  }
+```
+
+Also remove the old modal mobile overrides that reference `.mobile-menu-overlay ~ div[x-show="showNewSessionModal"] > div` etc. (lines ~1401-1410 in current style.css), since those are replaced by the class-based selectors.
+
+- [ ] **Step 3: Verify CSS compiles and no syntax errors**
+
+Run: Open `http://localhost:9999` in a browser and check DevTools console for CSS errors. Or just visually confirm the page still loads correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/web/static/style.css
+git commit -m "feat(ui): add unified modal CSS class system (#119)"
+```
+
+---
+
+### Task 2: Refactor New Session Modal to Two-Column Layout
+
+**Files:**
+- Modify: `server/web/static/index.html:975-1073` (New Session Modal HTML)
+- Modify: `server/web/static/app.js` (add `showNewFolderInput` state)
+
+- [ ] **Step 1: Add `showNewFolderInput` state to app.js**
+
+In `server/web/static/app.js`, find the line with `newProjectCreating: false,` (line 51) and add after it:
+
+```javascript
+    showNewFolderInput: false,
+```
+
+- [ ] **Step 2: Replace the New Session Modal HTML**
+
+In `server/web/static/index.html`, replace the entire New Session Modal block (from `<!-- New Session Modal -->` at line 975 through the closing `</div>` before `<!-- Resume Picker Modal -->` at line 1074) with:
+
+```html
+  <!-- New Session Modal -->
+  <div x-show="showNewSessionModal" x-cloak
+       class="modal-backdrop" style="z-index:100;"
+       @click.self="showNewSessionModal = false">
+    <div class="modal-lg">
+      <!-- Mobile header -->
+      <div class="mobile-detail-header mobile-modal-header">
+        <button @click="showNewSessionModal = false" class="mobile-back-btn" aria-label="Back">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
+          </svg>
+        </button>
+        <span class="mobile-detail-title">New Session</span>
+      </div>
+
+      <!-- Desktop header -->
+      <div class="modal-header desktop-modal-title">
+        <h3>New Session</h3>
+        <button class="modal-close-btn" @click="showNewSessionModal = false" aria-label="Close">&times;</button>
+      </div>
+
+      <!-- Path input -->
+      <div style="padding:0 24px 12px;">
+        <div style="display:flex; gap:8px;">
+          <input x-model="newSessionCWD" type="text" placeholder="/path/to/project"
+                 class="modal-input" style="flex:1;"
+                 @keydown="handleBrowseInputKeydown($event)"
+                 @input="if (newSessionCWD === browsePath) { browseFilter = ''; } else if (browsePath && newSessionCWD.startsWith(browsePath + '/')) { browseFilter = newSessionCWD.slice(browsePath.length + 1); }">
+          <button class="btn btn-sm btn-primary" @click="browseTo(newSessionCWD)" style="white-space:nowrap;">Go</button>
+        </div>
+        <div x-show="browseConfirmed" style="font-size:11px; color:var(--accent); margin-top:4px;">
+          Press Enter again to start session in this folder
+        </div>
+        <div x-show="!browseConfirmed && browseFilter" style="font-size:11px; color:var(--text-muted); margin-top:4px;">
+          Filtering: <span x-text="browseFilter"></span>
+        </div>
+      </div>
+
+      <!-- Two-column body -->
+      <div class="modal-columns">
+        <!-- Left: Recent Projects -->
+        <div class="modal-columns-left">
+          <div class="modal-section-label">Recent Projects</div>
+          <template x-if="recentDirs.length === 0">
+            <div style="font-size:12px; color:var(--text-muted);">No recent projects</div>
+          </template>
+          <template x-for="dir in recentDirs" :key="dir.path">
+            <div class="browse-item" @click="selectRecentDir(dir.path)" style="cursor:pointer; border-radius:8px; padding:10px 12px; margin-bottom:4px;">
+              <span class="browse-icon" style="color:var(--accent);">&#9733;</span>
+              <div style="flex:1; min-width:0;">
+                <div style="font-weight:600; font-size:13px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="dir.name"></div>
+                <div style="font-size:10px; color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="abbreviatePath(dir.path)"></div>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <!-- Right: File Browser -->
+        <div class="modal-columns-right">
+          <!-- Breadcrumbs -->
+          <div class="browse-breadcrumbs" style="margin-bottom:10px;">
+            <template x-for="(crumb, i) in breadcrumbs" :key="crumb.path">
+              <span>
+                <span x-show="i > 0" style="color:var(--text-muted); margin:0 2px;">&rsaquo;</span>
+                <a href="#" @click.prevent="browseTo(crumb.path)" x-text="crumb.label"
+                   style="color:var(--accent); text-decoration:none; font-size:13px;"></a>
+              </span>
+            </template>
+          </div>
+
+          <!-- Directory list -->
+          <div class="browse-list" style="flex:1; min-height:0;">
+            <template x-if="browseLoading">
+              <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+            </template>
+            <template x-if="!browseLoading && filteredBrowseEntries.length === 0">
+              <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;" x-text="browseFilter ? 'No matching directories' : 'No subdirectories'"></div>
+            </template>
+            <template x-for="entry in filteredBrowseEntries" :key="entry.path">
+              <div class="browse-item" @click="browseFilter = ''; browseTo(entry.path)">
+                <span class="browse-icon" x-text="entry.is_git_repo ? '&#9679;' : '&#128193;'"
+                      :style="entry.is_git_repo ? 'color:var(--green)' : 'color:var(--text-muted)'"></span>
+                <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="entry.name"></span>
+                <span x-show="entry.is_git_repo" style="font-size:10px; color:var(--green); flex-shrink:0;">git</span>
+              </div>
+            </template>
+          </div>
+
+          <!-- Collapsed New Folder -->
+          <div class="new-folder-toggle" @click="showNewFolderInput = !showNewFolderInput" x-show="!showNewFolderInput">
+            + New Folder
+          </div>
+          <div x-show="showNewFolderInput" style="margin-top:8px; padding-top:8px; border-top:1px solid var(--border);">
+            <div style="display:flex; gap:8px;">
+              <input x-model="newProjectName" type="text" placeholder="Folder name..."
+                     class="modal-input" style="flex:1;"
+                     @keydown.enter.prevent="createNewProject()"
+                     @keydown.escape.prevent="showNewFolderInput = false; newProjectName = ''">
+              <button class="btn btn-sm btn-primary" @click="createNewProject()"
+                      :disabled="!isValidNewProjectName || newProjectCreating"
+                      x-text="newProjectCreating ? 'Creating...' : 'Create'"></button>
+              <button class="btn btn-sm" @click="showNewFolderInput = false; newProjectName = ''">&times;</button>
+            </div>
+            <div x-show="newProjectName && !isValidNewProjectName" style="font-size:11px; color:var(--red); margin-top:4px;">
+              Use letters, numbers, hyphens, dots, or underscores.
+            </div>
+            <div x-show="newProjectError" style="font-size:11px; color:var(--red); margin-top:4px;" x-text="newProjectError"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="modal-footer">
+        <button class="btn btn-sm" @click="showNewSessionModal = false">Cancel</button>
+        <button class="btn btn-sm btn-primary" @click="createManagedSession()" :disabled="!newSessionCWD.trim()">
+          Open
+        </button>
+      </div>
+    </div>
+  </div>
+```
+
+- [ ] **Step 3: Reset `showNewFolderInput` when modal closes**
+
+In `server/web/static/app.js`, find the `resetBrowseState()` method (called when the modal opens). Add `this.showNewFolderInput = false;` to it. Search for `resetBrowseState` and add the line inside that function body.
+
+- [ ] **Step 4: Verify the New Session modal opens and functions correctly**
+
+Run: Open `http://localhost:9999`, click the "+" button or "New Session" to open the modal. Verify:
+- Two-column layout visible on desktop
+- Recents on the left, file browser on the right
+- Path input works
+- "+ New Folder" collapses/expands
+- Cancel and Open buttons work
+- Click backdrop to close works
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/web/static/index.html server/web/static/app.js
+git commit -m "feat(ui): redesign New Session modal with two-column layout (#119)"
+```
+
+---
+
+### Task 3: Refactor Settings Modal to Tabbed Sidebar Layout
+
+**Files:**
+- Modify: `server/web/static/index.html:1213-1391` (Settings Modal HTML)
+- Modify: `server/web/static/app.js` (add `settingsActiveTab`, `settingsOriginal`, change tracking)
+
+- [ ] **Step 1: Add settings tab state and change tracking to app.js**
+
+In `server/web/static/app.js`, find the settings state block (around line 124-136). Replace:
+
+```javascript
+    settingsAccordion: { server: false, integrations: false, shortcuts: false },
+```
+
+with:
+
+```javascript
+    settingsActiveTab: 'server',
+    settingsOriginal: null,
+```
+
+- [ ] **Step 2: Add a computed property for unsaved changes count**
+
+In `server/web/static/app.js`, find `openSettingsModal()` (around line 481). After the line that sets `this.settingsForm` from the response data, add:
+
+```javascript
+        this.settingsOriginal = JSON.parse(JSON.stringify(this.settingsForm));
+```
+
+Then add a new method `settingsChangeCount()` near the other settings methods:
+
+```javascript
+    settingsChangeCount() {
+      if (!this.settingsOriginal) return 0;
+      let count = 0;
+      const keys = ['port', 'ngrok_authtoken', 'claude_bin', 'claude_args', 'claude_env', 'compact_every_n_continues', 'github_token', 'jira_url', 'jira_token', 'jira_email', 'asana_token', 'google_tasks_token'];
+      for (const key of keys) {
+        if (String(this.settingsForm[key] || '') !== String(this.settingsOriginal[key] || '')) count++;
+      }
+      if (JSON.stringify(this.settingsForm.shortcuts) !== JSON.stringify(this.settingsOriginal.shortcuts)) count++;
+      return count;
+    },
+
+    isFieldChanged(fieldName) {
+      if (!this.settingsOriginal) return false;
+      return String(this.settingsForm[fieldName] || '') !== String(this.settingsOriginal[fieldName] || '');
+    },
+```
+
+- [ ] **Step 3: Reset tab state when modal opens**
+
+In `openSettingsModal()`, add at the top of the method:
+
+```javascript
+      this.settingsActiveTab = 'server';
+```
+
+- [ ] **Step 4: Replace the Settings Modal HTML**
+
+In `server/web/static/index.html`, replace the entire Settings Modal block (from `<!-- Settings Modal -->` through its closing `</div>` before `<!-- Permission Prompt Modal -->`) with:
+
+```html
+  <!-- Settings Modal -->
+  <div x-show="showSettingsModal" x-cloak
+       class="modal-backdrop" style="z-index:100;"
+       @click.self="showSettingsModal = false">
+    <div class="modal-lg" style="height:min(85vh, 520px);">
+      <!-- Mobile header -->
+      <div class="mobile-detail-header mobile-modal-header">
+        <button @click="showSettingsModal = false" class="mobile-back-btn" aria-label="Back">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
+          </svg>
+        </button>
+        <span class="mobile-detail-title" x-text="settingsFirstRun ? 'Welcome — Configure Claude Controller' : 'Settings'"></span>
+      </div>
+
+      <!-- Desktop header -->
+      <div class="modal-header desktop-modal-title">
+        <h3 x-text="settingsFirstRun ? 'Welcome — Configure Claude Controller' : 'Settings'"></h3>
+        <button class="modal-close-btn" @click="showSettingsModal = false" aria-label="Close">&times;</button>
+      </div>
+
+      <!-- Tabbed layout -->
+      <div class="settings-layout" x-show="!settingsFirstRun">
+        <!-- Sidebar tabs -->
+        <div class="settings-tabs">
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'server' }" @click="settingsActiveTab = 'server'">Server</div>
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'integrations' }" @click="settingsActiveTab = 'integrations'">Integrations</div>
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'shortcuts' }" @click="settingsActiveTab = 'shortcuts'">Shortcuts</div>
+          <div class="settings-tab-divider"></div>
+          <div class="settings-tab danger" :class="{ active: settingsActiveTab === 'actions' }" @click="settingsActiveTab = 'actions'">Actions</div>
+        </div>
+
+        <!-- Content panel -->
+        <div class="settings-content">
+          <!-- Server tab -->
+          <div x-show="settingsActiveTab === 'server'">
+            <div class="settings-field">
+              <label class="modal-label">
+                Port
+                <span x-show="isFieldChanged('port')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.port" type="text" placeholder="8080" class="modal-input" :style="isFieldChanged('port') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Server port (requires restart)</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Ngrok Auth Token
+                <span x-show="isFieldChanged('ngrok_authtoken')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.ngrok_authtoken" type="password" placeholder="ngrok auth token" class="modal-input" :style="isFieldChanged('ngrok_authtoken') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">For remote access via ngrok tunnel (requires restart)</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Claude Binary
+                <span x-show="isFieldChanged('claude_bin')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.claude_bin" type="text" placeholder="claude" class="modal-input" :style="isFieldChanged('claude_bin') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Path to Claude CLI binary</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                CLI Arguments
+                <span x-show="isFieldChanged('claude_args')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.claude_args" type="text" placeholder="--dangerously-skip-permissions" class="modal-input" :style="isFieldChanged('claude_args') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Space-separated CLI flags for managed sessions</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Environment Variables
+                <span x-show="isFieldChanged('claude_env')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.claude_env" type="text" placeholder="CLAUDE_CONFIG_DIR=/path" class="modal-input" :style="isFieldChanged('claude_env') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Comma-separated KEY=VALUE pairs for managed session environment</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Compact Every N Continues
+                <span x-show="isFieldChanged('compact_every_n_continues')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.compact_every_n_continues" type="number" min="0" placeholder="0" class="modal-input" :style="isFieldChanged('compact_every_n_continues') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Run /compact every N auto-continues to reduce token usage. 0 = disabled.</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                GitHub Token
+                <span x-show="isFieldChanged('github_token')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.github_token" type="password" placeholder="ghp_..." class="modal-input" :style="isFieldChanged('github_token') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Personal access token for GitHub issue tracking (needs repo scope)</div>
+            </div>
+          </div>
+
+          <!-- Integrations tab -->
+          <div x-show="settingsActiveTab === 'integrations'">
+            <div style="font-size:12px; color:var(--text-muted); margin-bottom:16px;">
+              Connect project management tools to browse issues and tasks alongside GitHub.
+            </div>
+
+            <div style="border:1px solid var(--border); border-radius:10px; padding:14px; margin-bottom:12px;">
+              <div style="font-size:13px; font-weight:600; margin-bottom:10px; display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/></svg>
+                Jira
+              </div>
+              <div class="settings-field">
+                <label class="modal-label">Base URL</label>
+                <input x-model="settingsForm.jira_url" type="text" placeholder="https://yourorg.atlassian.net" class="modal-input">
+              </div>
+              <div class="settings-field">
+                <label class="modal-label">API Token</label>
+                <input x-model="settingsForm.jira_token" type="password" placeholder="Jira API token" class="modal-input">
+              </div>
+              <div class="settings-field" style="margin-bottom:0;">
+                <label class="modal-label">Email</label>
+                <input x-model="settingsForm.jira_email" type="email" placeholder="you@company.com" class="modal-input">
+              </div>
+            </div>
+
+            <div style="border:1px solid var(--border); border-radius:10px; padding:14px; margin-bottom:12px;">
+              <div style="font-size:13px; font-weight:600; margin-bottom:10px; display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
+                Asana
+              </div>
+              <div class="settings-field" style="margin-bottom:0;">
+                <label class="modal-label">Personal Access Token</label>
+                <input x-model="settingsForm.asana_token" type="password" placeholder="Asana personal access token" class="modal-input">
+              </div>
+            </div>
+
+            <div style="border:1px solid var(--border); border-radius:10px; padding:14px;">
+              <div style="font-size:13px; font-weight:600; margin-bottom:10px; display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+                Google Tasks
+              </div>
+              <div class="settings-field" style="margin-bottom:0;">
+                <label class="modal-label">API Key</label>
+                <input x-model="settingsForm.google_tasks_token" type="password" placeholder="Google Tasks API key" class="modal-input">
+              </div>
+            </div>
+          </div>
+
+          <!-- Shortcuts tab -->
+          <div x-show="settingsActiveTab === 'shortcuts'">
+            <div style="font-size:12px; color:var(--text-muted); margin-bottom:16px;">
+              Define shortcuts that map a key (emoji or text) to a message sent in chat.
+            </div>
+            <template x-for="(shortcut, idx) in settingsForm.shortcuts" :key="idx">
+              <div style="display:flex; gap:8px; align-items:center; margin-bottom:8px;">
+                <input x-model="shortcut.key" type="text" maxlength="20" placeholder="Key"
+                       class="modal-input" style="width:70px; flex-shrink:0; text-align:center;">
+                <input x-model="shortcut.value" type="text" placeholder="Message to send..."
+                       class="modal-input" style="flex:1;">
+                <button @click="settingsForm.shortcuts.splice(idx, 1)" class="btn btn-sm"
+                        style="padding:4px 8px; flex-shrink:0; color:var(--red);" title="Remove shortcut">&times;</button>
+              </div>
+            </template>
+            <button @click="settingsForm.shortcuts.push({key:'', value:''})" class="btn btn-sm"
+                    style="font-size:12px; color:var(--accent);">+ Add Shortcut</button>
+          </div>
+
+          <!-- Actions tab -->
+          <div x-show="settingsActiveTab === 'actions'">
+            <div class="settings-field">
+              <button class="btn btn-sm" @click="restartServer()" :disabled="serverRestarting"
+                      style="background:var(--red); color:white; border:none; padding:10px 20px; border-radius:8px; cursor:pointer; font-size:13px;">
+                <span x-show="!serverRestarting">Restart Server</span>
+                <span x-show="serverRestarting">Restarting...</span>
+              </button>
+              <div class="modal-hint">Gracefully restarts the server, preserving all session state</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- First-run flow (no sidebar, just server fields) -->
+      <div x-show="settingsFirstRun" class="modal-body" style="padding-top:16px;">
+        <div class="settings-field">
+          <label class="modal-label">Port</label>
+          <input x-model="settingsForm.port" type="text" placeholder="8080" class="modal-input">
+          <div class="modal-hint">Server port (requires restart)</div>
+        </div>
+        <div class="settings-field">
+          <label class="modal-label">Ngrok Auth Token</label>
+          <input x-model="settingsForm.ngrok_authtoken" type="password" placeholder="ngrok auth token" class="modal-input">
+          <div class="modal-hint">For remote access via ngrok tunnel (requires restart)</div>
+        </div>
+        <div class="settings-field">
+          <label class="modal-label">Claude Binary</label>
+          <input x-model="settingsForm.claude_bin" type="text" placeholder="claude" class="modal-input">
+          <div class="modal-hint">Path to Claude CLI binary</div>
+        </div>
+        <div class="settings-field">
+          <label class="modal-label">CLI Arguments</label>
+          <input x-model="settingsForm.claude_args" type="text" placeholder="--dangerously-skip-permissions" class="modal-input">
+          <div class="modal-hint">Space-separated CLI flags for managed sessions</div>
+        </div>
+      </div>
+
+      <!-- Error -->
+      <p class="error-msg" x-show="settingsError" x-text="settingsError" style="margin:0 24px 8px;"></p>
+
+      <!-- Footer -->
+      <div class="modal-footer">
+        <template x-if="!settingsFirstRun && settingsChangeCount() > 0">
+          <span class="modal-footer-status" x-text="settingsChangeCount() + ' unsaved change' + (settingsChangeCount() > 1 ? 's' : '')"></span>
+        </template>
+        <button class="btn btn-sm" @click="showSettingsModal = false; settingsFirstRun = false;" x-text="settingsFirstRun ? 'Skip' : 'Cancel'"></button>
+        <button class="btn btn-sm btn-primary" @click="saveSettings()" :disabled="settingsSaving">
+          <span x-show="!settingsSaving" x-text="settingsFirstRun ? 'Save & Continue' : 'Save'"></span>
+          <span x-show="settingsSaving">Saving...</span>
+        </button>
+      </div>
+    </div>
+  </div>
+```
+
+- [ ] **Step 5: Clean up references to `settingsAccordion` in app.js**
+
+Search for `settingsAccordion` in app.js and remove all references:
+- Remove the `settingsAccordion: { server: false, integrations: false, shortcuts: false },` line (already replaced in Step 1)
+- Search for any other references and remove them (there should be none beyond the state declaration)
+
+- [ ] **Step 6: Verify the Settings modal opens and all tabs work**
+
+Run: Open `http://localhost:9999`, click the settings gear icon. Verify:
+- Sidebar shows Server, Integrations, Shortcuts, divider, Actions
+- Clicking each tab shows the correct content
+- Server tab is selected by default
+- Change badges appear when editing a field
+- Footer shows "N unsaved changes" count
+- Save/Cancel buttons work
+- First-run flow shows simplified view (no sidebar)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/web/static/index.html server/web/static/app.js
+git commit -m "feat(ui): redesign Settings modal with tabbed sidebar layout (#119)"
+```
+
+---
+
+### Task 4: Refactor Task, Resume, and Permission Modals
+
+**Files:**
+- Modify: `server/web/static/index.html` (Task modal ~1121-1211, Resume modal ~1075-1119, Permission modal ~1393-1427)
+
+- [ ] **Step 1: Replace the Resume Picker Modal HTML**
+
+Replace the `<!-- Resume Picker Modal -->` block with:
+
+```html
+  <!-- Resume Picker Modal -->
+  <div x-show="showResumePicker" x-cloak
+       class="modal-backdrop" style="z-index:100;"
+       @click.self="showResumePicker = false">
+    <div class="modal-sm">
+      <!-- Mobile header -->
+      <div class="mobile-detail-header mobile-modal-header">
+        <button @click="showResumePicker = false" class="mobile-back-btn" aria-label="Back">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
+          </svg>
+        </button>
+        <span class="mobile-detail-title">Resume a Session</span>
+      </div>
+
+      <!-- Desktop header -->
+      <div class="modal-header desktop-modal-title">
+        <h3>Resume a Session</h3>
+        <button class="modal-close-btn" @click="showResumePicker = false" aria-label="Close">&times;</button>
+      </div>
+
+      <div class="modal-body">
+        <template x-if="resumeLoading">
+          <div style="padding:2rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading sessions...</div>
+        </template>
+
+        <template x-if="!resumeLoading && resumableSessions.length === 0">
+          <div style="padding:2rem; text-align:center; color:var(--text-muted); font-size:13px;">No sessions to resume</div>
+        </template>
+
+        <template x-for="rs in resumableSessions" :key="rs.session_id">
+          <div @click="resumeSession(rs.session_id, rs.summary)"
+               style="padding:12px 16px; border-bottom:1px solid var(--border); cursor:pointer; transition:background 0.15s;"
+               onmouseenter="this.style.background='var(--hover)'"
+               onmouseleave="this.style.background='transparent'">
+            <div style="font-weight:600; font-size:14px; margin-bottom:2px;" x-text="rs.summary || 'Untitled session'"></div>
+            <div style="font-size:12px; color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="rs.first_prompt"></div>
+            <div style="display:flex; gap:8px; margin-top:4px; font-size:11px; color:var(--text-muted);">
+              <span x-show="rs.git_branch" x-text="rs.git_branch" style="background:var(--input-bg); padding:1px 5px; border-radius:3px;"></span>
+              <span x-text="rs.message_count + ' messages'"></span>
+              <span x-text="timeAgo(rs.modified)"></span>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <div class="modal-footer">
+        <button class="btn btn-sm" @click="showResumePicker = false">Cancel</button>
+      </div>
+    </div>
+  </div>
+```
+
+- [ ] **Step 2: Replace the Task Create/Edit Modal HTML**
+
+Replace the `<!-- Task Create/Edit Modal -->` block with:
+
+```html
+  <!-- Task Create/Edit Modal -->
+  <div x-show="taskModalOpen" x-cloak
+       class="modal-backdrop" style="z-index:200;"
+       @click.self="taskModalOpen = false" @keydown.escape.window="taskModalOpen && (taskModalOpen = false)">
+    <div @click.stop class="modal-md">
+      <!-- Mobile header -->
+      <div class="mobile-detail-header mobile-modal-header">
+        <button @click="taskModalOpen = false" class="mobile-back-btn" aria-label="Back">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
+          </svg>
+        </button>
+        <span class="mobile-detail-title" x-text="editingTask ? editingTask.name : 'New Scheduled Task'"></span>
+      </div>
+
+      <!-- Desktop header -->
+      <div class="modal-header desktop-modal-title">
+        <h3 x-text="editingTask ? editingTask.name : 'New Scheduled Task'"></h3>
+        <div style="display:flex; align-items:center; gap:6px;">
+          <template x-if="editingTask">
+            <div style="display:flex; gap:6px;">
+              <button type="button" class="btn btn-sm" @click="triggerTask(editingTask.id)" style="font-size:0.75rem;">&#9654; Run Now</button>
+              <button type="button" class="btn btn-sm" @click="toggleTaskEnabled(editingTask); editingTask.enabled = !editingTask.enabled" style="font-size:0.75rem;"
+                      x-text="editingTask?.enabled ? 'Disable' : 'Enable'"></button>
+              <button type="button" class="btn btn-sm" @click="taskModalOpen = false; deleteTask(editingTask.id)" style="font-size:0.75rem; color:#ef4444;">Delete</button>
+            </div>
+          </template>
+          <button class="modal-close-btn" @click="taskModalOpen = false" aria-label="Close">&times;</button>
+        </div>
+      </div>
+
+      <div class="modal-body">
+        <form @submit.prevent="saveTask()">
+          <div class="settings-field">
+            <label class="modal-label">Name</label>
+            <input type="text" x-model="taskForm.name" required class="modal-input" placeholder="e.g., Daily Backup">
+          </div>
+          <div class="settings-field">
+            <label class="modal-label">Type</label>
+            <select x-model="taskForm.task_type" class="modal-input">
+              <option value="shell">Shell Command</option>
+              <option value="claude">Claude Command</option>
+            </select>
+          </div>
+          <div class="settings-field">
+            <label class="modal-label" x-text="taskForm.task_type === 'claude' ? 'Prompt' : 'Command'"></label>
+            <textarea x-model="taskForm.command" required rows="3"
+                      class="modal-input" style="font-family:monospace; font-size:0.85rem; resize:vertical;"
+                      :placeholder="taskForm.task_type === 'claude' ? 'e.g., Summarize the latest changes' : 'e.g., tar -czf backup.tar.gz ./data'"></textarea>
+          </div>
+          <div class="settings-field">
+            <label class="modal-label">Working Directory</label>
+            <input type="text" x-model="taskForm.working_directory" required
+                   class="modal-input" style="font-family:monospace; font-size:0.85rem;"
+                   placeholder="/absolute/path/to/project">
+          </div>
+          <div class="settings-field">
+            <label class="modal-label">Cron Expression</label>
+            <input type="text" x-model="taskForm.cron_expression" required
+                   class="modal-input" style="font-family:monospace; font-size:0.85rem;"
+                   placeholder="0 9 * * *">
+            <div class="modal-hint">
+              min hour day month weekday |
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 * * * *'">hourly</span>
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 9 * * *'">daily 9am</span>
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 9 * * 1-5'">weekdays</span>
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '*/5 * * * *'">every 5min</span>
+            </div>
+          </div>
+          <div x-show="taskFormErrors" style="color:#ef4444; font-size:0.8rem; margin-bottom:8px;" x-text="taskFormErrors"></div>
+
+          <!-- Recent Runs (only when editing) -->
+          <div x-show="editingTask && taskRuns.length > 0" style="margin-top:8px; border-top:1px solid var(--border); padding-top:16px;">
+            <h4 style="margin:0 0 10px 0; font-size:0.85rem; color:var(--text-muted);">Recent Runs</h4>
+            <template x-for="run in taskRuns.slice(0, 5)" :key="run.id">
+              <div style="border:1px solid var(--border); border-radius:8px; padding:8px 10px; margin-bottom:6px; font-size:0.8rem;">
+                <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:4px;">
+                  <div style="display:flex; align-items:center; gap:6px;">
+                    <span style="width:7px; height:7px; border-radius:50%;"
+                          :style="'background:' + (run.status === 'success' ? '#22c55e' : run.status === 'failed' ? '#ef4444' : '#eab308')"></span>
+                    <span style="font-weight:500;" x-text="run.status"></span>
+                    <span style="font-size:0.75rem; color:var(--text-muted);" x-text="formatRelativeTime(run.started_at)"></span>
+                  </div>
+                  <span style="font-size:0.7rem; color:var(--text-muted);" x-show="run.exit_code != null" x-text="'exit ' + run.exit_code"></span>
+                </div>
+                <div x-show="run.output" style="background:var(--input-bg); border-radius:4px; padding:6px; font-family:monospace; font-size:0.7rem; white-space:pre-wrap; word-break:break-all; max-height:120px; overflow-y:auto; color:var(--text-muted);"
+                     x-text="(run.output || '').substring(0, 300) + ((run.output || '').length > 300 ? '\n...' : '')"></div>
+              </div>
+            </template>
+          </div>
+
+          <div class="modal-footer" style="margin:16px -24px -24px; padding:16px 24px;">
+            <button type="button" class="btn btn-sm" @click="taskModalOpen = false">Cancel</button>
+            <button type="submit" class="btn btn-sm btn-primary" :disabled="taskLoading" x-text="editingTask ? 'Update' : 'Create'"></button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+```
+
+- [ ] **Step 3: Replace the Permission Prompt Modal HTML**
+
+Replace the `<!-- Permission Prompt Modal -->` block with:
+
+```html
+  <!-- Permission Prompt Modal -->
+  <div x-show="pendingPermission" x-cloak
+       class="modal-backdrop" style="z-index:200;">
+    <div @click.stop class="modal-sm">
+      <div class="modal-header">
+        <h3 style="display:flex; align-items:center; gap:8px;">
+          <span style="color:var(--yellow);">&#9888;</span> Permission Required
+        </h3>
+      </div>
+      <div class="modal-body" style="padding-bottom:16px;">
+        <template x-if="pendingPermission">
+          <div>
+            <div style="margin-bottom:12px;">
+              <span style="font-weight:600;" x-text="pendingPermission.tool_name || 'Tool'"></span>
+              <span style="color:var(--text-muted); margin-left:8px;" x-text="pendingPermission.description || ''"></span>
+            </div>
+            <template x-if="pendingPermission.input">
+              <pre style="background:var(--input-bg); border:1px solid var(--border); border-radius:8px; padding:12px; font-size:12px; overflow-x:auto; max-height:200px; overflow-y:auto; margin-bottom:16px; white-space:pre-wrap; word-break:break-all;"
+                   x-text="typeof pendingPermission.input === 'string' ? pendingPermission.input : JSON.stringify(pendingPermission.input, null, 2)"></pre>
+            </template>
+          </div>
+        </template>
+      </div>
+      <div class="modal-footer">
+        <button class="btn" @click="respondToPermission('deny')"
+                style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:8px; cursor:pointer;">
+          Deny
+        </button>
+        <button class="btn" @click="respondToPermission('allow_always')"
+                style="background:var(--input-bg); color:var(--text); border:1px solid var(--border); padding:8px 16px; border-radius:8px; cursor:pointer;">
+          Allow Always
+        </button>
+        <button class="btn" @click="respondToPermission('allow')"
+                style="background:var(--green); color:white; border:none; padding:8px 16px; border-radius:8px; cursor:pointer;">
+          Allow
+        </button>
+      </div>
+    </div>
+  </div>
+```
+
+- [ ] **Step 4: Verify all three modals function correctly**
+
+Run: Open `http://localhost:9999`. Test:
+- Resume picker: click "Resume" in sidebar menu — list renders, close works
+- Task modal: go to Tasks tab, click "New Task" or edit existing — form renders, save works
+- Permission modal: if a permission prompt appears, buttons work
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/web/static/index.html
+git commit -m "feat(ui): refactor Task, Resume, Permission modals to unified CSS (#119)"
+```
+
+---
+
+### Task 5: Clean Up Old Modal CSS and Remove Dead Code
+
+**Files:**
+- Modify: `server/web/static/style.css` (remove old modal-specific selectors)
+
+- [ ] **Step 1: Remove old mobile modal overrides**
+
+In `server/web/static/style.css`, inside the `@media (max-width: 768px)` block, find and remove the old modal selectors that targeted inline-styled modals:
+
+```css
+  /* Remove these rules — replaced by .modal-sm/.modal-md/.modal-lg selectors */
+  .mobile-menu-overlay ~ div[x-show="showNewSessionModal"] > div,
+  .mobile-menu-overlay ~ div[x-show="showResumePicker"] > div,
+  .mobile-menu-overlay ~ div[x-show="taskModalOpen"] > div {
+    width: 100vw !important;
+    height: 100vh !important;
+    height: 100dvh !important;
+    max-width: none !important;
+    max-height: none !important;
+    border-radius: 0 !important;
+  }
+```
+
+Also find and remove any `.modal-inner` rules in the mobile block (like `padding-top: 0 !important`) since we no longer use `.modal-inner`.
+
+- [ ] **Step 2: Remove the old `.settings-accordion-header` and `.settings-accordion-body` CSS**
+
+Search for `settings-accordion` in style.css and remove all related rules (the accordion header, chevron, and body styles). These are no longer used since we replaced accordions with tabs.
+
+- [ ] **Step 3: Verify no console errors and all modals still work**
+
+Run: Open `http://localhost:9999`, open each modal in succession. Check DevTools console for any CSS or JS errors. Confirm mobile view works using browser DevTools responsive mode.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/web/static/style.css
+git commit -m "chore(ui): remove old modal CSS overrides and accordion styles (#119)"
+```
+
+---
+
+### Task 6: Final Verification and Test
+
+**Files:**
+- No file changes — verification only
+
+- [ ] **Step 1: Run Go tests to ensure nothing is broken**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass. (The modal changes are HTML/CSS/JS only, so Go tests should be unaffected.)
+
+- [ ] **Step 2: Verify all modals on desktop**
+
+Open `http://localhost:9999` in a desktop browser. Test each modal:
+1. **New Session**: Two-column layout, recents left, browser right, "+ New Folder" collapses, "Open" button works
+2. **Settings**: Tabbed sidebar, all 4 tabs work, change badges appear, unsaved changes count in footer
+3. **Task Editor**: Form fields, cron shortcuts, recent runs (if editing)
+4. **Resume Picker**: Session list, click to resume
+5. **Permission Prompt**: (trigger by using a managed session that requests permission)
+
+- [ ] **Step 3: Verify all modals on mobile (responsive mode)**
+
+Open DevTools, switch to responsive mode (iPhone SE or similar). For each modal:
+- Full-screen rendering
+- Sticky header with back button
+- New Session: columns stacked vertically
+- Settings: horizontal tab bar at top
+- Scrolling works within modal body
+
+- [ ] **Step 4: Commit any final fixes if needed**
+
+If any issues were found and fixed:
+```bash
+git add -A
+git commit -m "fix(ui): polish modal redesign edge cases (#119)"
+```
+
+Now let me do the self-review of this plan against the spec.
+
+**Self-Review:**
+
+1. **Spec coverage:**
+   - Unified CSS system: Task 1
+   - New Session two-column: Task 2
+   - Settings tabbed sidebar: Task 3
+   - Task/Resume/Permission cleanup: Task 4
+   - Mobile behavior: Tasks 1 (CSS) + 6 (verification)
+   - Remove old CSS: Task 5
+   - First-run flow: Task 3 (included in Settings HTML)
+   - All covered.
+
+2. **Placeholder scan:** No TBDs, TODOs, or vague instructions. All steps have code or commands.
+
+3. **Type consistency:** `settingsActiveTab`, `showNewFolderInput`, `settingsOriginal`, `settingsChangeCount()`, `isFieldChanged()` — used consistently across Tasks 2-3. CSS class names match between Task 1 definitions and Tasks 2-4 usage.
+
+Plan is clean. Saving now.

--- a/docs/superpowers/specs/2026-04-19-modal-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-modal-redesign-design.md
@@ -1,0 +1,203 @@
+# Modal Redesign Design Spec
+
+**Date:** 2026-04-19
+**Issue:** #119 — New Modal Experience
+**Scope:** Design-only changes. No functional changes to modal behavior or data flow.
+
+## Problem
+
+The current modal system has several UX issues:
+
+1. **Too narrow** — All modals use a fixed 500px width, cramping content-heavy modals like New Session and Settings
+2. **Cluttered** — New Session modal packs path input, recent dirs, breadcrumbs, directory browser, folder creation, and action buttons into a single column at 70vh max-height
+3. **Folder creation dominates** — The "Create new project" section takes significant space despite being rarely used
+4. **Settings are hard to read** — Accordion-based layout in a small box makes it hard to see all config at once; saving is unclear about what changed
+5. **Inline styles everywhere** — All 5 modals use inline styles, making them inconsistent and hard to maintain
+6. **Mobile is a hack** — Mobile overrides force 100vw/100dvh with `!important` rather than responsive design
+
+## Design: Wide Centered Modal
+
+### Unified Modal CSS System
+
+Replace all inline modal styles with shared CSS classes. All modals use a consistent structure:
+
+**Shared traits (all sizes):**
+- Centered on screen with dark backdrop (`rgba(0,0,0,0.5)`)
+- Click backdrop or press Escape to close
+- `border-radius: 16px` (up from 12px)
+- Consistent padding: 24px desktop, 16px mobile
+- `max-height: 85vh` with internal scroll
+- `box-shadow: 0 24px 80px rgba(0,0,0,0.4)`
+- Mobile: all sizes become full-screen with sticky header
+- X close button in top-right corner (standard pattern)
+
+**CSS classes replacing inline styles:**
+- `.modal-backdrop` — fixed overlay with centering flexbox
+- `.modal-sm` — 480px width (Permission Prompt, Resume Picker)
+- `.modal-md` — 560px width (Task Editor)
+- `.modal-lg` — 640px width (New Session, Settings)
+- `.modal-header` — title + close button row
+- `.modal-body` — scrollable content area
+- `.modal-footer` — sticky bottom action bar
+
+### New Session Modal (Large — 640px)
+
+Two-column layout replacing the current single-column stack.
+
+**Structure:**
+```
+┌─────────────────────────────────────────┐
+│ New Session                           ✕ │
+├─────────────────────────────────────────┤
+│ [/path/to/project                ] [Go] │
+├──────────────────┬──────────────────────┤
+│ RECENT PROJECTS  │ / > Users > jay >    │
+│                  │   workspaces          │
+│ ● claude-control │ ● _personal_/    git │
+│   ~/_personal_   │ 📁 _work_/           │
+│                  │ ● experiments/    git │
+│ ● boll-website   │ 📁 archive/          │
+│   ~/workspaces   │                      │
+│                  │ + New Folder          │
+│ ● experiments    │                      │
+│   ~/projects     │                      │
+├──────────────────┴──────────────────────┤
+│                        [Cancel] [Open]  │
+└─────────────────────────────────────────┘
+```
+
+**Key changes from current:**
+- **Two-column split** — recents/favorites (45%) on left, file browser (55%) on right, separated by a vertical border
+- **Path input** — full width above the columns
+- **Folder creation collapsed** — just a `+ New Folder` text link at the bottom of the file browser column; clicking it expands an inline input + Create button; collapses back after creation or cancel
+- **Recents** — each item shows project name (bold), abbreviated path below, and a green dot for git repos
+- **File browser** — breadcrumb navigation above the directory listing; git repos show green dot + "git" badge
+- **"Select This Folder" → "Open"** — shorter, clearer action button
+- **Mobile** — columns stack vertically: recents on top, browser below
+
+### Settings Modal (Large — 640px, Tabbed Sidebar)
+
+Replace accordion layout with a left sidebar tab navigation.
+
+**Structure:**
+```
+┌─────────────────────────────────────────┐
+│ Settings                              ✕ │
+├────────────┬────────────────────────────┤
+│            │                            │
+│ Server  ◄──│ Port                       │
+│ Integra-   │ [8080]                     │
+│   tions    │ Requires restart           │
+│ Shortcuts  │                            │
+│ ────────── │ Ngrok Token       [changed]│
+│ Actions    │ [••••••••••]               │
+│            │ Requires restart           │
+│            │                            │
+│            │ Claude Binary              │
+│            │ [claude]                   │
+│            │                            │
+│            │ CLI Arguments              │
+│            │ [--dangerously-skip-perms] │
+│            │                            │
+├────────────┴────────────────────────────┤
+│ 1 unsaved change       [Cancel] [Save]  │
+└─────────────────────────────────────────┘
+```
+
+**Tabs:**
+1. **Server** (default/active) — Port, Ngrok Token, Claude Binary, CLI Arguments, Environment Variables, Compact Every N Continues, GitHub Token
+2. **Integrations** — Jira (URL, Token, Email), Asana (Token), Google Tasks (API Key); each integration in a bordered card; unconfigured ones show "Not configured" summary
+3. **Shortcuts** — key/value list with delete buttons, "+ Add Shortcut" at bottom
+4. **Actions** — separated from other tabs by a divider; red text; contains Restart Server button
+
+**Key changes from current:**
+- **Left sidebar** — 160px wide, background `var(--bg-surface)` or equivalent, active tab has accent-colored text + left border highlight + selected background
+- **Content panel** — scrolls independently; sidebar stays fixed
+- **Change indicators** — modified fields show a "changed" badge next to the label and a highlighted border on the input
+- **Sticky save footer** — spans full modal width; shows "N unsaved changes" count (or hidden when clean); Cancel + Save buttons always visible
+- **First-run flow** — still supported; title changes to "Welcome — Configure Claude Controller"; sidebar hidden during first-run; shows only Server fields + "Save & Continue" button
+- **Mobile** — sidebar becomes a horizontal scrollable tab bar at the top of the full-screen modal
+
+### Task Create/Edit Modal (Medium — 560px)
+
+Minimal changes — the current form layout works well.
+
+**Changes:**
+- Migrate all inline styles to shared CSS classes (`.modal-backdrop`, `.modal-md`, `.modal-header`, etc.)
+- `border-radius: 16px`
+- Slightly larger input padding (8px → 10px)
+- Consistent box-shadow with other modals
+- X close button in header
+
+### Resume Picker Modal (Small — 480px)
+
+**Changes:**
+- Migrate to CSS classes (`.modal-sm`)
+- Add X close button in header
+- Slightly more padding on list items (10px 12px → 12px 16px)
+- Consistent border-radius and shadow
+- Same list layout — it's already clean
+
+### Permission Prompt Modal (Small — 480px)
+
+**Changes:**
+- Migrate to CSS classes (`.modal-sm`)
+- Consistent border-radius (16px) and shadow
+- Same button layout: Deny (red), Allow Always (neutral), Allow (green)
+- No structural changes — it's functional as-is
+
+## Mobile Behavior
+
+All modals become full-screen on mobile (existing behavior), but implemented via the shared CSS classes rather than `!important` overrides:
+
+- `.modal-sm`, `.modal-md`, `.modal-lg` all get `width: 100vw; height: 100dvh; max-width: none; border-radius: 0` inside a `@media (max-width: 768px)` block
+- Sticky header with back button (existing pattern, now via `.modal-header`)
+- Desktop title hidden, mobile header shown (existing pattern)
+- **New Session mobile**: columns stack vertically — recents section on top, file browser below
+- **Settings mobile**: left sidebar becomes a horizontal scrollable tab bar at top
+
+## CSS Organization
+
+New CSS added to `style.css` (~80-100 lines):
+
+```
+/* ===== Modal System ===== */
+.modal-backdrop { ... }
+.modal-sm { width: 480px; }
+.modal-md { width: 560px; }
+.modal-lg { width: 640px; }
+.modal-header { ... }
+.modal-body { ... }
+.modal-footer { ... }
+.modal-close-btn { ... }
+
+/* New Session specific */
+.modal-columns { ... }
+.modal-sidebar-list { ... }
+
+/* Settings specific */
+.settings-tabs { ... }
+.settings-tab { ... }
+.settings-tab.active { ... }
+.settings-content { ... }
+.settings-change-badge { ... }
+
+/* Mobile overrides */
+@media (max-width: 768px) {
+  .modal-sm, .modal-md, .modal-lg { ... full-screen ... }
+  .modal-columns { flex-direction: column; }
+  .settings-tabs { ... horizontal tab bar ... }
+}
+```
+
+Inline styles on the 5 modal HTML blocks in `index.html` will be replaced with these classes.
+
+## What's NOT Changing
+
+- Modal open/close logic (Alpine.js `x-show` bindings)
+- Data flow (API calls, form submission, directory browsing)
+- Feature set (no features added or removed)
+- Shortcut picker popup (not a modal — separate component)
+- z-index hierarchy (100 for standard modals, 200 for Permission/Task)
+- Escape key behavior
+- Alpine.js state properties

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -49,6 +49,7 @@ document.addEventListener('alpine:init', () => {
     newProjectName: '',
     newProjectError: '',
     newProjectCreating: false,
+    showNewFolderInput: false,
     recentDirs: [],
 
     // Resume picker state
@@ -1236,6 +1237,7 @@ document.addEventListener('alpine:init', () => {
       this.newProjectName = '';
       this.newProjectError = '';
       this.newProjectCreating = false;
+      this.showNewFolderInput = false;
       // Fetch recent directories
       try {
         const res = await fetch('/api/sessions/recent-dirs', {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -134,7 +134,8 @@ document.addEventListener('alpine:init', () => {
     // Shortcuts state
     shortcuts: [],
     showShortcutPicker: false,
-    settingsAccordion: { server: false, integrations: false, shortcuts: false },
+    settingsActiveTab: 'server',
+    settingsOriginal: null,
 
     // Usage tracking
     lastTurnThreshold: 0,
@@ -482,6 +483,7 @@ document.addEventListener('alpine:init', () => {
     async openSettingsModal() {
       this.settingsError = '';
       this.settingsFirstRun = false;
+      this.settingsActiveTab = 'server';
       try {
         const res = await fetch('/api/settings', {
           headers: { 'Authorization': 'Bearer ' + this.apiKey }
@@ -503,10 +505,27 @@ document.addEventListener('alpine:init', () => {
           google_tasks_token: data.google_tasks_token || '',
           shortcuts: data.shortcuts || [],
         };
+        this.settingsOriginal = JSON.parse(JSON.stringify(this.settingsForm));
       } catch (e) {
         this.settingsForm = { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] };
       }
       this.showSettingsModal = true;
+    },
+
+    settingsChangeCount() {
+      if (!this.settingsOriginal) return 0;
+      let count = 0;
+      const keys = ['port', 'ngrok_authtoken', 'claude_bin', 'claude_args', 'claude_env', 'compact_every_n_continues', 'github_token', 'jira_url', 'jira_token', 'jira_email', 'asana_token', 'google_tasks_token'];
+      for (const key of keys) {
+        if (String(this.settingsForm[key] || '') !== String(this.settingsOriginal[key] || '')) count++;
+      }
+      if (JSON.stringify(this.settingsForm.shortcuts) !== JSON.stringify(this.settingsOriginal.shortcuts)) count++;
+      return count;
+    },
+
+    isFieldChanged(fieldName) {
+      if (!this.settingsOriginal) return false;
+      return String(this.settingsForm[fieldName] || '') !== String(this.settingsOriginal[fieldName] || '');
     },
 
     async saveSettings() {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1233,9 +1233,10 @@
 
   <!-- Settings Modal -->
   <div x-show="showSettingsModal" x-cloak
-       style="position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:100; display:flex; align-items:center; justify-content:center;"
+       class="modal-backdrop" style="z-index:100;"
        @click.self="showSettingsModal = false">
-    <div class="modal-inner" style="background:var(--bg); border-radius:12px; padding:24px; width:500px; max-width:90vw; border:1px solid var(--border); display:flex; flex-direction:column; max-height:80vh; overflow-y:auto;">
+    <div class="modal-lg" style="height:min(85vh, 520px);">
+      <!-- Mobile header -->
       <div class="mobile-detail-header mobile-modal-header">
         <button @click="showSettingsModal = false" class="mobile-back-btn" aria-label="Back">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
@@ -1244,164 +1245,205 @@
         </button>
         <span class="mobile-detail-title" x-text="settingsFirstRun ? 'Welcome \u2014 Configure Claude Controller' : 'Settings'"></span>
       </div>
-      <h3 class="desktop-modal-title" style="margin-top:0; margin-bottom:16px;" x-text="settingsFirstRun ? 'Welcome \u2014 Configure Claude Controller' : 'Settings'"></h3>
 
-      <!-- Server Configuration accordion -->
-      <div>
-        <div class="settings-accordion-header" @click="settingsAccordion.server = !settingsAccordion.server">
-          <h4>Server Configuration</h4>
-          <span class="settings-accordion-chevron" :class="{ open: settingsAccordion.server }">&#9654;</span>
+      <!-- Desktop header -->
+      <div class="modal-header desktop-modal-title">
+        <h3 x-text="settingsFirstRun ? 'Welcome \u2014 Configure Claude Controller' : 'Settings'"></h3>
+        <button class="modal-close-btn" @click="showSettingsModal = false" aria-label="Close">&times;</button>
+      </div>
+
+      <!-- Tabbed layout -->
+      <div class="settings-layout" x-show="!settingsFirstRun">
+        <!-- Sidebar tabs -->
+        <div class="settings-tabs">
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'server' }" @click="settingsActiveTab = 'server'">Server</div>
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'integrations' }" @click="settingsActiveTab = 'integrations'">Integrations</div>
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'shortcuts' }" @click="settingsActiveTab = 'shortcuts'">Shortcuts</div>
+          <div class="settings-tab-divider"></div>
+          <div class="settings-tab danger" :class="{ active: settingsActiveTab === 'actions' }" @click="settingsActiveTab = 'actions'">Actions</div>
         </div>
-        <div class="settings-accordion-body" x-show="settingsAccordion.server">
-          <div>
-            <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">PORT</label>
-            <input x-model="settingsForm.port" type="text" placeholder="8080"
-                   style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-            <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Server port (requires restart)</div>
+
+        <!-- Content panel -->
+        <div class="settings-content">
+          <!-- Server tab -->
+          <div x-show="settingsActiveTab === 'server'">
+            <div class="settings-field">
+              <label class="modal-label">
+                Port
+                <span x-show="isFieldChanged('port')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.port" type="text" placeholder="8080" class="modal-input" :style="isFieldChanged('port') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Server port (requires restart)</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Ngrok Auth Token
+                <span x-show="isFieldChanged('ngrok_authtoken')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.ngrok_authtoken" type="password" placeholder="ngrok auth token" class="modal-input" :style="isFieldChanged('ngrok_authtoken') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">For remote access via ngrok tunnel (requires restart)</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Claude Binary
+                <span x-show="isFieldChanged('claude_bin')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.claude_bin" type="text" placeholder="claude" class="modal-input" :style="isFieldChanged('claude_bin') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Path to Claude CLI binary</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                CLI Arguments
+                <span x-show="isFieldChanged('claude_args')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.claude_args" type="text" placeholder="--dangerously-skip-permissions" class="modal-input" :style="isFieldChanged('claude_args') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Space-separated CLI flags for managed sessions</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Environment Variables
+                <span x-show="isFieldChanged('claude_env')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.claude_env" type="text" placeholder="CLAUDE_CONFIG_DIR=/path" class="modal-input" :style="isFieldChanged('claude_env') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Comma-separated KEY=VALUE pairs for managed session environment</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                Compact Every N Continues
+                <span x-show="isFieldChanged('compact_every_n_continues')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.compact_every_n_continues" type="number" min="0" placeholder="0" class="modal-input" :style="isFieldChanged('compact_every_n_continues') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Run /compact every N auto-continues to reduce token usage. 0 = disabled.</div>
+            </div>
+
+            <div class="settings-field">
+              <label class="modal-label">
+                GitHub Token
+                <span x-show="isFieldChanged('github_token')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.github_token" type="password" placeholder="ghp_..." class="modal-input" :style="isFieldChanged('github_token') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Personal access token for GitHub issue tracking (needs repo scope)</div>
+            </div>
           </div>
 
-          <div>
-            <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">NGROK_AUTHTOKEN</label>
-            <input x-model="settingsForm.ngrok_authtoken" type="password" placeholder="ngrok auth token"
-                   style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-            <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">For remote access via ngrok tunnel (requires restart)</div>
+          <!-- Integrations tab -->
+          <div x-show="settingsActiveTab === 'integrations'">
+            <div style="font-size:12px; color:var(--text-muted); margin-bottom:16px;">
+              Connect project management tools to browse issues and tasks alongside GitHub.
+            </div>
+
+            <div style="border:1px solid var(--border); border-radius:10px; padding:14px; margin-bottom:12px;">
+              <div style="font-size:13px; font-weight:600; margin-bottom:10px; display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/></svg>
+                Jira
+              </div>
+              <div class="settings-field">
+                <label class="modal-label">Base URL</label>
+                <input x-model="settingsForm.jira_url" type="text" placeholder="https://yourorg.atlassian.net" class="modal-input">
+              </div>
+              <div class="settings-field">
+                <label class="modal-label">API Token</label>
+                <input x-model="settingsForm.jira_token" type="password" placeholder="Jira API token" class="modal-input">
+              </div>
+              <div class="settings-field" style="margin-bottom:0;">
+                <label class="modal-label">Email</label>
+                <input x-model="settingsForm.jira_email" type="email" placeholder="you@company.com" class="modal-input">
+              </div>
+            </div>
+
+            <div style="border:1px solid var(--border); border-radius:10px; padding:14px; margin-bottom:12px;">
+              <div style="font-size:13px; font-weight:600; margin-bottom:10px; display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
+                Asana
+              </div>
+              <div class="settings-field" style="margin-bottom:0;">
+                <label class="modal-label">Personal Access Token</label>
+                <input x-model="settingsForm.asana_token" type="password" placeholder="Asana personal access token" class="modal-input">
+              </div>
+            </div>
+
+            <div style="border:1px solid var(--border); border-radius:10px; padding:14px;">
+              <div style="font-size:13px; font-weight:600; margin-bottom:10px; display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
+                Google Tasks
+              </div>
+              <div class="settings-field" style="margin-bottom:0;">
+                <label class="modal-label">API Key</label>
+                <input x-model="settingsForm.google_tasks_token" type="password" placeholder="Google Tasks API key" class="modal-input">
+              </div>
+            </div>
           </div>
 
-          <div>
-            <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">CLAUDE_BIN</label>
-            <input x-model="settingsForm.claude_bin" type="text" placeholder="claude"
-                   style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-            <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Path to Claude CLI binary</div>
+          <!-- Shortcuts tab -->
+          <div x-show="settingsActiveTab === 'shortcuts'">
+            <div style="font-size:12px; color:var(--text-muted); margin-bottom:16px;">
+              Define shortcuts that map a key (emoji or text) to a message sent in chat.
+            </div>
+            <template x-for="(shortcut, idx) in settingsForm.shortcuts" :key="idx">
+              <div style="display:flex; gap:8px; align-items:center; margin-bottom:8px;">
+                <input x-model="shortcut.key" type="text" maxlength="20" placeholder="Key"
+                       class="modal-input" style="width:70px; flex-shrink:0; text-align:center;">
+                <input x-model="shortcut.value" type="text" placeholder="Message to send..."
+                       class="modal-input" style="flex:1;">
+                <button @click="settingsForm.shortcuts.splice(idx, 1)" class="btn btn-sm"
+                        style="padding:4px 8px; flex-shrink:0; color:var(--red);" title="Remove shortcut">&times;</button>
+              </div>
+            </template>
+            <button @click="settingsForm.shortcuts.push({key:'', value:''})" class="btn btn-sm"
+                    style="font-size:12px; color:var(--accent);">+ Add Shortcut</button>
           </div>
 
-          <div>
-            <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">CLAUDE_ARGS</label>
-            <input x-model="settingsForm.claude_args" type="text" placeholder="--dangerously-skip-permissions"
-                   style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-            <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Space-separated CLI flags for managed sessions</div>
-          </div>
-
-          <div>
-            <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">CLAUDE_ENV</label>
-            <input x-model="settingsForm.claude_env" type="text" placeholder="CLAUDE_CONFIG_DIR=/path"
-                   style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-            <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Comma-separated KEY=VALUE pairs for managed session environment</div>
-          </div>
-
-          <div>
-            <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">COMPACT_EVERY_N_CONTINUES</label>
-            <input x-model="settingsForm.compact_every_n_continues" type="number" min="0" placeholder="0"
-                   style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-            <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Run /compact every N auto-continues to reduce token usage. 0 = disabled.</div>
-          </div>
-
-          <div>
-            <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:4px;">GITHUB_TOKEN</label>
-            <input x-model="settingsForm.github_token" type="password" placeholder="ghp_..."
-                   style="width:100%; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-            <div style="font-size:11px; color:var(--text-muted); margin-top:2px;">Personal access token for GitHub issue tracking (needs repo scope)</div>
+          <!-- Actions tab -->
+          <div x-show="settingsActiveTab === 'actions'">
+            <div class="settings-field">
+              <button class="btn btn-sm" @click="restartServer()" :disabled="serverRestarting"
+                      style="background:var(--red); color:white; border:none; padding:10px 20px; border-radius:8px; cursor:pointer; font-size:13px;">
+                <span x-show="!serverRestarting">Restart Server</span>
+                <span x-show="serverRestarting">Restarting...</span>
+              </button>
+              <div class="modal-hint">Gracefully restarts the server, preserving all session state</div>
+            </div>
           </div>
         </div>
       </div>
 
-      <!-- Integrations accordion -->
-      <div>
-        <div class="settings-accordion-header" @click="settingsAccordion.integrations = !settingsAccordion.integrations">
-          <h4>Integrations</h4>
-          <span class="settings-accordion-chevron" :class="{ open: settingsAccordion.integrations }">&#9654;</span>
+      <!-- First-run flow (no sidebar, just server fields) -->
+      <div x-show="settingsFirstRun" class="modal-body" style="padding-top:16px;">
+        <div class="settings-field">
+          <label class="modal-label">Port</label>
+          <input x-model="settingsForm.port" type="text" placeholder="8080" class="modal-input">
+          <div class="modal-hint">Server port (requires restart)</div>
         </div>
-        <div class="settings-accordion-body" x-show="settingsAccordion.integrations">
-          <div style="font-size:12px; color:var(--text-muted); margin-bottom:8px;">
-            Connect project management tools to browse issues and tasks alongside GitHub.
-          </div>
-
-          <div style="border:1px solid var(--border); border-radius:8px; padding:12px; margin-bottom:12px;">
-            <div style="font-size:12px; font-weight:600; margin-bottom:8px; display:flex; align-items:center; gap:6px;">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/></svg>
-              Jira
-            </div>
-            <div>
-              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">BASE URL</label>
-              <input x-model="settingsForm.jira_url" type="text" placeholder="https://yourorg.atlassian.net"
-                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box; margin-bottom:6px;">
-            </div>
-            <div>
-              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">API TOKEN</label>
-              <input x-model="settingsForm.jira_token" type="password" placeholder="Jira API token"
-                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box; margin-bottom:6px;">
-            </div>
-            <div>
-              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">EMAIL</label>
-              <input x-model="settingsForm.jira_email" type="email" placeholder="you@company.com"
-                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box;">
-            </div>
-          </div>
-
-          <div style="border:1px solid var(--border); border-radius:8px; padding:12px; margin-bottom:12px;">
-            <div style="font-size:12px; font-weight:600; margin-bottom:8px; display:flex; align-items:center; gap:6px;">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
-              Asana
-            </div>
-            <div>
-              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">PERSONAL ACCESS TOKEN</label>
-              <input x-model="settingsForm.asana_token" type="password" placeholder="Asana personal access token"
-                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box;">
-            </div>
-          </div>
-
-          <div style="border:1px solid var(--border); border-radius:8px; padding:12px;">
-            <div style="font-size:12px; font-weight:600; margin-bottom:8px; display:flex; align-items:center; gap:6px;">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
-              Google Tasks
-            </div>
-            <div>
-              <label style="font-size:11px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:2px;">API KEY</label>
-              <input x-model="settingsForm.google_tasks_token" type="password" placeholder="Google Tasks API key"
-                     style="width:100%; padding:6px 8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:12px; box-sizing:border-box;">
-            </div>
-          </div>
+        <div class="settings-field">
+          <label class="modal-label">Ngrok Auth Token</label>
+          <input x-model="settingsForm.ngrok_authtoken" type="password" placeholder="ngrok auth token" class="modal-input">
+          <div class="modal-hint">For remote access via ngrok tunnel (requires restart)</div>
+        </div>
+        <div class="settings-field">
+          <label class="modal-label">Claude Binary</label>
+          <input x-model="settingsForm.claude_bin" type="text" placeholder="claude" class="modal-input">
+          <div class="modal-hint">Path to Claude CLI binary</div>
+        </div>
+        <div class="settings-field">
+          <label class="modal-label">CLI Arguments</label>
+          <input x-model="settingsForm.claude_args" type="text" placeholder="--dangerously-skip-permissions" class="modal-input">
+          <div class="modal-hint">Space-separated CLI flags for managed sessions</div>
         </div>
       </div>
 
-      <!-- Shortcuts accordion -->
-      <div>
-        <div class="settings-accordion-header" @click="settingsAccordion.shortcuts = !settingsAccordion.shortcuts">
-          <h4>Shortcuts</h4>
-          <span class="settings-accordion-chevron" :class="{ open: settingsAccordion.shortcuts }">&#9654;</span>
-        </div>
-        <div class="settings-accordion-body" x-show="settingsAccordion.shortcuts">
-          <div style="font-size:12px; color:var(--text-muted); margin-bottom:4px;">
-            Define shortcuts that map a key (emoji or text) to a message sent in chat.
-          </div>
-          <template x-for="(shortcut, idx) in settingsForm.shortcuts" :key="idx">
-            <div style="display:flex; gap:8px; align-items:center;">
-              <input x-model="shortcut.key" type="text" maxlength="20" placeholder="Key (e.g. 👍)"
-                     style="width:80px; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box; flex-shrink:0;">
-              <input x-model="shortcut.value" type="text" placeholder="Message to send..."
-                     style="flex:1; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;">
-              <button @click="settingsForm.shortcuts.splice(idx, 1)" class="btn btn-sm"
-                      style="padding:4px 8px; flex-shrink:0; color:var(--red);" title="Remove shortcut">&times;</button>
-            </div>
-          </template>
-          <button @click="settingsForm.shortcuts.push({key:'', value:''})" class="btn btn-sm"
-                  style="align-self:flex-start; font-size:12px;">+ Add Shortcut</button>
-        </div>
-      </div>
+      <!-- Error -->
+      <p class="error-msg" x-show="settingsError" x-text="settingsError" style="margin:0 24px 8px;"></p>
 
-      <p class="error-msg" x-show="settingsError" x-text="settingsError" style="margin-top:8px;"></p>
-
-      <!-- Actions -->
-      <div x-show="!settingsFirstRun" style="margin-top:20px; padding-top:16px; border-top:1px solid var(--border);">
-        <label style="font-size:12px; font-weight:600; color:var(--text-muted); display:block; margin-bottom:8px;">ACTIONS</label>
-        <button class="btn btn-sm" @click="restartServer()" :disabled="serverRestarting"
-                style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer; font-size:13px;">
-          <span x-show="!serverRestarting">Restart Server</span>
-          <span x-show="serverRestarting">Restarting...</span>
-        </button>
-        <div style="font-size:11px; color:var(--text-muted); margin-top:4px;">Gracefully restarts the server, preserving all session state</div>
-      </div>
-
-      <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:16px;">
+      <!-- Footer -->
+      <div class="modal-footer">
+        <template x-if="!settingsFirstRun && settingsChangeCount() > 0">
+          <span class="modal-footer-status" x-text="settingsChangeCount() + ' unsaved change' + (settingsChangeCount() > 1 ? 's' : '')"></span>
+        </template>
         <button class="btn btn-sm" @click="showSettingsModal = false; settingsFirstRun = false;" x-text="settingsFirstRun ? 'Skip' : 'Cancel'"></button>
         <button class="btn btn-sm btn-primary" @click="saveSettings()" :disabled="settingsSaving">
           <span x-show="!settingsSaving" x-text="settingsFirstRun ? 'Save & Continue' : 'Save'"></span>

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1095,9 +1095,9 @@
 
   <!-- Resume Picker Modal -->
   <div x-show="showResumePicker" x-cloak
-       style="position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:100; display:flex; align-items:center; justify-content:center;"
+       class="modal-backdrop" style="z-index:100;"
        @click.self="showResumePicker = false">
-    <div class="modal-inner" style="background:var(--bg); border-radius:12px; padding:24px; width:500px; max-width:90vw; border:1px solid var(--border); display:flex; flex-direction:column; max-height:70vh;">
+    <div class="modal-sm">
       <div class="mobile-detail-header mobile-modal-header">
         <button @click="showResumePicker = false" class="mobile-back-btn" aria-label="Back">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
@@ -1106,20 +1106,20 @@
         </button>
         <span class="mobile-detail-title">Resume a Session</span>
       </div>
-      <h3 class="desktop-modal-title" style="margin-top:0; margin-bottom:12px;">Resume a Session</h3>
-
-      <template x-if="resumeLoading">
-        <div style="padding:2rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading sessions...</div>
-      </template>
-
-      <template x-if="!resumeLoading && resumableSessions.length === 0">
-        <div style="padding:2rem; text-align:center; color:var(--text-muted); font-size:13px;">No sessions to resume</div>
-      </template>
-
-      <div style="overflow-y:auto; flex:1; min-height:0;">
+      <div class="modal-header desktop-modal-title">
+        <h3>Resume a Session</h3>
+        <button class="modal-close-btn" @click="showResumePicker = false" aria-label="Close">&times;</button>
+      </div>
+      <div class="modal-body">
+        <template x-if="resumeLoading">
+          <div style="padding:2rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading sessions...</div>
+        </template>
+        <template x-if="!resumeLoading && resumableSessions.length === 0">
+          <div style="padding:2rem; text-align:center; color:var(--text-muted); font-size:13px;">No sessions to resume</div>
+        </template>
         <template x-for="rs in resumableSessions" :key="rs.session_id">
           <div @click="resumeSession(rs.session_id, rs.summary)"
-               style="padding:10px 12px; border-bottom:1px solid var(--border); cursor:pointer; transition:background 0.15s;"
+               style="padding:12px 16px; border-bottom:1px solid var(--border); cursor:pointer; transition:background 0.15s;"
                onmouseenter="this.style.background='var(--hover)'"
                onmouseleave="this.style.background='transparent'">
             <div style="font-weight:600; font-size:14px; margin-bottom:2px;" x-text="rs.summary || 'Untitled session'"></div>
@@ -1132,8 +1132,7 @@
           </div>
         </template>
       </div>
-
-      <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:12px; flex-shrink:0;">
+      <div class="modal-footer">
         <button class="btn btn-sm" @click="showResumePicker = false">Cancel</button>
       </div>
     </div>
@@ -1141,9 +1140,9 @@
 
   <!-- Task Create/Edit Modal -->
   <div x-show="taskModalOpen" x-cloak
-       style="position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:200; display:flex; align-items:center; justify-content:center;"
+       class="modal-backdrop" style="z-index:200;"
        @click.self="taskModalOpen = false" @keydown.escape.window="taskModalOpen && (taskModalOpen = false)">
-    <div @click.stop class="modal-inner" style="background:var(--bg); border-radius:12px; padding:24px; border:1px solid var(--border); max-height:85vh; overflow-y:auto; width:500px; max-width:90vw; box-shadow:0 20px 60px rgba(0,0,0,0.5);">
+    <div @click.stop class="modal-md">
       <div class="mobile-detail-header mobile-modal-header">
         <button @click="taskModalOpen = false" class="mobile-back-btn" aria-label="Back">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
@@ -1152,81 +1151,82 @@
         </button>
         <span class="mobile-detail-title" x-text="editingTask ? editingTask.name : 'New Scheduled Task'"></span>
       </div>
-      <div class="desktop-modal-title" style="display:flex; align-items:center; justify-content:space-between; margin-bottom:16px;">
-        <h3 style="margin:0; font-size:1rem;" x-text="editingTask ? editingTask.name : 'New Scheduled Task'"></h3>
-        <div x-show="editingTask" style="display:flex; gap:6px;">
-          <button type="button" class="btn btn-sm" @click="triggerTask(editingTask.id)" style="font-size:0.75rem;">&#9654; Run Now</button>
-          <button type="button" class="btn btn-sm" @click="toggleTaskEnabled(editingTask); editingTask.enabled = !editingTask.enabled" style="font-size:0.75rem;"
-                  x-text="editingTask?.enabled ? 'Disable' : 'Enable'"></button>
-          <button type="button" class="btn btn-sm" @click="taskModalOpen = false; deleteTask(editingTask.id)" style="font-size:0.75rem; color:#ef4444;">Delete</button>
+      <div class="modal-header desktop-modal-title">
+        <h3 x-text="editingTask ? editingTask.name : 'New Scheduled Task'"></h3>
+        <div style="display:flex; align-items:center; gap:6px;">
+          <template x-if="editingTask">
+            <div style="display:flex; gap:6px;">
+              <button type="button" class="btn btn-sm" @click="triggerTask(editingTask.id)" style="font-size:0.75rem;">&#9654; Run Now</button>
+              <button type="button" class="btn btn-sm" @click="toggleTaskEnabled(editingTask); editingTask.enabled = !editingTask.enabled" style="font-size:0.75rem;"
+                      x-text="editingTask?.enabled ? 'Disable' : 'Enable'"></button>
+              <button type="button" class="btn btn-sm" @click="taskModalOpen = false; deleteTask(editingTask.id)" style="font-size:0.75rem; color:#ef4444;">Delete</button>
+            </div>
+          </template>
+          <button class="modal-close-btn" @click="taskModalOpen = false" aria-label="Close">&times;</button>
         </div>
       </div>
-      <form @submit.prevent="saveTask()">
-        <div style="margin-bottom:12px;">
-          <label style="display:block; font-size:0.8rem; margin-bottom:4px; color:var(--text-muted);">Name</label>
-          <input type="text" x-model="taskForm.name" required
-                 style="width:100%; padding:8px; background:var(--input-bg); color:var(--text); border:1px solid var(--border); border-radius:6px; box-sizing:border-box;"
-                 placeholder="e.g., Daily Backup">
-        </div>
-        <div style="margin-bottom:12px;">
-          <label style="display:block; font-size:0.8rem; margin-bottom:4px; color:var(--text-muted);">Type</label>
-          <select x-model="taskForm.task_type"
-                  style="width:100%; padding:8px; background:var(--input-bg); color:var(--text); border:1px solid var(--border); border-radius:6px;">
-            <option value="shell">Shell Command</option>
-            <option value="claude">Claude Command</option>
-          </select>
-        </div>
-        <div style="margin-bottom:12px;">
-          <label style="display:block; font-size:0.8rem; margin-bottom:4px; color:var(--text-muted);"
-                 x-text="taskForm.task_type === 'claude' ? 'Prompt' : 'Command'"></label>
-          <textarea x-model="taskForm.command" required rows="3"
-                    style="width:100%; padding:8px; background:var(--input-bg); color:var(--text); border:1px solid var(--border); border-radius:6px; font-family:monospace; font-size:0.85rem; resize:vertical; box-sizing:border-box;"
-                    :placeholder="taskForm.task_type === 'claude' ? 'e.g., Summarize the latest changes' : 'e.g., tar -czf backup.tar.gz ./data'"></textarea>
-        </div>
-        <div style="margin-bottom:12px;">
-          <label style="display:block; font-size:0.8rem; margin-bottom:4px; color:var(--text-muted);">Working Directory</label>
-          <input type="text" x-model="taskForm.working_directory" required
-                 style="width:100%; padding:8px; background:var(--input-bg); color:var(--text); border:1px solid var(--border); border-radius:6px; font-family:monospace; font-size:0.85rem; box-sizing:border-box;"
-                 placeholder="/absolute/path/to/project">
-        </div>
-        <div style="margin-bottom:12px;">
-          <label style="display:block; font-size:0.8rem; margin-bottom:4px; color:var(--text-muted);">Cron Expression</label>
-          <input type="text" x-model="taskForm.cron_expression" required
-                 style="width:100%; padding:8px; background:var(--input-bg); color:var(--text); border:1px solid var(--border); border-radius:6px; font-family:monospace; font-size:0.85rem; box-sizing:border-box;"
-                 placeholder="0 9 * * *">
-          <div style="font-size:0.7rem; color:var(--text-muted); margin-top:4px;">
-            min hour day month weekday |
-            <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 * * * *'">hourly</span>
-            <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 9 * * *'">daily 9am</span>
-            <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 9 * * 1-5'">weekdays</span>
-            <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '*/5 * * * *'">every 5min</span>
+      <div class="modal-body">
+        <form @submit.prevent="saveTask()">
+          <div class="settings-field">
+            <label class="modal-label">Name</label>
+            <input type="text" x-model="taskForm.name" required class="modal-input" placeholder="e.g., Daily Backup">
           </div>
-        </div>
-        <div x-show="taskFormErrors" style="color:#ef4444; font-size:0.8rem; margin-bottom:8px;" x-text="taskFormErrors"></div>
-        <div style="display:flex; gap:8px; justify-content:flex-end;">
-          <button type="button" class="btn btn-sm" @click="taskModalOpen = false">Cancel</button>
-          <button type="submit" class="btn btn-sm btn-primary" :disabled="taskLoading" x-text="editingTask ? 'Update' : 'Create'"></button>
-        </div>
-      </form>
-
-      <!-- Recent Runs (only when editing) -->
-      <div x-show="editingTask && taskRuns.length > 0" style="margin-top:16px; border-top:1px solid var(--border); padding-top:16px;">
-        <h4 style="margin:0 0 10px 0; font-size:0.85rem; color:var(--text-muted);">Recent Runs</h4>
-        <template x-for="run in taskRuns.slice(0, 5)" :key="run.id">
-          <div style="border:1px solid var(--border); border-radius:6px; padding:8px 10px; margin-bottom:6px; font-size:0.8rem;">
-            <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:4px;">
-              <div style="display:flex; align-items:center; gap:6px;">
-                <span style="width:7px; height:7px; border-radius:50%;"
-                      :style="'background:' + (run.status === 'success' ? '#22c55e' : run.status === 'failed' ? '#ef4444' : '#eab308')"></span>
-                <span style="font-weight:500;" x-text="run.status"></span>
-                <span style="font-size:0.75rem; color:var(--text-muted);" x-text="formatRelativeTime(run.started_at)"></span>
-              </div>
-              <span style="font-size:0.7rem; color:var(--text-muted);" x-show="run.exit_code != null" x-text="'exit ' + run.exit_code"></span>
+          <div class="settings-field">
+            <label class="modal-label">Type</label>
+            <select x-model="taskForm.task_type" class="modal-input">
+              <option value="shell">Shell Command</option>
+              <option value="claude">Claude Command</option>
+            </select>
+          </div>
+          <div class="settings-field">
+            <label class="modal-label" x-text="taskForm.task_type === 'claude' ? 'Prompt' : 'Command'"></label>
+            <textarea x-model="taskForm.command" required rows="3"
+                      class="modal-input" style="font-family:monospace; font-size:0.85rem; resize:vertical;"
+                      :placeholder="taskForm.task_type === 'claude' ? 'e.g., Summarize the latest changes' : 'e.g., tar -czf backup.tar.gz ./data'"></textarea>
+          </div>
+          <div class="settings-field">
+            <label class="modal-label">Working Directory</label>
+            <input type="text" x-model="taskForm.working_directory" required
+                   class="modal-input" style="font-family:monospace; font-size:0.85rem;"
+                   placeholder="/absolute/path/to/project">
+          </div>
+          <div class="settings-field">
+            <label class="modal-label">Cron Expression</label>
+            <input type="text" x-model="taskForm.cron_expression" required
+                   class="modal-input" style="font-family:monospace; font-size:0.85rem;"
+                   placeholder="0 9 * * *">
+            <div class="modal-hint">
+              min hour day month weekday |
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 * * * *'">hourly</span>
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 9 * * *'">daily 9am</span>
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 9 * * 1-5'">weekdays</span>
+              <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '*/5 * * * *'">every 5min</span>
             </div>
-            <div x-show="run.output" style="background:var(--input-bg); border-radius:4px; padding:6px; font-family:monospace; font-size:0.7rem; white-space:pre-wrap; word-break:break-all; max-height:120px; overflow-y:auto; color:var(--text-muted);"
-                 x-text="(run.output || '').substring(0, 300) + ((run.output || '').length > 300 ? '\n...' : '')"></div>
           </div>
-        </template>
+          <div x-show="taskFormErrors" style="color:#ef4444; font-size:0.8rem; margin-bottom:8px;" x-text="taskFormErrors"></div>
+          <div x-show="editingTask && taskRuns.length > 0" style="margin-top:8px; border-top:1px solid var(--border); padding-top:16px;">
+            <h4 style="margin:0 0 10px 0; font-size:0.85rem; color:var(--text-muted);">Recent Runs</h4>
+            <template x-for="run in taskRuns.slice(0, 5)" :key="run.id">
+              <div style="border:1px solid var(--border); border-radius:8px; padding:8px 10px; margin-bottom:6px; font-size:0.8rem;">
+                <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:4px;">
+                  <div style="display:flex; align-items:center; gap:6px;">
+                    <span style="width:7px; height:7px; border-radius:50%;"
+                          :style="'background:' + (run.status === 'success' ? '#22c55e' : run.status === 'failed' ? '#ef4444' : '#eab308')"></span>
+                    <span style="font-weight:500;" x-text="run.status"></span>
+                    <span style="font-size:0.75rem; color:var(--text-muted);" x-text="formatRelativeTime(run.started_at)"></span>
+                  </div>
+                  <span style="font-size:0.7rem; color:var(--text-muted);" x-show="run.exit_code != null" x-text="'exit ' + run.exit_code"></span>
+                </div>
+                <div x-show="run.output" style="background:var(--input-bg); border-radius:4px; padding:6px; font-family:monospace; font-size:0.7rem; white-space:pre-wrap; word-break:break-all; max-height:120px; overflow-y:auto; color:var(--text-muted);"
+                     x-text="(run.output || '').substring(0, 300) + ((run.output || '').length > 300 ? '\n...' : '')"></div>
+              </div>
+            </template>
+          </div>
+          <div class="modal-footer" style="margin:16px -24px -24px; padding:16px 24px;">
+            <button type="button" class="btn btn-sm" @click="taskModalOpen = false">Cancel</button>
+            <button type="submit" class="btn btn-sm btn-primary" :disabled="taskLoading" x-text="editingTask ? 'Update' : 'Create'"></button>
+          </div>
+        </form>
       </div>
     </div>
   </div>
@@ -1455,37 +1455,41 @@
 
   <!-- Permission Prompt Modal -->
   <div x-show="pendingPermission" x-cloak
-       style="position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:200; display:flex; align-items:center; justify-content:center;">
-    <div @click.stop class="modal-inner" style="background:var(--bg); border-radius:12px; padding:24px; width:500px; max-width:90vw; border:1px solid var(--border); box-shadow:0 20px 60px rgba(0,0,0,0.5);">
-      <h3 style="margin-top:0; margin-bottom:16px; display:flex; align-items:center; gap:8px;">
-        <span style="color:var(--yellow);">&#9888;</span> Permission Required
-      </h3>
-      <template x-if="pendingPermission">
-        <div>
-          <div style="margin-bottom:12px;">
-            <span style="font-weight:600;" x-text="pendingPermission.tool_name || 'Tool'"></span>
-            <span style="color:var(--text-muted); margin-left:8px;" x-text="pendingPermission.description || ''"></span>
+       class="modal-backdrop" style="z-index:200;">
+    <div @click.stop class="modal-sm">
+      <div class="modal-header">
+        <h3 style="display:flex; align-items:center; gap:8px;">
+          <span style="color:var(--yellow);">&#9888;</span> Permission Required
+        </h3>
+      </div>
+      <div class="modal-body" style="padding-bottom:16px;">
+        <template x-if="pendingPermission">
+          <div>
+            <div style="margin-bottom:12px;">
+              <span style="font-weight:600;" x-text="pendingPermission.tool_name || 'Tool'"></span>
+              <span style="color:var(--text-muted); margin-left:8px;" x-text="pendingPermission.description || ''"></span>
+            </div>
+            <template x-if="pendingPermission.input">
+              <pre style="background:var(--input-bg); border:1px solid var(--border); border-radius:8px; padding:12px; font-size:12px; overflow-x:auto; max-height:200px; overflow-y:auto; margin-bottom:16px; white-space:pre-wrap; word-break:break-all;"
+                   x-text="typeof pendingPermission.input === 'string' ? pendingPermission.input : JSON.stringify(pendingPermission.input, null, 2)"></pre>
+            </template>
           </div>
-          <template x-if="pendingPermission.input">
-            <pre style="background:var(--input-bg); border:1px solid var(--border); border-radius:6px; padding:12px; font-size:12px; overflow-x:auto; max-height:200px; overflow-y:auto; margin-bottom:16px; white-space:pre-wrap; word-break:break-all;"
-                 x-text="typeof pendingPermission.input === 'string' ? pendingPermission.input : JSON.stringify(pendingPermission.input, null, 2)"></pre>
-          </template>
-          <div style="display:flex; gap:8px; justify-content:flex-end;">
-            <button class="btn" @click="respondToPermission('deny')"
-                    style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer;">
-              Deny
-            </button>
-            <button class="btn" @click="respondToPermission('allow_always')"
-                    style="background:var(--input-bg); color:var(--text); border:1px solid var(--border); padding:8px 16px; border-radius:6px; cursor:pointer;">
-              Allow Always
-            </button>
-            <button class="btn" @click="respondToPermission('allow')"
-                    style="background:var(--green); color:white; border:none; padding:8px 16px; border-radius:6px; cursor:pointer;">
-              Allow
-            </button>
-          </div>
-        </div>
-      </template>
+        </template>
+      </div>
+      <div class="modal-footer">
+        <button class="btn" @click="respondToPermission('deny')"
+                style="background:var(--red); color:white; border:none; padding:8px 16px; border-radius:8px; cursor:pointer;">
+          Deny
+        </button>
+        <button class="btn" @click="respondToPermission('allow_always')"
+                style="background:var(--input-bg); color:var(--text); border:1px solid var(--border); padding:8px 16px; border-radius:8px; cursor:pointer;">
+          Allow Always
+        </button>
+        <button class="btn" @click="respondToPermission('allow')"
+                style="background:var(--green); color:white; border:none; padding:8px 16px; border-radius:8px; cursor:pointer;">
+          Allow
+        </button>
+      </div>
     </div>
   </div>
 

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -997,10 +997,10 @@
       <div style="padding:0 24px 12px;">
         <div style="display:flex; gap:8px;">
           <input x-model="newSessionCWD" type="text" placeholder="/path/to/project"
-                 class="modal-input" style="flex:1;"
+                 class="modal-input" style="flex:1; min-width:0;"
                  @keydown="handleBrowseInputKeydown($event)"
                  @input="if (newSessionCWD === browsePath) { browseFilter = ''; } else if (browsePath && newSessionCWD.startsWith(browsePath + '/')) { browseFilter = newSessionCWD.slice(browsePath.length + 1); }">
-          <button class="btn btn-sm btn-primary" @click="browseTo(newSessionCWD)" style="white-space:nowrap;">Go</button>
+          <button class="btn btn-sm btn-primary" @click="browseTo(newSessionCWD)" style="white-space:nowrap; width:auto; flex-shrink:0;">Go</button>
         </div>
         <div x-show="browseConfirmed" style="font-size:11px; color:var(--accent); margin-top:4px;">
           Press Enter again to start session in this folder

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -974,99 +974,120 @@
 
   <!-- New Session Modal -->
   <div x-show="showNewSessionModal" x-cloak
-       style="position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:100; display:flex; align-items:center; justify-content:center;"
+       class="modal-backdrop" style="z-index:100;"
        @click.self="showNewSessionModal = false">
-    <div class="modal-inner" style="background:var(--bg); border-radius:12px; padding:24px; width:500px; max-width:90vw; border:1px solid var(--border); display:flex; flex-direction:column; max-height:70vh;">
+    <div class="modal-lg">
+      <!-- Mobile header -->
       <div class="mobile-detail-header mobile-modal-header">
         <button @click="showNewSessionModal = false" class="mobile-back-btn" aria-label="Back">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
             <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
           </svg>
         </button>
-        <span class="mobile-detail-title">New Managed Session</span>
-      </div>
-      <h3 class="desktop-modal-title" style="margin-top:0; margin-bottom:12px;">New Managed Session</h3>
-
-      <!-- Path input with search -->
-      <div style="display:flex; gap:8px; margin-bottom:4px;">
-        <input x-model="newSessionCWD" type="text" placeholder="/path/to/project"
-               style="flex:1; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;"
-               @keydown="handleBrowseInputKeydown($event)"
-               @input="if (newSessionCWD === browsePath) { browseFilter = ''; } else if (browsePath && newSessionCWD.startsWith(browsePath + '/')) { browseFilter = newSessionCWD.slice(browsePath.length + 1); }">
-        <button class="btn btn-sm" @click="browseTo(newSessionCWD)" style="white-space:nowrap;">Go</button>
-      </div>
-      <div x-show="browseConfirmed" style="font-size:11px; color:var(--accent); margin-bottom:8px;">
-        Press Enter again to start session in this folder
-      </div>
-      <div x-show="!browseConfirmed && browseFilter" style="font-size:11px; color:var(--text-muted); margin-bottom:8px;">
-        Filtering: <span x-text="browseFilter"></span>
+        <span class="mobile-detail-title">New Session</span>
       </div>
 
-      <!-- Recent directories -->
-      <template x-if="recentDirs.length > 0">
-        <div style="margin-bottom:8px;">
-          <div style="font-size:11px; color:var(--text-muted); margin-bottom:4px; font-weight:600;">Recent Projects</div>
+      <!-- Desktop header -->
+      <div class="modal-header desktop-modal-title">
+        <h3>New Session</h3>
+        <button class="modal-close-btn" @click="showNewSessionModal = false" aria-label="Close">&times;</button>
+      </div>
+
+      <!-- Path input -->
+      <div style="padding:0 24px 12px;">
+        <div style="display:flex; gap:8px;">
+          <input x-model="newSessionCWD" type="text" placeholder="/path/to/project"
+                 class="modal-input" style="flex:1;"
+                 @keydown="handleBrowseInputKeydown($event)"
+                 @input="if (newSessionCWD === browsePath) { browseFilter = ''; } else if (browsePath && newSessionCWD.startsWith(browsePath + '/')) { browseFilter = newSessionCWD.slice(browsePath.length + 1); }">
+          <button class="btn btn-sm btn-primary" @click="browseTo(newSessionCWD)" style="white-space:nowrap;">Go</button>
+        </div>
+        <div x-show="browseConfirmed" style="font-size:11px; color:var(--accent); margin-top:4px;">
+          Press Enter again to start session in this folder
+        </div>
+        <div x-show="!browseConfirmed && browseFilter" style="font-size:11px; color:var(--text-muted); margin-top:4px;">
+          Filtering: <span x-text="browseFilter"></span>
+        </div>
+      </div>
+
+      <!-- Two-column body -->
+      <div class="modal-columns">
+        <!-- Left: Recent Projects -->
+        <div class="modal-columns-left">
+          <div class="modal-section-label">Recent Projects</div>
+          <template x-if="recentDirs.length === 0">
+            <div style="font-size:12px; color:var(--text-muted);">No recent projects</div>
+          </template>
           <template x-for="dir in recentDirs" :key="dir.path">
-            <div class="browse-item" @click="selectRecentDir(dir.path)" style="cursor:pointer;">
+            <div class="browse-item" @click="selectRecentDir(dir.path)" style="cursor:pointer; border-radius:8px; padding:10px 12px; margin-bottom:4px;">
               <span class="browse-icon" style="color:var(--accent);">&#9733;</span>
-              <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:500;" x-text="dir.name"></span>
-              <span style="font-size:10px; color:var(--text-muted); flex-shrink:0;" x-text="abbreviatePath(dir.path)"></span>
+              <div style="flex:1; min-width:0;">
+                <div style="font-weight:600; font-size:13px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="dir.name"></div>
+                <div style="font-size:10px; color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="abbreviatePath(dir.path)"></div>
+              </div>
             </div>
           </template>
         </div>
-      </template>
 
-      <!-- Breadcrumb navigation -->
-      <div class="browse-breadcrumbs">
-        <template x-for="(crumb, i) in breadcrumbs" :key="crumb.path">
-          <span>
-            <span x-show="i > 0" style="color:var(--text-muted); margin:0 2px;">/</span>
-            <a href="#" @click.prevent="browseTo(crumb.path)" x-text="crumb.label"
-               style="color:var(--accent); text-decoration:none; font-size:13px;"></a>
-          </span>
-        </template>
-      </div>
-
-      <!-- Directory list -->
-      <div class="browse-list">
-        <template x-if="browseLoading">
-          <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-        </template>
-        <template x-if="!browseLoading && filteredBrowseEntries.length === 0">
-          <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;" x-text="browseFilter ? 'No matching directories' : 'No subdirectories'"></div>
-        </template>
-        <template x-for="entry in filteredBrowseEntries" :key="entry.path">
-          <div class="browse-item" @click="browseFilter = ''; browseTo(entry.path)">
-            <span class="browse-icon" x-text="entry.is_git_repo ? '&#9679;' : '&#128193;'"
-                  :style="entry.is_git_repo ? 'color:var(--green)' : 'color:var(--text-muted)'"></span>
-            <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="entry.name"></span>
-            <span x-show="entry.is_git_repo" style="font-size:10px; color:var(--green); flex-shrink:0;">git</span>
+        <!-- Right: File Browser -->
+        <div class="modal-columns-right">
+          <!-- Breadcrumbs -->
+          <div class="browse-breadcrumbs" style="margin-bottom:10px;">
+            <template x-for="(crumb, i) in breadcrumbs" :key="crumb.path">
+              <span>
+                <span x-show="i > 0" style="color:var(--text-muted); margin:0 2px;">&rsaquo;</span>
+                <a href="#" @click.prevent="browseTo(crumb.path)" x-text="crumb.label"
+                   style="color:var(--accent); text-decoration:none; font-size:13px;"></a>
+              </span>
+            </template>
           </div>
-        </template>
+
+          <!-- Directory list -->
+          <div class="browse-list" style="flex:1; min-height:0;">
+            <template x-if="browseLoading">
+              <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+            </template>
+            <template x-if="!browseLoading && filteredBrowseEntries.length === 0">
+              <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;" x-text="browseFilter ? 'No matching directories' : 'No subdirectories'"></div>
+            </template>
+            <template x-for="entry in filteredBrowseEntries" :key="entry.path">
+              <div class="browse-item" @click="browseFilter = ''; browseTo(entry.path)">
+                <span class="browse-icon" x-text="entry.is_git_repo ? '&#9679;' : '&#128193;'"
+                      :style="entry.is_git_repo ? 'color:var(--green)' : 'color:var(--text-muted)'"></span>
+                <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" x-text="entry.name"></span>
+                <span x-show="entry.is_git_repo" style="font-size:10px; color:var(--green); flex-shrink:0;">git</span>
+              </div>
+            </template>
+          </div>
+
+          <!-- Collapsed New Folder -->
+          <div class="new-folder-toggle" @click="showNewFolderInput = !showNewFolderInput" x-show="!showNewFolderInput">
+            + New Folder
+          </div>
+          <div x-show="showNewFolderInput" style="margin-top:8px; padding-top:8px; border-top:1px solid var(--border);">
+            <div style="display:flex; gap:8px;">
+              <input x-model="newProjectName" type="text" placeholder="Folder name..."
+                     class="modal-input" style="flex:1;"
+                     @keydown.enter.prevent="createNewProject()"
+                     @keydown.escape.prevent="showNewFolderInput = false; newProjectName = ''">
+              <button class="btn btn-sm btn-primary" @click="createNewProject()"
+                      :disabled="!isValidNewProjectName || newProjectCreating"
+                      x-text="newProjectCreating ? 'Creating...' : 'Create'"></button>
+              <button class="btn btn-sm" @click="showNewFolderInput = false; newProjectName = ''">&times;</button>
+            </div>
+            <div x-show="newProjectName && !isValidNewProjectName" style="font-size:11px; color:var(--red); margin-top:4px;">
+              Use letters, numbers, hyphens, dots, or underscores.
+            </div>
+            <div x-show="newProjectError" style="font-size:11px; color:var(--red); margin-top:4px;" x-text="newProjectError"></div>
+          </div>
+        </div>
       </div>
 
-      <!-- New Project -->
-      <div style="border-top:1px solid var(--border); padding-top:10px; margin-top:8px;">
-        <div style="font-size:11px; color:var(--text-muted); margin-bottom:6px;">Create new project in this folder:</div>
-        <div style="display:flex; gap:8px;">
-          <input x-model="newProjectName" type="text" placeholder="New project name..."
-                 style="flex:1; padding:8px; background:var(--input-bg); border:1px solid var(--border); border-radius:6px; color:var(--text); font-size:13px; box-sizing:border-box;"
-                 @keydown.enter.prevent="createNewProject()">
-          <button class="btn btn-sm btn-primary" @click="createNewProject()"
-                  :disabled="!isValidNewProjectName || newProjectCreating"
-                  x-text="newProjectCreating ? 'Creating...' : 'Create'"></button>
-        </div>
-        <div x-show="newProjectName && !isValidNewProjectName" style="font-size:11px; color:var(--red); margin-top:4px;">
-          Use letters, numbers, hyphens, dots, or underscores. Must start/end with alphanumeric.
-        </div>
-        <div x-show="newProjectError" style="font-size:11px; color:var(--red); margin-top:4px;" x-text="newProjectError"></div>
-      </div>
-
-      <!-- Actions -->
-      <div style="display:flex; gap:8px; justify-content:flex-end; margin-top:12px; flex-shrink:0;">
+      <!-- Footer -->
+      <div class="modal-footer">
         <button class="btn btn-sm" @click="showNewSessionModal = false">Cancel</button>
         <button class="btn btn-sm btn-primary" @click="createManagedSession()" :disabled="!newSessionCWD.trim()">
-          Select This Folder
+          Open
         </button>
       </div>
     </div>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1273,6 +1273,11 @@ body {
   flex-shrink: 0;
 }
 
+.modal-footer .btn-primary,
+.modal-header .btn-primary {
+  width: auto;
+}
+
 .modal-input {
   width: 100%;
   padding: 10px 12px;

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1192,6 +1192,249 @@ body {
 }
 .chat-bubble.user .markdown-content a { color: #fff; }
 
+/* ===== Modal System ===== */
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-sm,
+.modal-md,
+.modal-lg {
+  background: var(--bg);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  max-height: 85vh;
+  max-width: 90vw;
+}
+
+.modal-sm { width: 480px; }
+.modal-md { width: 560px; }
+.modal-lg { width: 640px; }
+
+.modal-header {
+  padding: 20px 24px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.modal-close-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.modal-close-btn:hover {
+  background: var(--border);
+}
+
+.modal-body {
+  padding: 0 24px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.modal-input {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--input-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  box-sizing: border-box;
+}
+
+.modal-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.modal-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.modal-hint {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 3px;
+}
+
+/* ===== New Session Modal ===== */
+.modal-columns {
+  display: flex;
+  min-height: 280px;
+  border-top: 1px solid var(--border);
+}
+
+.modal-columns-left {
+  width: 45%;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.modal-columns-right {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.modal-section-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.new-folder-toggle {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.new-folder-toggle:hover {
+  text-decoration: underline;
+}
+
+/* ===== Settings Modal ===== */
+.settings-layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  border-top: 1px solid var(--border);
+}
+
+.settings-tabs {
+  width: 160px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  padding: 12px 0;
+  background: var(--bg-secondary);
+}
+
+.settings-tab {
+  padding: 8px 16px;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-left: 2px solid transparent;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+  background: var(--bg);
+}
+
+.settings-tab.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: var(--bg);
+  font-weight: 500;
+}
+
+.settings-tab-divider {
+  border-top: 1px solid var(--border);
+  margin: 8px 16px;
+}
+
+.settings-tab.danger {
+  color: var(--red);
+}
+
+.settings-tab.danger:hover {
+  background: var(--bg);
+}
+
+.settings-content {
+  flex: 1;
+  padding: 20px 24px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.settings-section-header {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-field {
+  margin-bottom: 16px;
+}
+
+.settings-change-badge {
+  font-size: 9px;
+  background: var(--yellow);
+  color: #000;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+  margin-left: 6px;
+}
+
+.modal-footer-status {
+  margin-right: auto;
+  font-size: 12px;
+  color: var(--yellow);
+  font-weight: 500;
+}
+
 /* ===== Mobile Menu (hidden on desktop) ===== */
 .mobile-hamburger { display: none; }
 .mobile-menu-overlay { display: none; }
@@ -1397,10 +1640,10 @@ body {
     min-height: 0;
   }
 
-  /* Full-screen modals on mobile */
-  .mobile-menu-overlay ~ div[x-show="showNewSessionModal"] > div,
-  .mobile-menu-overlay ~ div[x-show="showResumePicker"] > div,
-  .mobile-menu-overlay ~ div[x-show="taskModalOpen"] > div {
+  /* Modal full-screen on mobile */
+  .modal-sm,
+  .modal-md,
+  .modal-lg {
     width: 100vw !important;
     height: 100vh !important;
     height: 100dvh !important;
@@ -1409,15 +1652,69 @@ body {
     border-radius: 0 !important;
   }
 
+  .modal-header {
+    padding: 12px 16px;
+  }
+
+  .modal-body {
+    padding: 0 16px;
+  }
+
+  .modal-footer {
+    padding: 12px 16px;
+  }
+
+  /* New Session: stack columns vertically on mobile */
+  .modal-columns {
+    flex-direction: column;
+  }
+
+  .modal-columns-left {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    max-height: 200px;
+  }
+
+  .modal-columns-right {
+    flex: 1;
+  }
+
+  /* Settings: horizontal tab bar on mobile */
+  .settings-layout {
+    flex-direction: column;
+  }
+
+  .settings-tabs {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    overflow-x: auto;
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  .settings-tab {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    white-space: nowrap;
+    padding: 10px 16px;
+  }
+
+  .settings-tab.active {
+    border-left-color: transparent;
+    border-bottom-color: var(--accent);
+  }
+
+  .settings-tab-divider {
+    display: none;
+  }
+
   /* Larger tap targets in modals */
   .browse-item {
     min-height: 44px;
     padding: 10px 12px;
-  }
-
-  /* On mobile, remove top padding from modal so header sits flush */
-  .modal-inner {
-    padding-top: 0 !important;
   }
 
   /* Mobile modal header: sticky at top of scrollable modal */

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -2297,40 +2297,6 @@ body {
   }
 }
 
-/* Settings accordion */
-.settings-accordion-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border);
-  user-select: none;
-}
-.settings-accordion-header:hover {
-  color: var(--accent);
-}
-.settings-accordion-header h4 {
-  margin: 0;
-  font-size: 13px;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-.settings-accordion-chevron {
-  font-size: 12px;
-  color: var(--text-muted);
-  transition: transform 0.15s;
-}
-.settings-accordion-chevron.open {
-  transform: rotate(90deg);
-}
-.settings-accordion-body {
-  padding-top: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
 
 /* Image upload button */
 .image-upload-btn {


### PR DESCRIPTION
## Summary

- **Unified modal CSS system** — replaces all inline styles across 5 modals with shared CSS classes (`.modal-backdrop`, `.modal-sm/md/lg`, `.modal-header/body/footer`)
- **New Session modal redesigned** — two-column layout with recents on left, file browser on right; folder creation collapsed to a subtle "+ New Folder" link
- **Settings modal redesigned** — tabbed sidebar (Server/Integrations/Shortcuts/Actions) replacing accordions; sticky footer with unsaved change count and field-level "changed" badges
- **Task, Resume, Permission modals** — migrated to unified CSS classes with consistent border-radius (16px), shadows, and close buttons

Closes #119

## Design

- Spec: `docs/superpowers/specs/2026-04-19-modal-redesign-design.md`
- Plan: `docs/superpowers/plans/2026-04-19-modal-redesign.md`

## Test plan

- [ ] Open New Session modal — verify two-column layout, recents left, browser right
- [ ] Click "+ New Folder" — verify it expands inline, collapses on cancel/escape
- [ ] Open Settings — verify tabbed sidebar with 4 tabs (Server, Integrations, Shortcuts, Actions)
- [ ] Edit a settings field — verify "changed" badge appears and footer shows unsaved count
- [ ] Open Task editor, Resume picker, Permission prompt — verify consistent styling
- [ ] Test all modals on mobile (responsive mode) — full-screen, stacked columns, horizontal tabs
- [ ] Run `go test ./...` — all pass