### PR TITLE
feat: move model selector into shortcut toolbar as compact button

### DIFF
--- a/docs/superpowers/plans/2026-04-24-model-selector-toolbar.md
+++ b/docs/superpowers/plans/2026-04-24-model-selector-toolbar.md
@@ -1,0 +1,127 @@
+# Model Selector Toolbar Relocation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the model `<select>` from its own row above the message input into the shortcut buttons toolbar, styled as a compact button-like control.
+
+**Architecture:** Pure HTML + CSS change — remove the standalone wrapper div, relocate the `<select>` into `.shortcut-buttons` between the mic button and the hint text, and add a `.model-select-btn` CSS class that makes it blend with the toolbar.
+
+**Tech Stack:** HTML (Alpine.js x-model bindings), CSS custom properties
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `server/web/static/index.html` | Remove standalone model `<div>` (lines 289–297); add `<select>` into `.shortcut-buttons` after mic button |
+| `server/web/static/style.css` | Add `.model-select-btn` rule after `.voice-chat-btn` block |
+
+---
+
+### Task 1: Add `.model-select-btn` CSS rule
+
+**Files:**
+- Modify: `server/web/static/style.css` (after line ~2433, end of `.voice-chat-btn` block)
+
+- [ ] **Step 1: Add the CSS rule**
+
+In `server/web/static/style.css`, after the `.voice-chat-btn.active.listening` / `@keyframes voice-pulse` block (around line 2433), add:
+
+```css
+/* Model selector styled as toolbar button */
+.model-select-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.75rem;
+  padding: 4px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  outline: none;
+  flex-shrink: 0;
+}
+.model-select-btn:hover {
+  background: var(--bg-tertiary, #e5e7eb);
+}
+```
+
+- [ ] **Step 2: Verify CSS file saves cleanly** — open `server/web/static/style.css` and confirm the new rule appears without syntax errors (no mismatched braces).
+
+---
+
+### Task 2: Relocate the model `<select>` in index.html
+
+**Files:**
+- Modify: `server/web/static/index.html` lines 289–297 (remove), line 368 (insert after)
+
+- [ ] **Step 1: Remove the standalone model wrapper div**
+
+In `server/web/static/index.html`, remove these lines (289–297):
+
+```html
+              <div x-show="currentSession?.mode === 'managed' && !shellMode" x-cloak style="display:flex; align-items:center; padding:0 0 6px 0;">
+                <select x-model="selectedModel" @change="localStorage.setItem('claude-controller-model', selectedModel)"
+                        aria-label="Model"
+                        style="background:var(--bg-secondary); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:3px 8px; font-size:0.75rem; cursor:pointer; outline:none;">
+                  <option value="claude-opus-4-6">Opus</option>
+                  <option value="claude-sonnet-4-6">Sonnet</option>
+                  <option value="claude-haiku-4-5-20251001">Haiku</option>
+                </select>
+              </div>
+```
+
+- [ ] **Step 2: Insert the `<select>` into `.shortcut-buttons` after the mic button**
+
+After the closing `</button>` of the `.voice-chat-btn` block (currently line 368, just before `<span class="input-hint">`), insert:
+
+```html
+                <select x-model="selectedModel"
+                        x-show="currentSession?.mode === 'managed' && !shellMode"
+                        x-cloak
+                        @change="localStorage.setItem('claude-controller-model', selectedModel)"
+                        aria-label="Model"
+                        class="model-select-btn">
+                  <option value="claude-opus-4-6">Opus</option>
+                  <option value="claude-sonnet-4-6">Sonnet</option>
+                  <option value="claude-haiku-4-5-20251001">Haiku</option>
+                </select>
+```
+
+The resulting `.shortcut-buttons` block should read:
+
+```
+[ shortcut picker ] [ $ shell ] [ image upload ] [ mic ] [ model select ] [ ⌘↵ hint ]
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git checkout -b feat/model-selector-toolbar
+git add server/web/static/index.html server/web/static/style.css
+git commit -m "feat: move model selector into shortcut toolbar as compact button"
+```
+
+---
+
+### Task 3: Visual verification
+
+**Files:** None (read-only verification)
+
+- [ ] **Step 1: Start the server**
+
+```bash
+cd server && go run .
+```
+
+Expected output: server starts on `:8080` with no errors.
+
+- [ ] **Step 2: Open the UI and verify layout**
+
+Open `http://localhost:8080` in a browser. Start or select a managed session. Confirm:
+1. No model dropdown appears above the message input (old row is gone).
+2. In the shortcut toolbar: `😁 | $ | 🖼 | 🎤 | [Sonnet ▾] | ⌘↵ to send`
+3. The model selector blends visually — no visible border, transparent background.
+4. Hovering the selector shows a subtle background highlight.
+5. Changing the model still persists to `localStorage` (reload and confirm the selection is remembered).
+6. In hook-mode sessions or shell mode, the selector is hidden (matches old behavior).

