### PR TITLE
feat: move GitHub token to integrations tab with required eyebrow label

### DIFF
--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1376,21 +1376,28 @@
               <input x-model="settingsForm.compact_every_n_continues" type="number" min="0" placeholder="0" class="modal-input" :style="isFieldChanged('compact_every_n_continues') ? 'border-color:var(--yellow)' : ''">
               <div class="modal-hint">Run /compact every N auto-continues to reduce token usage. 0 = disabled.</div>
             </div>
-
-            <div class="settings-field">
-              <label class="modal-label">
-                GitHub Token
-                <span x-show="isFieldChanged('github_token')" class="settings-change-badge">changed</span>
-              </label>
-              <input x-model="settingsForm.github_token" type="password" placeholder="ghp_..." class="modal-input" :style="isFieldChanged('github_token') ? 'border-color:var(--yellow)' : ''">
-              <div class="modal-hint">Personal access token for GitHub issue tracking (needs repo scope)</div>
-            </div>
           </div>
 
           <!-- Integrations tab -->
           <div x-show="settingsActiveTab === 'integrations'">
             <div style="font-size:12px; color:var(--text-muted); margin-bottom:16px;">
-              Connect project management tools to browse issues and tasks alongside GitHub.
+              Connect source control and project management tools to browse issues, pull requests, and tasks.
+            </div>
+
+            <div style="font-size:10px; font-weight:600; letter-spacing:0.08em; text-transform:uppercase; color:var(--accent); margin-bottom:6px;">Required</div>
+            <div style="border:1px solid var(--border); border-radius:10px; padding:14px; margin-bottom:12px;">
+              <div style="font-size:13px; font-weight:600; margin-bottom:10px; display:flex; align-items:center; gap:6px;">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                GitHub
+              </div>
+              <div class="settings-field" style="margin-bottom:0;">
+                <label class="modal-label">
+                  Personal Access Token
+                  <span x-show="isFieldChanged('github_token')" class="settings-change-badge">changed</span>
+                </label>
+                <input x-model="settingsForm.github_token" type="password" placeholder="ghp_..." class="modal-input" :style="isFieldChanged('github_token') ? 'border-color:var(--yellow)' : ''">
+                <div class="modal-hint">Needs <code>repo</code> scope for issue and pull request tracking</div>
+              </div>
             </div>
 
             <div style="border:1px solid var(--border); border-radius:10px; padding:14px; margin-bottom:12px;">


### PR DESCRIPTION
## Summary
- Removes GitHub Token field from the Server settings tab
- Adds a GitHub card as the first integration in the Integrations tab, matching the visual treatment of Jira, Asana, and Google Tasks (bordered card, logo SVG, bold header)
- Adds a \"Required\" eyebrow label above the GitHub card to distinguish it from optional integrations
- Updates the Integrations tab description to reflect GitHub being a source control integration, not just a project management tool

## Test Plan
- [ ] Open Settings → Server tab: confirm GitHub Token field is gone, last field is "Compact Every N Continues"
- [ ] Open Settings → Integrations tab: confirm GitHub card appears first with "REQUIRED" eyebrow, followed by Jira, Asana, Google Tasks
- [ ] Type a value into the GitHub token field → confirm "changed" badge and yellow border appear
- [ ] Save and reload → confirm token persists