### PR TITLE
feat: model selection for chat and scheduled tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,5 @@ docker compose down                             # Stop
 - Shortcut creator plan: `docs/superpowers/plans/2026-04-03-shortcut-creator.md`
 - Status line spec: `docs/superpowers/specs/2026-04-19-status-line-design.md`
 - Status line plan: `docs/superpowers/plans/2026-04-19-status-line.md`
+- Model selection spec: `docs/superpowers/specs/2026-04-22-model-selection-design.md`
+- Model selection plan: `docs/superpowers/plans/2026-04-22-model-selection.md`

--- a/docs/superpowers/plans/2026-04-22-model-selection.md
+++ b/docs/superpowers/plans/2026-04-22-model-selection.md
@@ -1,0 +1,503 @@
+# Model Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-turn model selection to the chat UI and per-task model selection for scheduled tasks.
+
+**Architecture:** Model is ephemeral per-turn for chat (stored in localStorage, sent with each message POST). For scheduled tasks, model is persisted in the `scheduled_tasks` DB table. The `--model` CLI flag is appended to process args when a model is specified.
+
+**Tech Stack:** Go (server), SQLite (DB), Alpine.js (frontend)
+
+---
+
+### Task 1: Add model field to scheduled tasks DB layer
+
+**Files:**
+- Modify: `server/db/db.go:101-114` (migrations)
+- Modify: `server/db/scheduled_tasks.go:19-32` (struct), `44` (taskColumns), `46-59` (scanTask), `78` (CreateScheduledTask), `130` (UpdateScheduledTask)
+- Modify: `server/db/scheduled_tasks_test.go`
+
+- [ ] **Step 1: Write failing test for model field in scheduled tasks**
+
+Add to `server/db/scheduled_tasks_test.go`:
+
+```go
+func TestScheduledTaskModelField(t *testing.T) {
+	store := newTestStore(t)
+	task, err := store.CreateScheduledTask("", "Model task", "claude", "summarize", "/tmp", "0 9 * * *", "claude-opus-4-6")
+	if err != nil {
+		t.Fatalf("CreateScheduledTask: %v", err)
+	}
+	if task.Model != "claude-opus-4-6" {
+		t.Errorf("model: got %q, want %q", task.Model, "claude-opus-4-6")
+	}
+
+	// Verify empty model works
+	task2, err := store.CreateScheduledTask("", "No model", "shell", "echo hi", "/tmp", "0 * * * *", "")
+	if err != nil {
+		t.Fatalf("CreateScheduledTask: %v", err)
+	}
+	if task2.Model != "" {
+		t.Errorf("model: got %q, want empty", task2.Model)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./db/ -v -run TestScheduledTaskModelField`
+Expected: FAIL — `CreateScheduledTask` has wrong number of arguments
+
+- [ ] **Step 3: Add migration, update struct, columns, scan, and create/update functions**
+
+In `server/db/db.go`, add migration after line 132 (the `compact_every_n_continues` migration):
+
+```go
+`ALTER TABLE scheduled_tasks ADD COLUMN model TEXT NOT NULL DEFAULT ''`,
+```
+
+In `server/db/scheduled_tasks.go`:
+
+Add `Model` field to `ScheduledTask` struct (after `UpdatedAt`):
+
+```go
+Model            string     `json:"model"`
+```
+
+Update `taskColumns` constant to:
+
+```go
+const taskColumns = `id, session_id, name, task_type, command, working_directory, cron_expression, enabled, last_run_at, next_run_at, created_at, updated_at, COALESCE(model,'')`
+```
+
+Update `scanTask` to scan Model — add `&t.Model` at the end of the Scan call:
+
+```go
+err := scanner.Scan(
+    &t.ID, &t.SessionID, &t.Name, &t.TaskType, &t.Command,
+    &t.WorkingDirectory, &t.CronExpression, &enabled,
+    &t.LastRunAt, &t.NextRunAt, &t.CreatedAt, &t.UpdatedAt,
+    &t.Model,
+)
+```
+
+Update `CreateScheduledTask` signature to accept `model string`:
+
+```go
+func (s *Store) CreateScheduledTask(sessionID, name, taskType, command, workingDir, cronExpr, model string) (*ScheduledTask, error) {
+```
+
+Update the INSERT SQL in `CreateScheduledTask`:
+
+```go
+_, err := s.db.Exec(`
+    INSERT INTO scheduled_tasks (id, session_id, name, task_type, command, working_directory, cron_expression, model, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+`, id, sessPtr, name, taskType, command, workingDir, cronExpr, model)
+```
+
+Update `UpdateScheduledTask` signature to accept `model string`:
+
+```go
+func (s *Store) UpdateScheduledTask(id, name, taskType, command, workingDir, cronExpr string, enabled bool, model string) error {
+```
+
+Update the UPDATE SQL:
+
+```go
+_, err := s.db.Exec(`
+    UPDATE scheduled_tasks
+    SET name = ?, task_type = ?, command = ?, working_directory = ?, cron_expression = ?, enabled = ?, model = ?, updated_at = datetime('now')
+    WHERE id = ?
+`, name, taskType, command, workingDir, cronExpr, enabledInt, model, id)
+```
+
+- [ ] **Step 4: Fix all callers of CreateScheduledTask and UpdateScheduledTask**
+
+Update existing test calls in `server/db/scheduled_tasks_test.go` to pass `""` as the new `model` parameter:
+
+```go
+// Every existing call like:
+store.CreateScheduledTask(sess.ID, "Task A", "shell", "echo a", "/tmp", "0 * * * *")
+// becomes:
+store.CreateScheduledTask(sess.ID, "Task A", "shell", "echo a", "/tmp", "0 * * * *", "")
+```
+
+Update `server/api/tasks.go` — `handleCreateTask` (line 73):
+
+```go
+task, err := s.store.CreateScheduledTask(req.SessionID, req.Name, req.TaskType, req.Command, req.WorkingDirectory, req.CronExpression, req.Model)
+```
+
+Update `server/api/tasks.go` — `handleUpdateTask` (line 148):
+
+```go
+if err := s.store.UpdateScheduledTask(taskID, req.Name, req.TaskType, req.Command, req.WorkingDirectory, req.CronExpression, req.Enabled, req.Model); err != nil {
+```
+
+Add `Model` field to both request structs in `server/api/tasks.go`:
+
+```go
+type createTaskRequest struct {
+	SessionID        string `json:"session_id"`
+	Name             string `json:"name"`
+	TaskType         string `json:"task_type"`
+	Command          string `json:"command"`
+	WorkingDirectory string `json:"working_directory"`
+	CronExpression   string `json:"cron_expression"`
+	Model            string `json:"model"`
+}
+
+type updateTaskRequest struct {
+	Name             string `json:"name"`
+	TaskType         string `json:"task_type"`
+	Command          string `json:"command"`
+	WorkingDirectory string `json:"working_directory"`
+	CronExpression   string `json:"cron_expression"`
+	Enabled          bool   `json:"enabled"`
+	Model            string `json:"model"`
+}
+```
+
+Update `server/api/tasks.go` — `toggleTaskEnabled` body construction in the test if needed, and update the scheduler caller in `server/scheduler/scheduler_test.go` if it calls `CreateScheduledTask`.
+
+- [ ] **Step 5: Run all tests to verify**
+
+Run: `cd server && go test ./db/ -v -run TestScheduledTask`
+Run: `cd server && go test ./... -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/db/db.go server/db/scheduled_tasks.go server/db/scheduled_tasks_test.go server/api/tasks.go
+git commit -m "feat: add model field to scheduled tasks DB layer (#122)"
+```
+
+---
+
+### Task 2: Pass model flag in scheduler execution
+
+**Files:**
+- Modify: `server/scheduler/scheduler.go:127-165` (executeTask)
+- Modify: `server/scheduler/scheduler_test.go`
+
+- [ ] **Step 1: Write failing test for model in task execution**
+
+Add to `server/scheduler/scheduler_test.go`:
+
+```go
+func TestExecuteTaskWithModel(t *testing.T) {
+	store := newTestStore(t)
+	task, err := store.CreateScheduledTask("", "Model test", "claude", "hello", "/tmp", "0 * * * *", "claude-opus-4-6")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	sched := New(store)
+	sched.executeTask(*task)
+
+	runs, err := store.ListTaskRuns(task.ID, 1)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) == 0 {
+		t.Fatal("expected at least one run")
+	}
+	// The test verifies the task runs without panicking with the model field.
+	// Since "claude" binary won't exist in CI, we just check a run was created.
+}
+```
+
+- [ ] **Step 2: Run test to confirm baseline behavior**
+
+Run: `cd server && go test ./scheduler/ -v -run TestExecuteTaskWithModel`
+Expected: PASS or FAIL depending on whether `claude` binary exists — but no panic.
+
+- [ ] **Step 3: Add model flag to executeTask**
+
+In `server/scheduler/scheduler.go`, update the `executeTask` function. Change the `case "claude"` block (line 140):
+
+```go
+case "claude":
+    args := []string{"-p"}
+    if task.Model != "" {
+        args = append(args, "--model", task.Model)
+    }
+    args = append(args, task.Command)
+    cmd = exec.CommandContext(ctx, "claude", args...)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && go test ./scheduler/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/scheduler/scheduler.go server/scheduler/scheduler_test.go
+git commit -m "feat: pass --model flag in scheduled task execution (#122)"
+```
+
+---
+
+### Task 3: Add per-turn model to message API
+
+**Files:**
+- Modify: `server/api/managed_sessions.go:138-152` (handleSendMessage request struct), `69-121` (buildPersistentArgs)
+
+- [ ] **Step 1: Write failing test for model in message request**
+
+Add to `server/api/managed_sessions_test.go`:
+
+```go
+func TestBuildPersistentArgs_WithModel(t *testing.T) {
+	sess := &db.Session{
+		ID:       "test-id",
+		MaxTurns: 10,
+	}
+	cfg := managed.Config{}
+	args := buildPersistentArgs(sess, cfg)
+
+	// Without model, no --model flag
+	for _, a := range args {
+		if a == "--model" {
+			t.Error("unexpected --model flag without model set")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify baseline passes**
+
+Run: `cd server && go test ./api/ -v -run TestBuildPersistentArgs_WithModel`
+Expected: PASS (baseline — no model yet)
+
+- [ ] **Step 3: Add model parameter to handleSendMessage and thread through to process spawn**
+
+In `server/api/managed_sessions.go`, update the request struct in `handleSendMessage` (line 141):
+
+```go
+var req struct {
+    Message string `json:"message"`
+    ImageID string `json:"image_id"`
+    Model   string `json:"model"`
+}
+```
+
+Then, after the request is parsed (around line 205, before the goroutine), store the model so it can be used in `buildPersistentArgs`. The cleanest approach: pass the model through by temporarily setting it on the session object before calling `buildPersistentArgs`. Add a `Model` field to the `Session` struct (it won't be persisted — just used as a carrier).
+
+In `server/db/sessions.go`, add `Model` field to the `Session` struct (after `CompactEveryNContinues`):
+
+```go
+Model                  string  `json:"model,omitempty"`
+```
+
+Note: This field is NOT in the DB — it's only used as a transient carrier for the per-turn model. Don't add it to `sessionColumns` or `scanSession`.
+
+In `server/api/managed_sessions.go`, inside the `handleSendMessage` goroutine, before the `for` loop (around line 220), set the model on the session:
+
+```go
+sess.Model = req.Model
+```
+
+In `buildPersistentArgs`, add after the `max-budget-usd` block (after line 99):
+
+```go
+if sess.Model != "" {
+    args = append(args, "--model", sess.Model)
+}
+```
+
+- [ ] **Step 4: Update test to verify model flag is appended**
+
+Update the test in `server/api/managed_sessions_test.go`:
+
+```go
+func TestBuildPersistentArgs_WithModel(t *testing.T) {
+	sess := &db.Session{
+		ID:       "test-id",
+		MaxTurns: 10,
+	}
+	cfg := managed.Config{}
+
+	// Without model — no --model flag
+	args := buildPersistentArgs(sess, cfg)
+	for _, a := range args {
+		if a == "--model" {
+			t.Error("unexpected --model flag without model set")
+		}
+	}
+
+	// With model — --model flag present
+	sess.Model = "claude-opus-4-6"
+	args = buildPersistentArgs(sess, cfg)
+	found := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "claude-opus-4-6" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --model claude-opus-4-6 in args, got: %v", args)
+	}
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd server && go test ./api/ -v -run TestBuildPersistentArgs`
+Expected: PASS
+
+Run: `cd server && go test ./... -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/api/managed_sessions.go server/api/managed_sessions_test.go server/db/sessions.go
+git commit -m "feat: add per-turn model flag to message API (#122)"
+```
+
+---
+
+### Task 4: Add model selector to chat UI
+
+**Files:**
+- Modify: `server/web/static/app.js:113` (taskForm state), `1519-1562` (sendManagedMessage)
+- Modify: `server/web/static/index.html:289-311` (chat input area), `1210-1242` (task form)
+
+- [ ] **Step 1: Add selectedModel state to Alpine.js app**
+
+In `server/web/static/app.js`, find the app state initialization (around line 36) and add:
+
+```javascript
+selectedModel: localStorage.getItem('claude-controller-model') || 'claude-sonnet-4-6',
+```
+
+- [ ] **Step 2: Add model to taskForm state**
+
+In `server/web/static/app.js`, update the `taskForm` object (line 113):
+
+```javascript
+taskForm: { name: '', task_type: 'shell', command: '', working_directory: '', cron_expression: '', session_id: '', model: '' },
+```
+
+- [ ] **Step 3: Add model dropdown to chat input area in HTML**
+
+In `server/web/static/index.html`, add a model selector row just before the `<div class="input-row">` (before line 289). Insert:
+
+```html
+              <div x-show="currentSession?.mode === 'managed' && !shellMode" x-cloak style="display:flex; align-items:center; padding:0 0 6px 0;">
+                <select x-model="selectedModel" @change="localStorage.setItem('claude-controller-model', selectedModel)"
+                        style="background:var(--bg-secondary); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:3px 8px; font-size:0.75rem; cursor:pointer; outline:none;">
+                  <option value="claude-opus-4-6">Opus</option>
+                  <option value="claude-sonnet-4-6">Sonnet</option>
+                  <option value="claude-haiku-4-5-20251001">Haiku</option>
+                </select>
+              </div>
+```
+
+- [ ] **Step 4: Send model with managed message**
+
+In `server/web/static/app.js`, in the `sendManagedMessage` function (around line 1532), update the body construction:
+
+```javascript
+const body = { message: msg, model: this.selectedModel };
+if (imageId) body.image_id = imageId;
+```
+
+- [ ] **Step 5: Add model dropdown to task creation form**
+
+In `server/web/static/index.html`, add a model field to the task form after the cron expression field (after line 1241, before the error div):
+
+```html
+          <div class="settings-field" x-show="taskForm.task_type === 'claude'">
+            <label class="modal-label">Model</label>
+            <select x-model="taskForm.model" class="modal-input">
+              <option value="">Default</option>
+              <option value="claude-opus-4-6">Opus</option>
+              <option value="claude-sonnet-4-6">Sonnet</option>
+              <option value="claude-haiku-4-5-20251001">Haiku</option>
+            </select>
+          </div>
+```
+
+- [ ] **Step 6: Populate model when editing existing tasks**
+
+In `server/web/static/app.js`, update the `openTaskModal` function (around line 3194). When populating `taskForm` from an existing task (line 3197-3201), add `model`:
+
+```javascript
+this.taskForm = {
+    name: task.name, task_type: task.task_type, command: task.command,
+    working_directory: task.working_directory, cron_expression: task.cron_expression,
+    session_id: task.session_id || '', model: task.model || ''
+};
+```
+
+And when creating a new task (line 3206), include `model`:
+
+```javascript
+this.taskForm = { name: '', task_type: 'shell', command: '', working_directory: '', cron_expression: '', session_id: '', model: '' };
+```
+
+Also update `toggleTaskEnabled` (around line 3256) to include model in the PUT body:
+
+```javascript
+body: JSON.stringify({
+    name: task.name, task_type: task.task_type, command: task.command,
+    working_directory: task.working_directory, cron_expression: task.cron_expression,
+    enabled: !task.enabled, model: task.model || ''
+})
+```
+
+- [ ] **Step 7: Manual verification**
+
+Run: `cd server && go run .`
+Verify:
+1. Model dropdown appears above chat input for managed sessions
+2. Changing model persists across page reload (localStorage)
+3. Model dropdown in task form only shows for "claude" task type
+4. Sending a message includes the model in the request body (check network tab)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/web/static/app.js server/web/static/index.html
+git commit -m "feat: add model selector dropdown to chat UI and task form (#122)"
+```
+
+---
+
+### Task 5: Update CLAUDE.md and final verification
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add model selection spec/plan references to CLAUDE.md**
+
+Add to the Spec & Plan section of `CLAUDE.md`:
+
+```markdown
+- Model selection spec: `docs/superpowers/specs/2026-04-22-model-selection-design.md`
+- Model selection plan: `docs/superpowers/plans/2026-04-22-model-selection.md`
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd server && go test ./... -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Build to verify no compile errors**
+
+Run: `cd server && go build -o claude-controller .`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add model selection spec/plan references to CLAUDE.md (#122)"
+```

--- a/docs/superpowers/specs/2026-04-22-model-selection-design.md
+++ b/docs/superpowers/specs/2026-04-22-model-selection-design.md
@@ -1,0 +1,96 @@
+# Model Selection Design
+
+**Issue:** #122
+**Date:** 2026-04-22
+
+## Overview
+
+Add model selection to two places: (1) a persistent dropdown in the managed session chat UI for switching models between turns, and (2) a dropdown in the scheduled task creation form.
+
+## Goals
+
+- Let users switch between Opus, Sonnet, and Haiku between turns in managed sessions
+- Let users choose a model per scheduled task
+- Keep the implementation minimal — no DB changes for sessions, per-turn model only
+
+## Non-Goals
+
+- Per-session persistent model (model is not stored in the sessions table)
+- Free-text model ID input
+- Model selection for hook-mode sessions
+- Model usage tracking or cost display
+
+## Design
+
+### Model Options
+
+Three curated models, no free-text input:
+
+| Display Name | CLI `--model` Value         |
+|--------------|-----------------------------|
+| Opus         | `claude-opus-4-6`           |
+| Sonnet       | `claude-sonnet-4-6`         |
+| Haiku        | `claude-haiku-4-5-20251001` |
+
+Default: Sonnet.
+
+### Chat UI — Per-Turn Model Selector
+
+**Location:** Persistent compact dropdown above the chat input area, left-aligned. Always visible, similar to ChatGPT's model picker.
+
+**State management:**
+- Alpine.js state variable `selectedModel` initialized from `localStorage` key `claude-controller-model` (default: `claude-sonnet-4-6`)
+- On model change, new value is written to `localStorage`
+- On each message send, the current `selectedModel` value is included in the POST request body
+
+**Display:** Short labels ("Opus", "Sonnet", "Haiku") in the dropdown. Compact styling that doesn't compete with the chat input.
+
+### API Changes
+
+**`POST /api/managed-sessions/:id/message`** — Add optional `model` string field to the JSON request body.
+
+**`buildPersistentArgs` function** — When the `model` field is present and non-empty in the message request, append `--model <value>` to the CLI args passed to `claude -p`. This is per-invocation — the session object is not modified.
+
+**No changes to:**
+- Session creation endpoint (model is not a session property)
+- Sessions table schema
+- Session GET/list responses
+
+### Scheduled Tasks — Per-Task Model
+
+**DB migration:** Add `model TEXT NOT NULL DEFAULT ''` column to `scheduled_tasks` table. Empty string means use the CLI's default model.
+
+**`ScheduledTask` struct:** Add `Model string` field with JSON tag `"model"`.
+
+**Task creation API:** Accept optional `model` field in the create/update request body.
+
+**Task execution (`executeTask`):** When `task.Model` is non-empty, append `--model <value>` to the command args before spawning the process.
+
+**UI:** Add a model dropdown to the scheduled task creation/edit form. Same three options (Opus, Sonnet, Haiku) plus a "Default" option that maps to empty string.
+
+### Data Flow
+
+#### Chat (per-turn):
+```
+User selects model in dropdown
+  → Alpine.js state + localStorage
+    → POST /api/managed-sessions/:id/message { model: "claude-opus-4-6", message: "..." }
+      → buildPersistentArgs appends --model flag
+        → claude -p --model claude-opus-4-6 ...
+```
+
+#### Scheduled tasks (per-task):
+```
+User selects model in task form
+  → POST /api/triggers { ..., model: "claude-haiku-4-5-20251001" }
+    → Stored in scheduled_tasks.model column
+      → executeTask reads task.Model, appends --model flag
+        → claude -p --model claude-haiku-4-5-20251001 ...
+```
+
+### Edge Cases
+
+- **Empty/missing model in message request:** Don't append `--model` flag; CLI uses its own default.
+- **Invalid model ID:** Let the CLI handle validation and error reporting — no server-side validation needed.
+- **localStorage unavailable:** Fall back to Sonnet default in Alpine.js init.
+- **Existing scheduled tasks after migration:** Get empty string model (DEFAULT ''), which means CLI default — no behavior change.

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -98,6 +98,10 @@ func buildPersistentArgs(sess *db.Session, cfg managed.Config) []string {
 		args = append(args, "--max-budget-usd", fmt.Sprintf("%.2f", sess.MaxBudgetUSD))
 	}
 
+	if sess.Model != "" {
+		args = append(args, "--model", sess.Model)
+	}
+
 	if cfg.BinaryPath != "" && cfg.ServerPort > 0 {
 		mcpConfig := map[string]interface{}{
 			"mcpServers": map[string]interface{}{
@@ -141,6 +145,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Message string `json:"message"`
 		ImageID string `json:"image_id"`
+		Model   string `json:"model"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -219,6 +224,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 		continuationCount := 0
 		currentMessage := req.Message
+		sess.Model = req.Model
 
 		// --- Per-turn mutable state, shared with onLine callback ---
 		// onLine runs in the StreamNDJSON goroutine, which lives for the

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -582,6 +582,36 @@ func TestRecentDirsAPI(t *testing.T) {
 	}
 }
 
+func TestBuildPersistentArgs_WithModel(t *testing.T) {
+	sess := &db.Session{
+		ID:       "test-id",
+		MaxTurns: 10,
+	}
+	cfg := managed.Config{}
+
+	// Without model — no --model flag
+	args := buildPersistentArgs(sess, cfg)
+	for _, a := range args {
+		if a == "--model" {
+			t.Error("unexpected --model flag without model set")
+		}
+	}
+
+	// With model — --model flag present
+	sess.Model = "claude-opus-4-6"
+	args = buildPersistentArgs(sess, cfg)
+	found := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "claude-opus-4-6" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --model claude-opus-4-6 in args, got: %v", args)
+	}
+}
+
 func TestStaleState_ServerRestart(t *testing.T) {
 	dir := t.TempDir()
 	store, err := db.Open(dir + "/test.db")

--- a/server/api/tasks.go
+++ b/server/api/tasks.go
@@ -19,6 +19,7 @@ type createTaskRequest struct {
 	Command          string `json:"command"`
 	WorkingDirectory string `json:"working_directory"`
 	CronExpression   string `json:"cron_expression"`
+	Model            string `json:"model"`
 }
 
 type updateTaskRequest struct {
@@ -28,6 +29,7 @@ type updateTaskRequest struct {
 	WorkingDirectory string `json:"working_directory"`
 	CronExpression   string `json:"cron_expression"`
 	Enabled          bool   `json:"enabled"`
+	Model            string `json:"model"`
 }
 
 func validateTaskRequest(name, taskType, command, workingDir, cronExpr string) (string, bool) {
@@ -70,7 +72,7 @@ func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := s.store.CreateScheduledTask(req.SessionID, req.Name, req.TaskType, req.Command, req.WorkingDirectory, req.CronExpression)
+	task, err := s.store.CreateScheduledTask(req.SessionID, req.Name, req.TaskType, req.Command, req.WorkingDirectory, req.CronExpression, req.Model)
 	if err != nil {
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return
@@ -145,7 +147,7 @@ func (s *Server) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.UpdateScheduledTask(taskID, req.Name, req.TaskType, req.Command, req.WorkingDirectory, req.CronExpression, req.Enabled); err != nil {
+	if err := s.store.UpdateScheduledTask(taskID, req.Name, req.TaskType, req.Command, req.WorkingDirectory, req.CronExpression, req.Model, req.Enabled); err != nil {
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return
 	}

--- a/server/api/tasks_test.go
+++ b/server/api/tasks_test.go
@@ -98,7 +98,7 @@ func TestListTasks(t *testing.T) {
 	ts, store := newTestServer(t)
 
 	// Create a task directly via store
-	_, err := store.CreateScheduledTask("", "Task A", "shell", "ls", "/tmp", "0 * * * *")
+	_, err := store.CreateScheduledTask("", "Task A", "shell", "ls", "/tmp", "0 * * * *", "")
 	if err != nil {
 		t.Fatalf("CreateScheduledTask: %v", err)
 	}

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -130,6 +130,7 @@ func migrate(db *sql.DB) error {
 			last_used_at DATETIME NOT NULL DEFAULT (datetime('now'))
 		)`,
 		`ALTER TABLE sessions ADD COLUMN compact_every_n_continues INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE scheduled_tasks ADD COLUMN model TEXT NOT NULL DEFAULT ''`,
 	}
 
 	for _, m := range migrations {

--- a/server/db/scheduled_tasks.go
+++ b/server/db/scheduled_tasks.go
@@ -29,6 +29,7 @@ type ScheduledTask struct {
 	NextRunAt        *time.Time `json:"next_run_at,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`
 	UpdatedAt        time.Time  `json:"updated_at"`
+	Model            string     `json:"model"`
 }
 
 type TaskRun struct {
@@ -41,7 +42,7 @@ type TaskRun struct {
 	Status     string     `json:"status"`
 }
 
-const taskColumns = `id, session_id, name, task_type, command, working_directory, cron_expression, enabled, last_run_at, next_run_at, created_at, updated_at`
+const taskColumns = `id, session_id, name, task_type, command, working_directory, cron_expression, enabled, last_run_at, next_run_at, created_at, updated_at, COALESCE(model,'')`
 
 func scanTask(scanner interface{ Scan(...interface{}) error }) (ScheduledTask, error) {
 	var t ScheduledTask
@@ -49,7 +50,7 @@ func scanTask(scanner interface{ Scan(...interface{}) error }) (ScheduledTask, e
 	err := scanner.Scan(
 		&t.ID, &t.SessionID, &t.Name, &t.TaskType, &t.Command,
 		&t.WorkingDirectory, &t.CronExpression, &enabled,
-		&t.LastRunAt, &t.NextRunAt, &t.CreatedAt, &t.UpdatedAt,
+		&t.LastRunAt, &t.NextRunAt, &t.CreatedAt, &t.UpdatedAt, &t.Model,
 	)
 	if err != nil {
 		return t, err
@@ -75,16 +76,16 @@ func scanRun(scanner interface{ Scan(...interface{}) error }) (TaskRun, error) {
 }
 
 // CreateScheduledTask creates a new scheduled task. Pass empty string for sessionID to create a session-less task.
-func (s *Store) CreateScheduledTask(sessionID, name, taskType, command, workingDir, cronExpr string) (*ScheduledTask, error) {
+func (s *Store) CreateScheduledTask(sessionID, name, taskType, command, workingDir, cronExpr, model string) (*ScheduledTask, error) {
 	id := uuid.New().String()
 	var sessPtr *string
 	if sessionID != "" {
 		sessPtr = &sessionID
 	}
 	_, err := s.db.Exec(`
-		INSERT INTO scheduled_tasks (id, session_id, name, task_type, command, working_directory, cron_expression, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
-	`, id, sessPtr, name, taskType, command, workingDir, cronExpr)
+		INSERT INTO scheduled_tasks (id, session_id, name, task_type, command, working_directory, cron_expression, model, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+	`, id, sessPtr, name, taskType, command, workingDir, cronExpr, model)
 	if err != nil {
 		return nil, fmt.Errorf("create scheduled task: %w", err)
 	}
@@ -127,16 +128,16 @@ func (s *Store) ListScheduledTasks(sessionID string) ([]ScheduledTask, error) {
 	return tasks, rows.Err()
 }
 
-func (s *Store) UpdateScheduledTask(id, name, taskType, command, workingDir, cronExpr string, enabled bool) error {
+func (s *Store) UpdateScheduledTask(id, name, taskType, command, workingDir, cronExpr, model string, enabled bool) error {
 	enabledInt := 0
 	if enabled {
 		enabledInt = 1
 	}
 	_, err := s.db.Exec(`
 		UPDATE scheduled_tasks
-		SET name = ?, task_type = ?, command = ?, working_directory = ?, cron_expression = ?, enabled = ?, updated_at = datetime('now')
+		SET name = ?, task_type = ?, command = ?, working_directory = ?, cron_expression = ?, model = ?, enabled = ?, updated_at = datetime('now')
 		WHERE id = ?
-	`, name, taskType, command, workingDir, cronExpr, enabledInt, id)
+	`, name, taskType, command, workingDir, cronExpr, model, enabledInt, id)
 	if err != nil {
 		return fmt.Errorf("update scheduled task: %w", err)
 	}

--- a/server/db/scheduled_tasks_test.go
+++ b/server/db/scheduled_tasks_test.go
@@ -12,7 +12,7 @@ func TestCreateAndGetScheduledTask(t *testing.T) {
 		t.Fatalf("UpsertSession: %v", err)
 	}
 
-	task, err := store.CreateScheduledTask(sess.ID, "Daily backup", "shell", "tar -czf backup.tar.gz .", "/tmp/project", "0 2 * * *")
+	task, err := store.CreateScheduledTask(sess.ID, "Daily backup", "shell", "tar -czf backup.tar.gz .", "/tmp/project", "0 2 * * *", "")
 	if err != nil {
 		t.Fatalf("CreateScheduledTask: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestCreateAndGetScheduledTask(t *testing.T) {
 
 func TestCreateScheduledTaskWithoutSession(t *testing.T) {
 	store := newTestStore(t)
-	task, err := store.CreateScheduledTask("", "Shell task", "shell", "echo hello", "/tmp", "*/5 * * * *")
+	task, err := store.CreateScheduledTask("", "Shell task", "shell", "echo hello", "/tmp", "*/5 * * * *", "")
 	if err != nil {
 		t.Fatalf("CreateScheduledTask: %v", err)
 	}
@@ -52,9 +52,9 @@ func TestCreateScheduledTaskWithoutSession(t *testing.T) {
 func TestListScheduledTasks(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/proj", "")
-	store.CreateScheduledTask(sess.ID, "Task A", "shell", "echo a", "/tmp", "0 * * * *")
-	store.CreateScheduledTask(sess.ID, "Task B", "claude", "summarize", "/tmp", "0 9 * * *")
-	store.CreateScheduledTask("", "Task C", "shell", "echo c", "/tmp", "*/5 * * * *")
+	store.CreateScheduledTask(sess.ID, "Task A", "shell", "echo a", "/tmp", "0 * * * *", "")
+	store.CreateScheduledTask(sess.ID, "Task B", "claude", "summarize", "/tmp", "0 9 * * *", "")
+	store.CreateScheduledTask("", "Task C", "shell", "echo c", "/tmp", "*/5 * * * *", "")
 
 	all, err := store.ListScheduledTasks("")
 	if err != nil {
@@ -76,9 +76,9 @@ func TestListScheduledTasks(t *testing.T) {
 func TestUpdateScheduledTask(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/proj", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "Old Name", "shell", "echo old", "/tmp", "0 * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "Old Name", "shell", "echo old", "/tmp", "0 * * * *", "")
 
-	err := store.UpdateScheduledTask(task.ID, "New Name", "shell", "echo new", "/tmp/new", "0 2 * * *", false)
+	err := store.UpdateScheduledTask(task.ID, "New Name", "shell", "echo new", "/tmp/new", "0 2 * * *", "", false)
 	if err != nil {
 		t.Fatalf("UpdateScheduledTask: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestUpdateScheduledTask(t *testing.T) {
 func TestDeleteScheduledTask(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/proj", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "To Delete", "shell", "echo x", "/tmp", "0 * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "To Delete", "shell", "echo x", "/tmp", "0 * * * *", "")
 
 	err := store.DeleteScheduledTask(task.ID)
 	if err != nil {
@@ -114,7 +114,7 @@ func TestDeleteScheduledTask(t *testing.T) {
 func TestTaskRunLifecycle(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/proj", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "echo hi", "/tmp", "0 * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "echo hi", "/tmp", "0 * * * *", "")
 
 	run, err := store.CreateTaskRun(task.ID)
 	if err != nil {
@@ -152,7 +152,7 @@ func TestTaskRunLifecycle(t *testing.T) {
 func TestCompleteTaskRunFailed(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/proj", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "exit 1", "/tmp", "0 * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "exit 1", "/tmp", "0 * * * *", "")
 
 	run, _ := store.CreateTaskRun(task.ID)
 	store.CompleteTaskRun(run.ID, 1, "error output")
@@ -167,8 +167,8 @@ func TestGetTasksDueForExecution(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/proj", "")
 
-	task1, _ := store.CreateScheduledTask(sess.ID, "Due", "shell", "echo a", "/tmp", "0 * * * *")
-	task2, _ := store.CreateScheduledTask(sess.ID, "Not Due", "shell", "echo b", "/tmp", "0 * * * *")
+	task1, _ := store.CreateScheduledTask(sess.ID, "Due", "shell", "echo a", "/tmp", "0 * * * *", "")
+	task2, _ := store.CreateScheduledTask(sess.ID, "Not Due", "shell", "echo b", "/tmp", "0 * * * *", "")
 
 	past := time.Now().Add(-1 * time.Minute)
 	future := time.Now().Add(1 * time.Hour)
@@ -190,12 +190,30 @@ func TestGetTasksDueForExecution(t *testing.T) {
 func TestCascadeDeleteTaskRuns(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/proj", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "echo hi", "/tmp", "0 * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "echo hi", "/tmp", "0 * * * *", "")
 	store.CreateTaskRun(task.ID)
 
 	store.DeleteScheduledTask(task.ID)
 	runs, _ := store.ListTaskRuns(task.ID, 20)
 	if len(runs) != 0 {
 		t.Errorf("expected 0 runs after cascade delete, got %d", len(runs))
+	}
+}
+
+func TestScheduledTaskModelField(t *testing.T) {
+	store := newTestStore(t)
+	task, err := store.CreateScheduledTask("", "Model task", "claude", "summarize", "/tmp", "0 9 * * *", "claude-opus-4-6")
+	if err != nil {
+		t.Fatalf("CreateScheduledTask: %v", err)
+	}
+	if task.Model != "claude-opus-4-6" {
+		t.Errorf("model: got %q, want %q", task.Model, "claude-opus-4-6")
+	}
+	task2, err := store.CreateScheduledTask("", "No model", "shell", "echo hi", "/tmp", "0 * * * *", "")
+	if err != nil {
+		t.Fatalf("CreateScheduledTask: %v", err)
+	}
+	if task2.Model != "" {
+		t.Errorf("model: got %q, want empty", task2.Model)
 	}
 }

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -29,6 +29,7 @@ type Session struct {
 	ActivityState         string  `json:"activity_state"`
 	Name                  string  `json:"name"`
 	CompactEveryNContinues int    `json:"compact_every_n_continues"`
+	Model                  string `json:"model,omitempty"`
 }
 
 const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), max_continuations, COALESCE(activity_state,'idle'), COALESCE(name,''), compact_every_n_continues`

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -29,7 +29,7 @@ type Session struct {
 	ActivityState         string  `json:"activity_state"`
 	Name                  string  `json:"name"`
 	CompactEveryNContinues int    `json:"compact_every_n_continues"`
-	Model                  string `json:"model,omitempty"`
+	Model                  string `json:"-"`
 }
 
 const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), max_continuations, COALESCE(activity_state,'idle'), COALESCE(name,''), compact_every_n_continues`

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -137,7 +137,12 @@ func (s *Scheduler) executeTask(task db.ScheduledTask) {
 	case "shell":
 		cmd = exec.CommandContext(ctx, "bash", "-c", task.Command)
 	case "claude":
-		cmd = exec.CommandContext(ctx, "claude", "-p", task.Command)
+		args := []string{"-p"}
+		if task.Model != "" {
+			args = append(args, "--model", task.Model)
+		}
+		args = append(args, task.Command)
+		cmd = exec.CommandContext(ctx, "claude", args...)
 	default:
 		s.store.CompleteTaskRunWithError(run.ID, fmt.Sprintf("unknown task type: %s", task.TaskType))
 		return

--- a/server/scheduler/scheduler_test.go
+++ b/server/scheduler/scheduler_test.go
@@ -21,7 +21,7 @@ func newTestStore(t *testing.T) *db.Store {
 func TestSchedulerExecutesShellTask(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/tmp", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "Echo test", "shell", "echo hello-from-scheduler", "/tmp", "* * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "Echo test", "shell", "echo hello-from-scheduler", "/tmp", "* * * * *", "")
 	store.UpdateTaskNextRun(task.ID, time.Now().Add(-1*time.Minute))
 
 	s := New(store)
@@ -46,7 +46,7 @@ func TestSchedulerExecutesShellTask(t *testing.T) {
 func TestSchedulerSkipsConcurrentExecution(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/tmp", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "Slow task", "shell", "sleep 3", "/tmp", "* * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "Slow task", "shell", "sleep 3", "/tmp", "* * * * *", "")
 	store.UpdateTaskNextRun(task.ID, time.Now().Add(-1*time.Minute))
 
 	s := New(store)
@@ -66,7 +66,7 @@ func TestSchedulerSkipsConcurrentExecution(t *testing.T) {
 func TestReconcileStaleRuns(t *testing.T) {
 	store := newTestStore(t)
 	sess, _ := store.UpsertSession("mac1", "/tmp", "")
-	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "echo hi", "/tmp", "* * * * *")
+	task, _ := store.CreateScheduledTask(sess.ID, "Task", "shell", "echo hi", "/tmp", "* * * * *", "")
 	run, _ := store.CreateTaskRun(task.ID)
 
 	s := New(store)

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -32,6 +32,8 @@ document.addEventListener('alpine:init', () => {
     // Browser notifications
     prevActivityStates: {},
 
+    selectedModel: localStorage.getItem('claude-controller-model') || 'claude-sonnet-4-6',
+
     // Managed session state
     showNewSessionModal: false,
     pendingPermission: null,
@@ -110,7 +112,7 @@ document.addEventListener('alpine:init', () => {
     taskRuns: [],
     taskModalOpen: false,
     editingTask: null,
-    taskForm: { name: '', task_type: 'shell', command: '', working_directory: '', cron_expression: '', session_id: '' },
+    taskForm: { name: '', task_type: 'shell', command: '', working_directory: '', cron_expression: '', session_id: '', model: '' },
     taskFormErrors: '',
     taskLoading: false,
     taskRunsLoading: false,
@@ -1529,7 +1531,7 @@ document.addEventListener('alpine:init', () => {
       this.clearPendingImage();
 
       try {
-        const body = { message: msg };
+        const body = { message: msg, model: this.selectedModel };
         if (imageId) body.image_id = imageId;
 
         const res = await fetch(`/api/sessions/${this.selectedSessionId}/message`, {
@@ -3197,13 +3199,13 @@ Please review this PR and provide feedback.`;
             this.taskForm = {
                 name: task.name, task_type: task.task_type, command: task.command,
                 working_directory: task.working_directory, cron_expression: task.cron_expression,
-                session_id: task.session_id || ''
+                session_id: task.session_id || '', model: task.model || ''
             };
             this.loadTaskRuns(task.id);
         } else {
             this.editingTask = null;
             this.taskRuns = [];
-            this.taskForm = { name: '', task_type: 'shell', command: '', working_directory: '', cron_expression: '', session_id: '' };
+            this.taskForm = { name: '', task_type: 'shell', command: '', working_directory: '', cron_expression: '', session_id: '', model: '' };
         }
         this.taskFormErrors = '';
         this.taskModalOpen = true;
@@ -3261,7 +3263,7 @@ Please review this PR and provide feedback.`;
                 body: JSON.stringify({
                     name: task.name, task_type: task.task_type, command: task.command,
                     working_directory: task.working_directory, cron_expression: task.cron_expression,
-                    enabled: !task.enabled
+                    enabled: !task.enabled, model: task.model || ''
                 })
             });
             await this.loadScheduledTasks();

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -286,6 +286,14 @@
                 </template>
               </div>
 
+              <div x-show="currentSession?.mode === 'managed' && !shellMode" x-cloak style="display:flex; align-items:center; padding:0 0 6px 0;">
+                <select x-model="selectedModel" @change="localStorage.setItem('claude-controller-model', selectedModel)"
+                        style="background:var(--bg-secondary); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:3px 8px; font-size:0.75rem; cursor:pointer; outline:none;">
+                  <option value="claude-opus-4-6">Opus</option>
+                  <option value="claude-sonnet-4-6">Sonnet</option>
+                  <option value="claude-haiku-4-5-20251001">Haiku</option>
+                </select>
+              </div>
               <div class="input-row">
                 <div class="input-wrapper">
                   <!-- Image preview -->
@@ -1238,6 +1246,15 @@
               <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '0 9 * * 1-5'">weekdays</span>
               <span style="cursor:pointer; text-decoration:underline;" @click="taskForm.cron_expression = '*/5 * * * *'">every 5min</span>
             </div>
+          </div>
+          <div class="settings-field" x-show="taskForm.task_type === 'claude'">
+            <label class="modal-label">Model</label>
+            <select x-model="taskForm.model" class="modal-input">
+              <option value="">Default</option>
+              <option value="claude-opus-4-6">Opus</option>
+              <option value="claude-sonnet-4-6">Sonnet</option>
+              <option value="claude-haiku-4-5-20251001">Haiku</option>
+            </select>
           </div>
           <div x-show="taskFormErrors" style="color:#ef4444; font-size:0.8rem; margin-bottom:8px;" x-text="taskFormErrors"></div>
           <div x-show="editingTask && taskRuns.length > 0" style="margin-top:8px; border-top:1px solid var(--border); padding-top:16px;">

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -288,6 +288,7 @@
 
               <div x-show="currentSession?.mode === 'managed' && !shellMode" x-cloak style="display:flex; align-items:center; padding:0 0 6px 0;">
                 <select x-model="selectedModel" @change="localStorage.setItem('claude-controller-model', selectedModel)"
+                        aria-label="Model"
                         style="background:var(--bg-secondary); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:3px 8px; font-size:0.75rem; cursor:pointer; outline:none;">
                   <option value="claude-opus-4-6">Opus</option>
                   <option value="claude-sonnet-4-6">Sonnet</option>
@@ -1217,7 +1218,7 @@
           </div>
           <div class="settings-field">
             <label class="modal-label">Type</label>
-            <select x-model="taskForm.task_type" class="modal-input">
+            <select x-model="taskForm.task_type" @change="if (taskForm.task_type !== 'claude') taskForm.model = ''" class="modal-input">
               <option value="shell">Shell Command</option>
               <option value="claude">Claude Command</option>
             </select>


### PR DESCRIPTION
## Summary

Closes #122

- Add per-turn model selector dropdown to the chat UI (Opus, Sonnet, Haiku) — model is sent with each message request, not persisted per-session
- Add per-task model field for scheduled tasks — stored in DB, passed as `--model` flag to CLI
- Model choice persists in localStorage across page reloads for chat; in the DB for scheduled tasks

## Changes

**Backend:**
- `server/db/db.go` — Migration: add `model` column to `scheduled_tasks`
- `server/db/scheduled_tasks.go` — Model field in struct, updated CRUD signatures
- `server/api/tasks.go` — Model in create/update request structs
- `server/api/managed_sessions.go` — Accept `model` in message request, pass `--model` to CLI via `buildPersistentArgs`
- `server/db/sessions.go` — Transient `Model` field on Session (not persisted, `json:"-"`)
- `server/scheduler/scheduler.go` — Pass `--model` flag when executing claude tasks

**Frontend:**
- `server/web/static/app.js` — `selectedModel` state with localStorage, model in message/task requests
- `server/web/static/index.html` — Model dropdown above chat input; model select in task form (shown for claude tasks only)

## Test plan

- [ ] Verify model dropdown appears above chat input for managed sessions
- [ ] Verify changing model persists across page reload (localStorage)
- [ ] Verify sending a message includes model in request body (network tab)
- [ ] Verify model dropdown in task form only shows for "claude" task type
- [ ] Verify existing tests pass: `cd server && go test ./...`