--- a/docs/superpowers/specs/2026-04-24-model-selector-toolbar-design.md
+++ b/docs/superpowers/specs/2026-04-24-model-selector-toolbar-design.md
@@ -33,14 +33,14 @@ Relocate the `<select>` into `.shortcut-buttons`, between the microphone (voice 
 Apply a new CSS class (e.g. `.model-select-btn`) to replace the current inline style:
 
 - `background: transparent`
-- `border: none`
+- `border: 1px solid var(--border)` — matches `.voice-chat-btn` and `.image-upload-btn`
 - `color: var(--text-secondary)`
 - `font-size: 0.75rem`
 - `padding: 4px 6px`
 - `border-radius: 6px`
 - `cursor: pointer`
 - `outline: none`
-- On hover: `background: var(--bg-hover)` — matches existing icon button hover behavior
+- On hover: `background: var(--bg-tertiary, #e5e7eb)` — matches `.shortcut-picker-btn:hover` pattern
 - Retains native `<select>` caret (no custom arrow needed)
 
 ## Scope

--- a/docs/superpowers/specs/2026-04-24-model-selector-toolbar-design.md
+++ b/docs/superpowers/specs/2026-04-24-model-selector-toolbar-design.md
@@ -1,0 +1,51 @@
+# Model Selector Toolbar Relocation — Design Spec
+
+**Date:** 2026-04-24
+**Status:** Approved
+
+## Overview
+
+Move the model selection dropdown from its own row above the message input into the shortcut buttons toolbar below the input, styled to look like a native toolbar button rather than a form field.
+
+## Problem
+
+The current model `<select>` sits in its own `<div>` above the input textarea, consuming a full row of vertical space and visually disconnected from the other action buttons.
+
+## Solution
+
+Relocate the `<select>` into `.shortcut-buttons`, between the microphone (voice chat) button and the `⌘↵ to send` hint text. Restyle it to blend with the toolbar rather than appear as a standalone form control.
+
+## Layout After Change
+
+```
+[ 😁 ] [ $ ] [ 🖼 ] [ 🎤 ] [ Sonnet ▾ ]   ⌘↵ to send
+```
+
+## HTML Changes
+
+- **Remove** the standalone wrapper `<div>` (currently at lines 289–297 of `index.html`) that contains the `<select>`.
+- **Add** the same `<select>` element into `.shortcut-buttons`, after the mic button and before the `.input-hint` span.
+- Visibility condition remains unchanged: `x-show="currentSession?.mode === 'managed' && !shellMode"`.
+- `x-model`, `@change` localStorage binding, and `<option>` list remain unchanged.
+
+## Styling
+
+Apply a new CSS class (e.g. `.model-select-btn`) to replace the current inline style:
+
+- `background: transparent`
+- `border: none`
+- `color: var(--text-secondary)`
+- `font-size: 0.75rem`
+- `padding: 4px 6px`
+- `border-radius: 6px`
+- `cursor: pointer`
+- `outline: none`
+- On hover: `background: var(--bg-hover)` — matches existing icon button hover behavior
+- Retains native `<select>` caret (no custom arrow needed)
+
+## Scope
+
+- `server/web/static/index.html` — move element, add class
+- `server/web/static/style.css` — add `.model-select-btn` rule
+
+No JavaScript changes. No behavioral changes.

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -286,15 +286,6 @@
                 </template>
               </div>
 
-              <div x-show="currentSession?.mode === 'managed' && !shellMode" x-cloak style="display:flex; align-items:center; padding:0 0 6px 0;">
-                <select x-model="selectedModel" @change="localStorage.setItem('claude-controller-model', selectedModel)"
-                        aria-label="Model"
-                        style="background:var(--bg-secondary); color:var(--text-primary); border:1px solid var(--border); border-radius:6px; padding:3px 8px; font-size:0.75rem; cursor:pointer; outline:none;">
-                  <option value="claude-opus-4-6">Opus</option>
-                  <option value="claude-sonnet-4-6">Sonnet</option>
-                  <option value="claude-haiku-4-5-20251001">Haiku</option>
-                </select>
-              </div>
               <div class="input-row">
                 <div class="input-wrapper">
                   <!-- Image preview -->
@@ -366,6 +357,16 @@
                     <line x1="5" y1="15" x2="11" y2="15"/>
                   </svg>
                 </button>
+                <select x-model="selectedModel"
+                        x-show="currentSession?.mode === 'managed' && !shellMode"
+                        x-cloak
+                        @change="localStorage.setItem('claude-controller-model', selectedModel)"
+                        aria-label="Model"
+                        class="model-select-btn">
+                  <option value="claude-opus-4-6">Opus</option>
+                  <option value="claude-sonnet-4-6">Sonnet</option>
+                  <option value="claude-haiku-4-5-20251001">Haiku</option>
+                </select>
                 <span class="input-hint">⌘↵ to send</span>
               </div>
             </div>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -2436,6 +2436,23 @@ body {
   50% { box-shadow: 0 0 0 6px rgba(220, 38, 38, 0); }
 }
 
+/* Model selector styled as toolbar button */
+.model-select-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.75rem;
+  padding: 4px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  outline: none;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+.model-select-btn:hover {
+  background: var(--bg-tertiary, #e5e7eb);
+}
+
 /* Image preview strip */
 .image-preview-strip {
   display: flex;


### PR DESCRIPTION
## Summary

- Removes the standalone model selector row that sat above the message input, reclaiming vertical space
- Relocates the `<select>` into the shortcut buttons toolbar, between the mic button and the ⌘↵ hint: `😁 | $ | 🖼 | 🎤 | [Sonnet ▾] | ⌘↵ to send`
- Adds `.model-select-btn` CSS class styling it as a compact, borderless-background button with a visible border matching adjacent icon buttons — replaces previous inline styles

## Test Plan

- [ ] No model dropdown appears above the input box
- [ ] Model selector appears in the shortcut toolbar after the mic button
- [ ] Selector is hidden in hook-mode sessions and shell mode
- [ ] Changing model still persists to localStorage (survives reload)
- [ ] Hover shows subtle background highlight