### PR TITLE
feat: configurable status line for managed sessions (#64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,5 @@ docker compose down                             # Stop
 - Session activity state plan: `docs/superpowers/plans/2026-03-23-session-activity-state.md`
 - Shortcut creator spec: `docs/superpowers/specs/2026-04-03-shortcut-creator-design.md`
 - Shortcut creator plan: `docs/superpowers/plans/2026-04-03-shortcut-creator.md`
+- Status line spec: `docs/superpowers/specs/2026-04-19-status-line-design.md`
+- Status line plan: `docs/superpowers/plans/2026-04-19-status-line.md`

--- a/docs/superpowers/plans/2026-04-19-status-line.md
+++ b/docs/superpowers/plans/2026-04-19-status-line.md
@@ -1,0 +1,335 @@
+# Status Line Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a configurable status line footer bar to the web UI showing session metadata (model, cost, context %, turns, activity, working directory) for managed sessions.
+
+**Architecture:** Frontend-only feature. Alpine.js state holds status line config (persisted to localStorage) and session model name (parsed from NDJSON stream). New "Status Line" tab in existing Settings modal with toggle checkboxes. Status line HTML sits between the instruction-bar and the end of the chat-column.
+
+**Tech Stack:** Alpine.js, vanilla CSS, localStorage
+
+---
+
+### Task 1: Add Alpine state and localStorage persistence for status line config
+
+**Files:**
+- Modify: `server/web/static/app.js:171` (add state properties after `sessionCost`)
+- Modify: `server/web/static/app.js:242-254` (load config in `init()`)
+- Modify: `server/web/static/app.js:857` (reset `sessionModel` on session switch)
+
+- [ ] **Step 1: Add state properties**
+
+In `server/web/static/app.js`, after line 171 (`sessionCost: null,`), add:
+
+```javascript
+    sessionModel: null,
+    statusLineConfig: {
+      model: true,
+      cost: true,
+      context: false,
+      turns: false,
+      activity: false,
+      cwd: false,
+    },
+```
+
+- [ ] **Step 2: Add config loading in init()**
+
+In `server/web/static/app.js`, inside the `init()` method, after line 244 (`this.voiceChatSupported = ...;`), add:
+
+```javascript
+      // Load status line config from localStorage
+      try {
+        const saved = localStorage.getItem('statusLineConfig');
+        if (saved) {
+          const parsed = JSON.parse(saved);
+          this.statusLineConfig = { ...this.statusLineConfig, ...parsed };
+        }
+      } catch (e) { /* ignore corrupt localStorage */ }
+```
+
+- [ ] **Step 3: Add helper methods**
+
+In `server/web/static/app.js`, add these methods (after the existing `turnBarColor()` method around line 728):
+
+```javascript
+    toggleStatusLineItem(key) {
+      this.statusLineConfig[key] = !this.statusLineConfig[key];
+      localStorage.setItem('statusLineConfig', JSON.stringify(this.statusLineConfig));
+    },
+
+    statusLineVisible() {
+      const sess = this.sessions.find(s => s.id === this.selectedSessionId);
+      if (!sess || sess.mode !== 'managed') return false;
+      return Object.values(this.statusLineConfig).some(v => v);
+    },
+```
+
+- [ ] **Step 4: Reset sessionModel on session switch**
+
+In `server/web/static/app.js`, inside `selectSession()`, after line 857 (`this.sessionCost = null;`), add:
+
+```javascript
+      this.sessionModel = null;
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/web/static/app.js
+git commit -m "feat(ui): add Alpine state and localStorage for status line config (#64)"
+```
+
+---
+
+### Task 2: Parse model name from NDJSON system/init event
+
+**Files:**
+- Modify: `server/web/static/app.js:1938` (SSE message handler, after the system error block)
+
+- [ ] **Step 1: Add model extraction from system/init events**
+
+In `server/web/static/app.js`, in the SSE `onmessage` handler, find the block at line 1938:
+
+```javascript
+          } else if (data.type === 'system' && data.error) {
+```
+
+Insert **before** that `else if` (after the closing `}` of the assistant text block at line 1937):
+
+```javascript
+          // Capture model name from system init event
+          if (data.type === 'system' && data.subtype === 'init' && data.model) {
+            this.sessionModel = data.model;
+          }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/web/static/app.js
+git commit -m "feat(ui): parse model name from NDJSON system/init event (#64)"
+```
+
+---
+
+### Task 3: Add status line HTML to index.html
+
+**Files:**
+- Modify: `server/web/static/index.html:362` (after instruction-bar closing `</div>`, before chat-column closing `</div>`)
+
+- [ ] **Step 1: Add status line HTML**
+
+In `server/web/static/index.html`, after line 362 (the `</div>` that closes the `.instruction-bar`), add:
+
+```html
+            <!-- Status line -->
+            <div class="status-line" x-show="statusLineVisible()" x-cloak>
+              <template x-if="statusLineConfig.model">
+                <span class="status-line-item" x-show="sessionModel">
+                  <span class="status-line-label">Model</span>
+                  <span x-text="sessionModel"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.cost">
+                <span class="status-line-item">
+                  <span class="status-line-label">Cost</span>
+                  <span x-text="sessionCost != null ? '$' + sessionCost.toFixed(4) : '$0.00'"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.context">
+                <span class="status-line-item" style="display:none;">
+                  <span class="status-line-label">Context</span>
+                  <span>—</span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.turns">
+                <span class="status-line-item" x-show="currentSession?.max_turns > 0">
+                  <span class="status-line-label">Turns</span>
+                  <span x-text="(currentSession?.turn_count || 0) + '/' + (currentSession?.max_turns || 0)"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.activity">
+                <span class="status-line-item">
+                  <span class="status-line-label">Activity</span>
+                  <span class="status-line-dot"
+                        :style="'background:' + (currentSession?.activity_state === 'working' ? '#f39c12' : currentSession?.activity_state === 'waiting' ? '#22c55e' : '#6b7280')"></span>
+                  <span x-text="currentSession?.activity_state || 'idle'"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.cwd">
+                <span class="status-line-item" x-show="currentSession?.cwd">
+                  <span class="status-line-label">CWD</span>
+                  <span x-text="currentSession?.cwd" style="max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-block; vertical-align:bottom;"></span>
+                </span>
+              </template>
+            </div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/web/static/index.html
+git commit -m "feat(ui): add status line HTML to chat column (#64)"
+```
+
+---
+
+### Task 4: Add status line CSS
+
+**Files:**
+- Modify: `server/web/static/style.css:535` (after `.instruction-bar` styles)
+
+- [ ] **Step 1: Add status line CSS**
+
+In `server/web/static/style.css`, after line 535 (the closing `}` of `.instruction-bar`), add:
+
+```css
+/* Status line */
+.status-line {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: var(--bg);
+  flex-shrink: 0;
+  min-height: 24px;
+}
+.status-line-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.status-line-item + .status-line-item::before {
+  content: '|';
+  color: var(--border);
+  margin-right: 4px;
+}
+.status-line-label {
+  opacity: 0.6;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.status-line-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add server/web/static/style.css
+git commit -m "feat(ui): add status line CSS styles (#64)"
+```
+
+---
+
+### Task 5: Add Status Line settings tab
+
+**Files:**
+- Modify: `server/web/static/index.html:1261` (settings tabs list)
+- Modify: `server/web/static/index.html:1400` (before Actions tab content)
+
+- [ ] **Step 1: Add the tab button**
+
+In `server/web/static/index.html`, after line 1261 (the Shortcuts tab div):
+
+```html
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'shortcuts' }" @click="settingsActiveTab = 'shortcuts'">Shortcuts</div>
+```
+
+Add:
+
+```html
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'statusline' }" @click="settingsActiveTab = 'statusline'">Status Line</div>
+```
+
+- [ ] **Step 2: Add the tab content**
+
+In `server/web/static/index.html`, after the Shortcuts tab content closing `</div>` (at line 1399, after the `</div>` that closes the `x-show="settingsActiveTab === 'shortcuts'"` block), add:
+
+```html
+          <!-- Status Line tab -->
+          <div x-show="settingsActiveTab === 'statusline'">
+            <div style="font-size:12px; color:var(--text-muted); margin-bottom:16px;">
+              Choose which items appear in the bottom status bar for managed sessions.
+            </div>
+            <template x-for="item in [
+              { key: 'model', label: 'Model', desc: 'Claude model name (e.g., Opus 4.6)' },
+              { key: 'cost', label: 'Cost', desc: 'Accumulated session cost' },
+              { key: 'context', label: 'Context %', desc: 'Context window usage (when available)' },
+              { key: 'turns', label: 'Turns', desc: 'Turn count / max turns' },
+              { key: 'activity', label: 'Activity', desc: 'Session activity state (working/waiting/idle)' },
+              { key: 'cwd', label: 'Working Dir', desc: 'Session working directory' },
+            ]" :key="item.key">
+              <div style="display:flex; align-items:center; gap:10px; padding:8px 0; border-bottom:1px solid var(--border);">
+                <label style="display:flex; align-items:center; gap:8px; cursor:pointer; flex:1;">
+                  <input type="checkbox" :checked="statusLineConfig[item.key]"
+                         @change="toggleStatusLineItem(item.key)"
+                         style="width:16px; height:16px; accent-color:var(--accent); cursor:pointer;">
+                  <div>
+                    <div style="font-size:13px; font-weight:500;" x-text="item.label"></div>
+                    <div style="font-size:11px; color:var(--text-muted);" x-text="item.desc"></div>
+                  </div>
+                </label>
+              </div>
+            </template>
+          </div>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/web/static/index.html
+git commit -m "feat(ui): add Status Line tab to Settings modal (#64)"
+```
+
+---
+
+### Task 6: Manual verification and final commit
+
+- [ ] **Step 1: Build and run the server**
+
+```bash
+cd server && go build -o claude-controller . && echo "Build OK"
+```
+
+- [ ] **Step 2: Verify the status line renders**
+
+Start the server and open the web UI. Create or select a managed session. Verify:
+- Status line appears at the bottom of the chat area
+- Model and Cost items are visible by default
+- Other items are hidden
+
+- [ ] **Step 3: Verify Settings tab works**
+
+Open Settings → Status Line tab. Toggle items on/off. Verify:
+- Changes immediately reflect in the status line
+- Refreshing the page preserves the config
+
+- [ ] **Step 4: Verify model name parsing**
+
+Send a message in a managed session. After the response, verify the Model item shows the model name (parsed from the NDJSON init event).
+
+- [ ] **Step 5: Update CLAUDE.md with spec/plan references**
+
+In `CLAUDE.md`, add to the Spec & Plan section:
+
+```markdown
+- Status line spec: `docs/superpowers/specs/2026-04-19-status-line-design.md`
+- Status line plan: `docs/superpowers/plans/2026-04-19-status-line.md`
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add status line spec/plan references to CLAUDE.md (#64)"
+```

--- a/docs/superpowers/specs/2026-04-19-status-line-design.md
+++ b/docs/superpowers/specs/2026-04-19-status-line-design.md
@@ -1,0 +1,118 @@
+# Status Line Design
+
+## Overview
+
+Add a configurable status line to the Claude Controller web UI, similar to the Claude Code CLI's status line. It displays session metadata (model, cost, context %, turns, activity state, working directory) in a persistent footer bar, with per-item visibility toggleable from the Settings modal.
+
+## Requirements
+
+- **Bottom bar**: Persistent footer pinned to the bottom of the `.main` area, below the chat input
+- **Configurable**: Each item can be toggled on/off via a new "Status Line" tab in the Settings modal
+- **Defaults**: Model and Cost enabled by default; all others off
+- **Persistence**: Configuration stored in `localStorage` under key `statusLineConfig`
+- **Managed sessions only**: Status line only visible when a managed session is selected (same as turns-monitor)
+
+## Available Items
+
+| Item | Key | Default | Data Source |
+|------|-----|---------|-------------|
+| Model | `model` | on | NDJSON `system/init` event — `{"type":"system","subtype":"init","model":"..."}` |
+| Cost | `cost` | on | Existing `sessionCost` accumulator from `result` events |
+| Context % | `context` | off | NDJSON `system` events if available; hidden if data not present |
+| Turns | `turns` | off | Existing `turn_count / max_turns` from session object |
+| Activity | `activity` | off | Existing `activity_state` from session object |
+| Working Dir | `cwd` | off | Existing `cwd` from session object |
+
+## Architecture
+
+### Data Flow — Model Name
+
+The Claude CLI NDJSON stream emits a `{"type":"system","subtype":"init"}` line at process start. This includes a `model` field. The frontend SSE handler already processes these NDJSON lines — we capture and store the model name in Alpine state as `sessionModel`. Reset to `null` on session switch.
+
+### Data Flow — Context %
+
+Claude CLI's NDJSON stream may include context window usage in `system` events. If the data is present, we parse and display it. If not, the item simply doesn't render (no error, no placeholder). No custom hook bridge for v1.
+
+### Settings UI
+
+New "Status Line" tab added to the Settings modal, positioned between "Shortcuts" and the divider. Contains labeled checkboxes for each of the 6 items. Changes apply immediately (no restart needed). The tab follows the existing settings pattern with `.settings-field` classes.
+
+Default `statusLineConfig` value:
+```json
+{
+  "model": true,
+  "cost": true,
+  "context": false,
+  "turns": false,
+  "activity": false,
+  "cwd": false
+}
+```
+
+Loaded from `localStorage` on app init. Written back on any toggle change.
+
+### Status Line HTML
+
+A `<div class="status-line">` element placed after the chat input area inside `.main`, containing a `<template x-for>` or individual `<span>` elements for each enabled item. Items are separated by `|` divider spans.
+
+Structure:
+```
+┌─────────────────────────────────────────┐
+│  Opus 4.6  |  $0.42                     │
+└─────────────────────────────────────────┘
+```
+
+### CSS
+
+- Pinned to bottom of `.main` via standard flow (not absolute/fixed positioning)
+- Height: single line, ~32px with padding
+- Font: `0.8rem`, color `var(--text-muted)` — matches `turns-monitor` styling
+- Background: `var(--bg)` with top border `1px solid var(--border)`
+- Items: `display: flex; align-items: center; gap: 8px;`
+- Dividers: `color: var(--border)` pipe characters
+- Responsive: on small screens, items wrap naturally; abbreviated labels if needed
+- Hidden when no managed session is selected or all items are toggled off
+
+### Alpine State
+
+New state properties in the main `Alpine.data` object:
+
+- `sessionModel: null` — string, set from NDJSON `system/init`
+- `statusLineConfig: { model: true, cost: true, context: false, turns: false, activity: false, cwd: false }` — loaded from localStorage on init
+
+New methods:
+
+- `initStatusLineConfig()` — reads from localStorage, merges with defaults
+- `toggleStatusLineItem(key)` — flips the boolean and persists to localStorage
+- `statusLineVisible()` — returns true if managed session selected AND at least one item is enabled
+
+### NDJSON Parsing Change
+
+In the existing SSE message handler (app.js ~line 1860-1970), add a check for `system/init` events:
+
+```javascript
+if (data.type === 'system' && data.subtype === 'init' && data.model) {
+  this.sessionModel = data.model;
+}
+```
+
+## Scope
+
+### In Scope
+- Status line footer bar with 6 configurable items
+- Settings modal tab with checkboxes
+- localStorage persistence
+- Model name extraction from NDJSON stream
+
+### Out of Scope
+- Hook mode sessions (no NDJSON stream available)
+- Custom hook bridge for context window data
+- Drag-and-drop reordering of items
+- Server-side persistence of status line config
+- Context % if Claude CLI doesn't emit it in NDJSON
+
+## Files to Modify
+
+1. **`server/web/static/index.html`** — Add status line HTML after chat input, add Settings tab
+2. **`server/web/static/app.js`** — Add state, methods, NDJSON parsing for model
+3. **`server/web/static/style.css`** — Add `.status-line` styles

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1935,6 +1935,11 @@ document.addEventListener('alpine:init', () => {
             this.addActivityPill('Thinking...', 'active');
           }
 
+          // Capture model name from system init event
+          if (data.type === 'system' && data.subtype === 'init' && data.model) {
+            this.sessionModel = data.model;
+          }
+
           // Only display assistant messages and error events
           if (data.type === 'assistant' && data.message) {
             // Extract text blocks from message content

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -169,6 +169,15 @@ document.addEventListener('alpine:init', () => {
     slashFilter: '',
     slashSelectedIndex: 0,
     sessionCost: null,
+    sessionModel: null,
+    statusLineConfig: {
+      model: true,
+      cost: true,
+      context: false,
+      turns: false,
+      activity: false,
+      cwd: false,
+    },
 
     // Activity Status Pills
     stalenessTimer: null,
@@ -242,6 +251,14 @@ document.addEventListener('alpine:init', () => {
     async init() {
       // Detect Web Speech API support
       this.voiceChatSupported = !!(window.SpeechRecognition || window.webkitSpeechRecognition) && !!window.speechSynthesis;
+      // Load status line config from localStorage
+      try {
+        const saved = localStorage.getItem('statusLineConfig');
+        if (saved) {
+          const parsed = JSON.parse(saved);
+          this.statusLineConfig = { ...this.statusLineConfig, ...parsed };
+        }
+      } catch (e) { /* ignore corrupt localStorage */ }
       if (this.apiKey) {
         await this.tryConnect(this.apiKey);
         await this.loadScheduledTasks();
@@ -721,6 +738,17 @@ document.addEventListener('alpine:init', () => {
       return 'var(--accent)';
     },
 
+    toggleStatusLineItem(key) {
+      this.statusLineConfig[key] = !this.statusLineConfig[key];
+      localStorage.setItem('statusLineConfig', JSON.stringify(this.statusLineConfig));
+    },
+
+    statusLineVisible() {
+      const sess = this.sessions.find(s => s.id === this.selectedSessionId);
+      if (!sess || sess.mode !== 'managed') return false;
+      return Object.values(this.statusLineConfig).some(v => v);
+    },
+
     pendingCountFor(sessionId) {
       return this.prompts.filter(p =>
         p.status === 'pending' && p.type === 'prompt' &&
@@ -855,6 +883,7 @@ document.addEventListener('alpine:init', () => {
       this.slashCommandsLoaded = false;
       this.showSlashMenu = false;
       this.sessionCost = null;
+      this.sessionModel = null;
       this.continuationCount = 0;
       this.isCompacting = false;
       this.sessionFiles = [];

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -744,7 +744,7 @@ document.addEventListener('alpine:init', () => {
     },
 
     statusLineVisible() {
-      const sess = this.sessions.find(s => s.id === this.selectedSessionId);
+      const sess = this.currentSession;
       if (!sess || sess.mode !== 'managed') return false;
       return Object.values(this.statusLineConfig).some(v => v);
     },

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -360,6 +360,48 @@
                 <span class="input-hint">⌘↵ to send</span>
               </div>
             </div>
+
+            <!-- Status line -->
+            <div class="status-line" x-show="statusLineVisible()" x-cloak>
+              <template x-if="statusLineConfig.model">
+                <span class="status-line-item" x-show="sessionModel">
+                  <span class="status-line-label">Model</span>
+                  <span x-text="sessionModel"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.cost">
+                <span class="status-line-item">
+                  <span class="status-line-label">Cost</span>
+                  <span x-text="sessionCost != null ? '$' + sessionCost.toFixed(4) : '$0.00'"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.context">
+                <span class="status-line-item" style="display:none;">
+                  <span class="status-line-label">Context</span>
+                  <span>—</span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.turns">
+                <span class="status-line-item" x-show="currentSession?.max_turns > 0">
+                  <span class="status-line-label">Turns</span>
+                  <span x-text="(currentSession?.turn_count || 0) + '/' + (currentSession?.max_turns || 0)"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.activity">
+                <span class="status-line-item">
+                  <span class="status-line-label">Activity</span>
+                  <span class="status-line-dot"
+                        :style="'background:' + (currentSession?.activity_state === 'working' ? '#f39c12' : currentSession?.activity_state === 'waiting' ? '#22c55e' : '#6b7280')"></span>
+                  <span x-text="currentSession?.activity_state || 'idle'"></span>
+                </span>
+              </template>
+              <template x-if="statusLineConfig.cwd">
+                <span class="status-line-item" x-show="currentSession?.cwd">
+                  <span class="status-line-label">CWD</span>
+                  <span x-text="currentSession?.cwd" style="max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-block; vertical-align:bottom;"></span>
+                </span>
+              </template>
+            </div>
           </div>
 
           <!-- File viewer resize handle -->

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -363,8 +363,8 @@
 
             <!-- Status line -->
             <div class="status-line" x-show="statusLineVisible()" x-cloak>
-              <template x-if="statusLineConfig.model">
-                <span class="status-line-item" x-show="sessionModel">
+              <template x-if="statusLineConfig.model && sessionModel">
+                <span class="status-line-item">
                   <span class="status-line-label">Model</span>
                   <span x-text="sessionModel"></span>
                 </span>
@@ -372,17 +372,11 @@
               <template x-if="statusLineConfig.cost">
                 <span class="status-line-item">
                   <span class="status-line-label">Cost</span>
-                  <span x-text="sessionCost != null ? '$' + sessionCost.toFixed(4) : '$0.00'"></span>
+                  <span x-text="sessionCost != null ? '$' + sessionCost.toFixed(4) : '$0.0000'"></span>
                 </span>
               </template>
-              <template x-if="statusLineConfig.context">
-                <span class="status-line-item" style="display:none;">
-                  <span class="status-line-label">Context</span>
-                  <span>—</span>
-                </span>
-              </template>
-              <template x-if="statusLineConfig.turns">
-                <span class="status-line-item" x-show="currentSession?.max_turns > 0">
+              <template x-if="statusLineConfig.turns && currentSession?.max_turns > 0">
+                <span class="status-line-item">
                   <span class="status-line-label">Turns</span>
                   <span x-text="(currentSession?.turn_count || 0) + '/' + (currentSession?.max_turns || 0)"></span>
                 </span>
@@ -395,8 +389,8 @@
                   <span x-text="currentSession?.activity_state || 'idle'"></span>
                 </span>
               </template>
-              <template x-if="statusLineConfig.cwd">
-                <span class="status-line-item" x-show="currentSession?.cwd">
+              <template x-if="statusLineConfig.cwd && currentSession?.cwd">
+                <span class="status-line-item">
                   <span class="status-line-label">CWD</span>
                   <span x-text="currentSession?.cwd" style="max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-block; vertical-align:bottom;"></span>
                 </span>
@@ -1449,7 +1443,6 @@
             <template x-for="item in [
               { key: 'model', label: 'Model', desc: 'Claude model name (e.g., Opus 4.6)' },
               { key: 'cost', label: 'Cost', desc: 'Accumulated session cost' },
-              { key: 'context', label: 'Context %', desc: 'Context window usage (when available)' },
               { key: 'turns', label: 'Turns', desc: 'Turn count / max turns' },
               { key: 'activity', label: 'Activity', desc: 'Session activity state (working/waiting/idle)' },
               { key: 'cwd', label: 'Working Dir', desc: 'Session working directory' },

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1301,6 +1301,7 @@
           <div class="settings-tab" :class="{ active: settingsActiveTab === 'server' }" @click="settingsActiveTab = 'server'">Server</div>
           <div class="settings-tab" :class="{ active: settingsActiveTab === 'integrations' }" @click="settingsActiveTab = 'integrations'">Integrations</div>
           <div class="settings-tab" :class="{ active: settingsActiveTab === 'shortcuts' }" @click="settingsActiveTab = 'shortcuts'">Shortcuts</div>
+          <div class="settings-tab" :class="{ active: settingsActiveTab === 'statusline' }" @click="settingsActiveTab = 'statusline'">Status Line</div>
           <div class="settings-tab-divider"></div>
           <div class="settings-tab danger" :class="{ active: settingsActiveTab === 'actions' }" @click="settingsActiveTab = 'actions'">Actions</div>
         </div>
@@ -1438,6 +1439,33 @@
             </template>
             <button @click="settingsForm.shortcuts.push({key:'', value:''})" class="btn btn-sm"
                     style="font-size:12px; color:var(--accent);">+ Add Shortcut</button>
+          </div>
+
+          <!-- Status Line tab -->
+          <div x-show="settingsActiveTab === 'statusline'">
+            <div style="font-size:12px; color:var(--text-muted); margin-bottom:16px;">
+              Choose which items appear in the bottom status bar for managed sessions.
+            </div>
+            <template x-for="item in [
+              { key: 'model', label: 'Model', desc: 'Claude model name (e.g., Opus 4.6)' },
+              { key: 'cost', label: 'Cost', desc: 'Accumulated session cost' },
+              { key: 'context', label: 'Context %', desc: 'Context window usage (when available)' },
+              { key: 'turns', label: 'Turns', desc: 'Turn count / max turns' },
+              { key: 'activity', label: 'Activity', desc: 'Session activity state (working/waiting/idle)' },
+              { key: 'cwd', label: 'Working Dir', desc: 'Session working directory' },
+            ]" :key="item.key">
+              <div style="display:flex; align-items:center; gap:10px; padding:8px 0; border-bottom:1px solid var(--border);">
+                <label style="display:flex; align-items:center; gap:8px; cursor:pointer; flex:1;">
+                  <input type="checkbox" :checked="statusLineConfig[item.key]"
+                         @change="toggleStatusLineItem(item.key)"
+                         style="width:16px; height:16px; accent-color:var(--accent); cursor:pointer;">
+                  <div>
+                    <div style="font-size:13px; font-weight:500;" x-text="item.label"></div>
+                    <div style="font-size:11px; color:var(--text-muted);" x-text="item.desc"></div>
+                  </div>
+                </label>
+              </div>
+            </template>
           </div>
 
           <!-- Actions tab -->

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -575,6 +575,42 @@ body {
 }
 .instruction-bar .helper { font-size: 0.6875rem; color: var(--text-muted); }
 
+/* Status line */
+.status-line {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: var(--bg);
+  flex-shrink: 0;
+  min-height: 24px;
+}
+.status-line-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.status-line-item + .status-line-item::before {
+  content: '|';
+  color: var(--border);
+  margin-right: 4px;
+}
+.status-line-label {
+  opacity: 0.6;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.status-line-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
 /* Connection banner */
 .connection-banner {
   background: var(--yellow);

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -579,7 +579,8 @@ body {
 .status-line {
   display: flex;
   align-items: center;
-  gap: 12px;
+  flex-wrap: wrap;
+  gap: 4px 12px;
   padding: 4px 1rem;
   border-top: 1px solid var(--border);
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- Adds a configurable status line footer bar to the bottom of the chat area for managed sessions
- Shows model name (parsed from NDJSON system/init event) and session cost by default
- 6 toggleable items: Model, Cost, Context %, Turns, Activity, Working Dir
- New "Status Line" tab in Settings modal with checkboxes, persisted to localStorage

Closes #64

## Test plan
- [ ] Select a managed session — status line appears at bottom with Model and Cost
- [ ] Open Settings → Status Line tab — toggle items on/off, verify immediate effect
- [ ] Refresh page — verify config persists via localStorage
- [ ] Send a message — verify model name populates from NDJSON init event
- [ ] Switch sessions — verify model/cost reset
- [ ] Select a hook-mode session — verify status line is hidden