### PR TITLE
feat: button-triggered directory search with depth-first sort

### DIFF
--- a/docs/superpowers/plans/2026-04-28-directory-search-ux.md
+++ b/docs/superpowers/plans/2026-04-28-directory-search-ux.md
@@ -1,0 +1,278 @@
+# Directory Search UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace as-you-type directory search with a button-triggered search, and sort results shallower-first.
+
+**Architecture:** Two independent changes — backend adds a `sort.Slice` by path depth after the walk in `browse.go`; frontend replaces `@input` handler with a 🔍 button and Enter-key trigger, removing the debounce timer.
+
+**Tech Stack:** Go (backend), Alpine.js (frontend), no new dependencies.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `server/api/browse.go` | Add `sort.Slice` after walk loop |
+| `server/api/browse_test.go` | Add `TestHandleBrowseSearchDepthSort` test |
+| `server/web/static/index.html` | Wrap input in flex row, add 🔍 button, remove `@input` handler |
+| `server/web/static/app.js` | Rename `onDirSearchInput` → `triggerDirSearch`, remove debounce timer and `_dirSearchTimer` |
+
+---
+
+## Task 1: Backend — sort search results by depth
+
+**Files:**
+- Modify: `server/api/browse.go:112-145`
+- Modify: `server/api/browse_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to `server/api/browse_test.go` (after the last existing test):
+
+```go
+func TestHandleBrowseSearchDepthSort(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	// Structure:
+	//   base/target            (depth 1 from base — shallower)
+	//   base/a/b/target        (depth 3 from base — deeper)
+	base := t.TempDir()
+	shallow := filepath.Join(base, "target")
+	deep := filepath.Join(base, "a", "b", "target")
+	for _, dir := range []string{shallow, deep} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req, _ := http.NewRequest("GET",
+		ts.URL+"/api/browse/search?path="+base+"&q=target",
+		nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	entries := result["entries"].([]interface{})
+
+	if len(entries) != 2 {
+		t.Fatalf("len(entries)=%d, want 2", len(entries))
+	}
+	// Shallow result must come first.
+	first := entries[0].(map[string]interface{})
+	if first["path"] != shallow {
+		t.Errorf("first path=%v, want %v (shallower dir)", first["path"], shallow)
+	}
+	second := entries[1].(map[string]interface{})
+	if second["path"] != deep {
+		t.Errorf("second path=%v, want %v (deeper dir)", second["path"], deep)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd server && go test ./api/ -v -run TestHandleBrowseSearchDepthSort
+```
+
+Expected: FAIL — results will be in walk order (deep may come before shallow depending on filesystem ordering, or the assertion will fail).
+
+- [ ] **Step 3: Add sort to `handleBrowseSearch` in `server/api/browse.go`**
+
+After the `filepath.Walk` block (line ~137, just before `if results == nil`), add the sort. The final section of `handleBrowseSearch` should look like this:
+
+```go
+	// (existing walk block ends here)
+
+	sort.Slice(results, func(i, j int) bool {
+		sep := string(filepath.Separator)
+		di := strings.Count(results[i].Path, sep)
+		dj := strings.Count(results[j].Path, sep)
+		if di != dj {
+			return di < dj
+		}
+		return strings.ToLower(results[i].Name) < strings.ToLower(results[j].Name)
+	})
+
+	if results == nil {
+		results = []dirEntry{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"entries": results,
+	})
+```
+
+The `sort` package is already imported at the top of `browse.go`. No new imports needed.
+
+- [ ] **Step 4: Run all browse tests to verify they pass**
+
+```bash
+cd server && go test ./api/ -v -run TestHandleBrowseSearch
+```
+
+Expected: all four `TestHandleBrowseSearch*` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/api/browse.go server/api/browse_test.go
+git commit -m "feat: sort directory search results shallower-first"
+```
+
+---
+
+## Task 2: Frontend — button-triggered search
+
+**Files:**
+- Modify: `server/web/static/index.html:1091-1096`
+- Modify: `server/web/static/app.js:56-59,1405-1430`
+
+- [ ] **Step 1: Replace the search input row in `index.html`**
+
+Find this block (around line 1091):
+
+```html
+          <!-- Directory search -->
+          <div style="margin-bottom:8px;">
+            <input x-model="dirSearch" type="text" placeholder="Search folders…"
+                   class="modal-input" style="width:100%; box-sizing:border-box;"
+                   @input="onDirSearchInput()">
+          </div>
+```
+
+Replace it with:
+
+```html
+          <!-- Directory search -->
+          <div style="margin-bottom:8px; display:flex; gap:6px;">
+            <input x-model="dirSearch" type="text" placeholder="Search folders…"
+                   class="modal-input" style="flex:1;"
+                   @keydown.enter.prevent="triggerDirSearch()">
+            <button class="btn btn-sm" @click="triggerDirSearch()">🔍</button>
+          </div>
+```
+
+- [ ] **Step 2: Remove `_dirSearchTimer` from the state object in `app.js`**
+
+Find (around line 56):
+
+```js
+    dirSearch: '',
+    dirSearchResults: [],
+    dirSearchLoading: false,
+    _dirSearchTimer: null,
+```
+
+Replace with:
+
+```js
+    dirSearch: '',
+    dirSearchResults: [],
+    dirSearchLoading: false,
+```
+
+- [ ] **Step 3: Replace `onDirSearchInput` with `triggerDirSearch` in `app.js`**
+
+Find the entire `onDirSearchInput` function (around line 1405):
+
+```js
+    onDirSearchInput() {
+      clearTimeout(this._dirSearchTimer);
+      const q = this.dirSearch.trim();
+      if (!q) {
+        this.dirSearchResults = [];
+        this.dirSearchLoading = false;
+        return;
+      }
+      this.dirSearchLoading = true;
+      this._dirSearchTimer = setTimeout(async () => {
+        try {
+          const path = encodeURIComponent(this.browsePath || '');
+          const res = await fetch(
+            '/api/browse/search?path=' + path + '&q=' + encodeURIComponent(q),
+            { headers: { 'Authorization': 'Bearer ' + this.apiKey } }
+          );
+          if (!res.ok) throw new Error(await res.text());
+          const data = await res.json();
+          this.dirSearchResults = data.entries || [];
+        } catch (e) {
+          this.dirSearchResults = [];
+        } finally {
+          this.dirSearchLoading = false;
+        }
+      }, 300);
+    },
+```
+
+Replace it with:
+
+```js
+    async triggerDirSearch() {
+      const q = this.dirSearch.trim();
+      if (!q) {
+        this.dirSearchResults = [];
+        this.dirSearchLoading = false;
+        return;
+      }
+      this.dirSearchLoading = true;
+      try {
+        const path = encodeURIComponent(this.browsePath || '');
+        const res = await fetch(
+          '/api/browse/search?path=' + path + '&q=' + encodeURIComponent(q),
+          { headers: { 'Authorization': 'Bearer ' + this.apiKey } }
+        );
+        if (!res.ok) throw new Error(await res.text());
+        const data = await res.json();
+        this.dirSearchResults = data.entries || [];
+      } catch (e) {
+        this.dirSearchResults = [];
+      } finally {
+        this.dirSearchLoading = false;
+      }
+    },
+```
+
+- [ ] **Step 4: Verify the server builds cleanly**
+
+```bash
+cd server && go build -o /dev/null .
+```
+
+Expected: no output, exit code 0.
+
+- [ ] **Step 5: Start the server and manually verify**
+
+```bash
+cd server && go run . &
+```
+
+Open `http://localhost:8080` in a browser. Open the new-session modal. Confirm:
+- Typing in the search box does NOT trigger a search.
+- Pressing Enter triggers the search.
+- Clicking 🔍 triggers the search.
+- Clearing the input and clicking 🔍 clears the results panel.
+- Results for a multi-depth query appear shallower-first.
+
+Stop the server after verifying (`kill %1` or Ctrl+C).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/web/static/index.html server/web/static/app.js
+git commit -m "feat: trigger directory search on button click, not on input"
+```

--- a/docs/superpowers/specs/2026-04-28-directory-search-ux-design.md
+++ b/docs/superpowers/specs/2026-04-28-directory-search-ux-design.md
@@ -1,0 +1,85 @@
+# Directory Search UX — Design Spec
+
+**Date:** 2026-04-28
+**Status:** Approved
+
+## Overview
+
+Improve the directory/project search experience in the new-session modal. Three changes: trigger search on button click instead of as-you-type, sort results shallower-first, and clarify that only directories whose own name matches the query are included (already the case in code, now made explicit in design).
+
+## Problem
+
+1. Search fires on every keystroke (with a 300 ms debounce), which is unnecessary for a filesystem walk and can feel janky.
+2. Results are returned in walk order (depth-first), so a deeply-nested exact-match can appear before a top-level match.
+3. The relevance rule (only a dir whose **name** contains the query is included — not its ancestors or descendants) was implicit; making it explicit helps reviewers and testers.
+
+## Approach
+
+Option A: button-triggered search + backend depth sort. No as-you-type debounce. Simple, focused.
+
+## Design
+
+### 1. UI (`server/web/static/index.html` + `app.js`)
+
+Replace the single search input with a flex row: input + 🔍 button.
+
+```html
+<div style="display:flex; gap:6px;">
+  <input x-model="dirSearch" type="text" placeholder="Search folders…"
+         class="modal-input" style="flex:1;"
+         @keydown.enter.prevent="triggerDirSearch()">
+  <button class="btn btn-sm" @click="triggerDirSearch()">🔍</button>
+</div>
+```
+
+- `@input="onDirSearchInput()"` is removed entirely — no as-you-type behavior.
+- Enter key on the input and clicking 🔍 both call `triggerDirSearch()`.
+- Clearing the input field (empty query) immediately clears results and hides the results panel (handled inside `triggerDirSearch()` with an early return).
+
+`onDirSearchInput()` in `app.js` is renamed `triggerDirSearch()`. The debounce timer (`_dirSearchTimer`, `setTimeout`) is removed — the function fires the API call directly and synchronously sets `dirSearchLoading = true`.
+
+State fields `dirSearch`, `dirSearchResults`, `dirSearchLoading`, and `_dirSearchTimer` remain. `_dirSearchTimer` can be removed since it is no longer used.
+
+### 2. Backend sort (`server/api/browse.go`)
+
+After the walk collects results, sort by two keys:
+
+1. **Depth** (primary) — `strings.Count(path, string(filepath.Separator))` ascending. Shallower paths come first.
+2. **Name** (tiebreaker) — case-insensitive alphabetical within the same depth.
+
+```go
+sort.Slice(results, func(i, j int) bool {
+    sep := string(filepath.Separator)
+    di := strings.Count(results[i].Path, sep)
+    dj := strings.Count(results[j].Path, sep)
+    if di != dj {
+        return di < dj
+    }
+    return strings.ToLower(results[i].Name) < strings.ToLower(results[j].Name)
+})
+```
+
+The walk and filtering logic are unchanged: only a directory whose **name** (the final path component) contains the query string (case-insensitive) is included. Parent directories that don't match are traversed but not emitted.
+
+**Example** — query `diffintegrator` starting from `~`:
+- `~/workspaces/diffintegrator` — depth 3, name matches → included, appears first
+- `~/workspaces/diffintegrator/deploy` — depth 4, name `deploy` does not match → excluded
+- `~/workspaces/diffintegrator/deploy/diffintegrator` — depth 5, name matches → included, appears second
+- Result order: `~/workspaces/diffintegrator`, then `~/workspaces/diffintegrator/deploy/diffintegrator`
+
+### 3. Files changed
+
+| File | Change |
+|------|--------|
+| `server/web/static/index.html` | Replace search input div with flex row + 🔍 button; remove `@input` handler |
+| `server/web/static/app.js` | Rename `onDirSearchInput` → `triggerDirSearch`; remove debounce timer; remove `_dirSearchTimer` state field |
+| `server/api/browse.go` | Add `sort.Slice` after walk loop to sort results by depth then name |
+| `server/api/browse_test.go` | Update/add tests to assert depth-first ordering |
+
+## Testing
+
+- Search `diffintegrator` from home: verify `~/workspaces/diffintegrator` appears before `~/workspaces/diffintegrator/deploy/diffintegrator`, and `~/workspaces/diffintegrator/deploy` does not appear.
+- Verify pressing Enter triggers the search.
+- Verify clicking 🔍 triggers the search.
+- Verify clearing the input and clicking 🔍 clears results.
+- Verify no network request fires while typing (only on button click / Enter).

--- a/server/api/browse.go
+++ b/server/api/browse.go
@@ -136,6 +136,16 @@ func (s *Server) handleBrowseSearch(w http.ResponseWriter, r *http.Request) {
 		return nil
 	})
 
+	sort.Slice(results, func(i, j int) bool {
+		sep := string(filepath.Separator)
+		di := strings.Count(results[i].Path, sep)
+		dj := strings.Count(results[j].Path, sep)
+		if di != dj {
+			return di < dj
+		}
+		return strings.ToLower(results[i].Name) < strings.ToLower(results[j].Name)
+	})
+
 	if results == nil {
 		results = []dirEntry{}
 	}

--- a/server/api/browse_test.go
+++ b/server/api/browse_test.go
@@ -115,3 +115,53 @@ func TestHandleBrowseSearchDepthCap(t *testing.T) {
 		t.Errorf("name=%v, want target-shallow", entry["name"])
 	}
 }
+
+func TestHandleBrowseSearchDepthSort(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	// Structure:
+	//   base/target            (depth 1 from base — shallower)
+	//   base/a/b/target        (depth 3 from base — deeper)
+	base := t.TempDir()
+	shallow := filepath.Join(base, "target")
+	deep := filepath.Join(base, "a", "b", "target")
+	for _, dir := range []string{shallow, deep} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	req, _ := http.NewRequest("GET",
+		ts.URL+"/api/browse/search?path="+base+"&q=target",
+		nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	entries := result["entries"].([]interface{})
+
+	if len(entries) != 2 {
+		t.Fatalf("len(entries)=%d, want 2", len(entries))
+	}
+	// Shallow result must come first.
+	first := entries[0].(map[string]interface{})
+	if first["path"] != shallow {
+		t.Errorf("first path=%v, want %v (shallower dir)", first["path"], shallow)
+	}
+	second := entries[1].(map[string]interface{})
+	if second["path"] != deep {
+		t.Errorf("second path=%v, want %v (deeper dir)", second["path"], deep)
+	}
+}

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -56,7 +56,6 @@ document.addEventListener('alpine:init', () => {
     dirSearch: '',
     dirSearchResults: [],
     dirSearchLoading: false,
-    _dirSearchTimer: null,
 
     // Resume picker state
     showResumePicker: false,
@@ -1402,8 +1401,7 @@ document.addEventListener('alpine:init', () => {
       await this.browseTo('');
     },
 
-    onDirSearchInput() {
-      clearTimeout(this._dirSearchTimer);
+    async triggerDirSearch() {
       const q = this.dirSearch.trim();
       if (!q) {
         this.dirSearchResults = [];
@@ -1411,22 +1409,20 @@ document.addEventListener('alpine:init', () => {
         return;
       }
       this.dirSearchLoading = true;
-      this._dirSearchTimer = setTimeout(async () => {
-        try {
-          const path = encodeURIComponent(this.browsePath || '');
-          const res = await fetch(
-            '/api/browse/search?path=' + path + '&q=' + encodeURIComponent(q),
-            { headers: { 'Authorization': 'Bearer ' + this.apiKey } }
-          );
-          if (!res.ok) throw new Error(await res.text());
-          const data = await res.json();
-          this.dirSearchResults = data.entries || [];
-        } catch (e) {
-          this.dirSearchResults = [];
-        } finally {
-          this.dirSearchLoading = false;
-        }
-      }, 300);
+      try {
+        const path = encodeURIComponent(this.browsePath || '');
+        const res = await fetch(
+          '/api/browse/search?path=' + path + '&q=' + encodeURIComponent(q),
+          { headers: { 'Authorization': 'Bearer ' + this.apiKey } }
+        );
+        if (!res.ok) throw new Error(await res.text());
+        const data = await res.json();
+        this.dirSearchResults = data.entries || [];
+      } catch (e) {
+        this.dirSearchResults = [];
+      } finally {
+        this.dirSearchLoading = false;
+      }
     },
 
     async browseTo(path) {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -56,6 +56,7 @@ document.addEventListener('alpine:init', () => {
     dirSearch: '',
     dirSearchResults: [],
     dirSearchLoading: false,
+    dirSearchActive: false,
 
     // Resume picker state
     showResumePicker: false,
@@ -1386,6 +1387,7 @@ document.addEventListener('alpine:init', () => {
       this.dirSearch = '';
       this.dirSearchResults = [];
       this.dirSearchLoading = false;
+      this.dirSearchActive = false;
       // Fetch recent directories
       try {
         const res = await fetch('/api/sessions/recent-dirs', {
@@ -1406,8 +1408,10 @@ document.addEventListener('alpine:init', () => {
       if (!q) {
         this.dirSearchResults = [];
         this.dirSearchLoading = false;
+        this.dirSearchActive = false;
         return;
       }
+      this.dirSearchActive = true;
       this.dirSearchLoading = true;
       try {
         const path = encodeURIComponent(this.browsePath || '');

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1089,10 +1089,11 @@
           </div>
 
           <!-- Directory search -->
-          <div style="margin-bottom:8px;">
+          <div style="margin-bottom:8px; display:flex; gap:6px;">
             <input x-model="dirSearch" type="text" placeholder="Search folders…"
-                   class="modal-input" style="width:100%; box-sizing:border-box;"
-                   @input="onDirSearchInput()">
+                   class="modal-input" style="flex:1;"
+                   @keydown.enter.prevent="triggerDirSearch()">
+            <button class="btn btn-sm" @click="triggerDirSearch()">🔍</button>
           </div>
 
           <!-- Directory list -->

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1099,7 +1099,7 @@
           <!-- Directory list -->
           <div class="browse-list" style="flex:1; min-height:0;">
             <!-- Normal browse (no active search) -->
-            <div x-show="!dirSearch">
+            <div x-show="!dirSearchActive">
               <template x-if="browseLoading">
                 <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
               </template>
@@ -1116,7 +1116,7 @@
               </template>
             </div>
             <!-- Search results (active search) -->
-            <div x-show="dirSearch">
+            <div x-show="dirSearchActive">
               <template x-if="dirSearchLoading">
                 <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">Searching…</div>
               </template>
@@ -1124,7 +1124,7 @@
                 <div style="padding:1rem; text-align:center; color:var(--text-muted); font-size:13px;">No matching directories</div>
               </template>
               <template x-for="entry in dirSearchResults" :key="entry.path">
-                <div class="browse-item" @click="dirSearch = ''; dirSearchResults = []; browseTo(entry.path)">
+                <div class="browse-item" @click="dirSearch = ''; dirSearchResults = []; dirSearchActive = false; browseTo(entry.path)">
                   <span class="browse-icon" x-text="entry.is_git_repo ? '&#9679;' : '&#128193;'"
                         :style="entry.is_git_repo ? 'color:var(--green)' : 'color:var(--text-muted)'"></span>
                   <div style="flex:1; min-width:0;">


### PR DESCRIPTION
## Summary

- **Button-triggered search:** Search in the new-session modal now fires on Enter or 🔍 button click — not as-you-type. Browse list stays visible while typing; only switches to results once a search actually executes (`dirSearchActive` flag).
- **Depth-first sort:** Results sorted shallower-first (fewer path components), alphabetical name as tiebreaker. `~/workspaces/foo` appears before `~/workspaces/foo/deploy/foo`.
- **Relevance unchanged:** Only dirs whose own name contains the query are included — existing behaviour, now explicit.

## Test Plan
- [ ] Open new-session modal — browse list shows normally
- [ ] Type in search box — browse list stays visible, no search fires
- [ ] Press Enter or click 🔍 — results replace browse list
- [ ] Clear input and click 🔍 — browse list reappears
- [ ] Search a name present at multiple depths — shallower result appears first
- [ ] `go test ./api/ -v -run TestHandleBrowseSearch` — all 4 tests pass