### PR TITLE
feat: Windows compatibility for Go server and hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PORT ?= 9999
 CLAUDE_DIR ?= ~/.claude
 SERVER_BIN := server/claude-controller
 
-.PHONY: help build test run stop open local run-docker run-docker-bg stop-docker logs ngrok hooks clean all
+.PHONY: help build build-windows test run stop open local run-docker run-docker-bg stop-docker logs ngrok hooks clean all
 
 .DEFAULT_GOAL := help
 
@@ -19,6 +19,9 @@ help: ## Show this help message
 
 build: ## Build the Go server binary
 	cd server && go build -o claude-controller .
+
+build-windows: ## Cross-compile the Go server binary for Windows (amd64)
+	cd server && GOOS=windows GOARCH=amd64 go build -o claude-controller.exe .
 
 test: ## Run all server tests
 	cd server && go test ./... -v

--- a/hooks/install.ps1
+++ b/hooks/install.ps1
@@ -1,0 +1,89 @@
+# Claude Controller Hook Installer (Windows)
+# Sets up the hooks in Claude Code settings and creates the config file.
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+Write-Host "=== Claude Controller Hook Installer ==="
+Write-Host ""
+
+# Claude settings location
+$DefaultClaudeDir = Join-Path $env:USERPROFILE ".claude"
+if ($env:CLAUDE_DIR) { $DefaultClaudeDir = $env:CLAUDE_DIR }
+$DefaultSettings = Join-Path $DefaultClaudeDir "settings.json"
+
+$inputSettings = Read-Host "Claude settings file [$DefaultSettings]"
+$SettingsFile = if ($inputSettings) { $inputSettings } else { $DefaultSettings }
+
+# Config file location
+$DefaultConfig = Join-Path $env:USERPROFILE ".claude-controller.json"
+$inputConfig = Read-Host "Controller config file [$DefaultConfig]"
+$ConfigFile = if ($inputConfig) { $inputConfig } else { $DefaultConfig }
+
+# Computer name
+$DefaultName = $env:COMPUTERNAME
+$inputName = Read-Host "Computer name [$DefaultName]"
+$ComputerName = if ($inputName) { $inputName } else { $DefaultName }
+
+# Server port and URL
+$inputPort = Read-Host "Server port [8080]"
+$Port = if ($inputPort) { $inputPort } else { "8080" }
+$DefaultURL = "http://localhost:$Port"
+$inputURL = Read-Host "Server URL [$DefaultURL]"
+$ServerURL = if ($inputURL) { $inputURL } else { $DefaultURL }
+
+# API key
+$APIKey = Read-Host "API key (from QR code or server output)"
+
+# Write config JSON
+$config = [ordered]@{
+    server_url    = $ServerURL
+    computer_name = $ComputerName
+    api_key       = $APIKey
+}
+$config | ConvertTo-Json | Set-Content -Path $ConfigFile -Encoding UTF8
+Write-Host "Config written to $ConfigFile"
+
+# Ensure settings directory and file exist
+$SettingsDir = Split-Path -Parent $SettingsFile
+if (-not (Test-Path $SettingsDir)) {
+    New-Item -ItemType Directory -Force -Path $SettingsDir | Out-Null
+}
+if (-not (Test-Path $SettingsFile)) {
+    Set-Content -Path $SettingsFile -Value "{}" -Encoding UTF8
+}
+
+# Build hook commands — embed config path if non-default
+$StopHook = Join-Path $ScriptDir "stop.ps1"
+$NotifyHook = Join-Path $ScriptDir "notify.ps1"
+
+if ($ConfigFile -eq $DefaultConfig) {
+    $StopCmd = "pwsh -NonInteractive -File `"$StopHook`""
+    $NotifyCmd = "pwsh -NonInteractive -File `"$NotifyHook`""
+} else {
+    $StopCmd = "`$env:CLAUDE_CONTROLLER_CONFIG='$ConfigFile'; pwsh -NonInteractive -File `"$StopHook`""
+    $NotifyCmd = "`$env:CLAUDE_CONTROLLER_CONFIG='$ConfigFile'; pwsh -NonInteractive -File `"$NotifyHook`""
+}
+
+# Patch Claude Code settings.json
+$settings = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+
+# Ensure hooks property exists
+if (-not $settings.PSObject.Properties['hooks']) {
+    $settings | Add-Member -MemberType NoteProperty -Name 'hooks' -Value ([PSCustomObject]@{})
+}
+
+$stopEntry = [PSCustomObject]@{
+    hooks = @([PSCustomObject]@{ type = "command"; command = $StopCmd })
+}
+$notifyEntry = [PSCustomObject]@{
+    hooks = @([PSCustomObject]@{ type = "command"; command = $NotifyCmd })
+}
+
+$settings.hooks | Add-Member -MemberType NoteProperty -Name 'Stop' -Value @($stopEntry) -Force
+$settings.hooks | Add-Member -MemberType NoteProperty -Name 'Notification' -Value @($notifyEntry) -Force
+
+$settings | ConvertTo-Json -Depth 10 | Set-Content -Path $SettingsFile -Encoding UTF8
+Write-Host "Hooks registered in $SettingsFile"
+Write-Host ""
+Write-Host "Done! Restart any running Claude Code sessions for hooks to take effect."

--- a/server/api/create_project.go
+++ b/server/api/create_project.go
@@ -94,9 +94,18 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Git init
+	// Git init — strip GIT_DIR and related vars that git push sets in hook
+	// context; inheriting them causes git init to reinitialize the parent
+	// repo at GIT_DIR instead of creating .git in fullPath.
 	gitCmd := exec.Command("git", "init")
 	gitCmd.Dir = fullPath
+	var gitEnv []string
+	for _, e := range os.Environ() {
+		if k, _, _ := strings.Cut(e, "="); k != "GIT_DIR" && k != "GIT_WORK_TREE" && k != "GIT_INDEX_FILE" && k != "GIT_OBJECT_DIRECTORY" {
+			gitEnv = append(gitEnv, e)
+		}
+	}
+	gitCmd.Env = gitEnv
 	if out, err := gitCmd.CombinedOutput(); err != nil {
 		os.RemoveAll(fullPath)
 		http.Error(w, fmt.Sprintf("git init failed: %s", string(out)), http.StatusInternalServerError)

--- a/server/api/resume.go
+++ b/server/api/resume.go
@@ -14,8 +14,14 @@ import (
 )
 
 // claudeProjectDir encodes a CWD to match Claude Code's project directory naming.
-// Replaces /, _, and . with -.
+// Replaces /, _, and . with -. Handles Windows paths (backslashes, drive letter colon).
 func claudeProjectDir(cwd string) string {
+	// Normalize Windows backslashes to forward slashes
+	cwd = filepath.ToSlash(cwd)
+	// Strip drive letter colon (e.g. "C:/Users/..." -> "C/Users/...")
+	if len(cwd) >= 2 && cwd[1] == ':' {
+		cwd = cwd[:1] + cwd[2:]
+	}
 	r := strings.NewReplacer("/", "-", "_", "-", ".", "-")
 	return r.Replace(cwd)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	qrcode "github.com/skip2/go-qrcode"
@@ -188,11 +187,7 @@ func main() {
 			os.Exit(0)
 		}
 		log.Printf("Re-execing %s %v", exe, os.Args)
-		execErr := syscall.Exec(exe, os.Args, os.Environ())
-		if execErr != nil {
-			log.Printf("syscall.Exec failed: %v — exiting for wrapper to restart", execErr)
-			os.Exit(0)
-		}
+		execRestart(exe, os.Args, os.Environ())
 	}
 }
 

--- a/server/managed/manager.go
+++ b/server/managed/manager.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -187,7 +186,7 @@ func (m *Manager) Interrupt(sessionID string) error {
 	if !ok {
 		return fmt.Errorf("no running process for session %s", sessionID)
 	}
-	return proc.Cmd.Process.Signal(syscall.SIGINT)
+	return interruptProcess(proc.Cmd.Process)
 }
 
 // ReapIdle closes stdin on any process that has been idle longer than maxIdle.
@@ -253,9 +252,8 @@ func (m *Manager) SpawnShell(sessionID string, opts ShellOpts) (*Process, error)
 	}
 	m.mu.Unlock()
 
-	cmd := exec.Command("sh", "-c", opts.Command)
+	cmd := newShellCmd(opts.Command)
 	cmd.Dir = opts.CWD
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -296,19 +294,7 @@ func (m *Manager) SpawnShell(sessionID string, opts ShellOpts) (*Process, error)
 		go func() {
 			select {
 			case <-time.After(opts.Timeout):
-				pgid, err := syscall.Getpgid(cmd.Process.Pid)
-				if err != nil {
-					cmd.Process.Kill()
-					return
-				}
-				proc.TimedOut = true
-				syscall.Kill(-pgid, syscall.SIGINT)
-				select {
-				case <-proc.Done:
-					return
-				case <-time.After(5 * time.Second):
-					syscall.Kill(-pgid, syscall.SIGKILL)
-				}
+				killWithTimeout(cmd, proc, 5*time.Second)
 			case <-proc.Done:
 				return
 			}

--- a/server/managed/manager_unix.go
+++ b/server/managed/manager_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package managed
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func interruptProcess(p *os.Process) error {
+	return p.Signal(syscall.SIGINT)
+}
+
+func newShellCmd(command string) *exec.Cmd {
+	cmd := exec.Command("sh", "-c", command)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd
+}
+
+// killWithTimeout sends SIGINT to the process group, waits gracePeriod, then SIGKILL.
+func killWithTimeout(cmd *exec.Cmd, proc *Process, gracePeriod time.Duration) {
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		cmd.Process.Kill()
+		return
+	}
+	proc.TimedOut = true
+	syscall.Kill(-pgid, syscall.SIGINT)
+	select {
+	case <-proc.Done:
+	case <-time.After(gracePeriod):
+		syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+}

--- a/server/managed/manager_windows.go
+++ b/server/managed/manager_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package managed
+
+import (
+	"os"
+	"os/exec"
+	"time"
+)
+
+func interruptProcess(p *os.Process) error {
+	return p.Signal(os.Interrupt)
+}
+
+func newShellCmd(command string) *exec.Cmd {
+	return exec.Command("cmd", "/c", command)
+}
+
+// killWithTimeout kills the process immediately on Windows (no process groups).
+func killWithTimeout(cmd *exec.Cmd, proc *Process, _ time.Duration) {
+	proc.TimedOut = true
+	cmd.Process.Kill()
+}

--- a/server/restart_unix.go
+++ b/server/restart_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"log"
+	"os"
+	"syscall"
+)
+
+func execRestart(exe string, args []string, env []string) {
+	if err := syscall.Exec(exe, args, env); err != nil {
+		log.Printf("syscall.Exec failed: %v — exiting for wrapper to restart", err)
+		os.Exit(0)
+	}
+}

--- a/server/restart_windows.go
+++ b/server/restart_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+)
+
+func execRestart(exe string, args []string, _ []string) {
+	cmd := exec.Command(exe, args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		log.Printf("restart failed: %v — exiting", err)
+	}
+	os.Exit(0)
+}

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"runtime"
 	"sync"
 	"time"
 
@@ -135,7 +136,11 @@ func (s *Scheduler) executeTask(task db.ScheduledTask) {
 	var cmd *exec.Cmd
 	switch task.TaskType {
 	case "shell":
-		cmd = exec.CommandContext(ctx, "bash", "-c", task.Command)
+		if runtime.GOOS == "windows" {
+			cmd = exec.CommandContext(ctx, "cmd", "/c", task.Command)
+		} else {
+			cmd = exec.CommandContext(ctx, "bash", "-c", task.Command)
+		}
 	case "claude":
 		args := []string{"-p"}
 		if task.Model != "" {


### PR DESCRIPTION
## Summary

- **Syscall isolation**: Extracted all Unix-only syscalls (SIGINT, Setpgid, Getpgid, Kill) into `manager_unix.go` / `manager_windows.go` build-tagged files. Windows uses `os.Interrupt` and direct Kill.
- **Shell commands**: `SpawnShell` now uses `sh -c` (Unix) or `cmd /c` (Windows) via `newShellCmd`. Same for the scheduler hardcoded `bash -c`.
- **Hot restart**: `syscall.Exec` in `main.go` moved to `restart_unix.go`; Windows version uses `cmd.Start()` + `os.Exit(0)`.
- **Windows paths**: `claudeProjectDir()` normalises backslash separators and strips drive letter colons (`C:\...`) before encoding.
- **Windows installer**: Added `hooks/install.ps1` mirroring `install.sh` — prompts for all config, writes `.claude-controller.json`, patches Claude Code `settings.json`.
- **Build target**: Added `make build-windows` (`GOOS=windows GOARCH=amd64`).
- **Bug fix**: `git init` in `handleCreateProject` now strips `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_OBJECT_DIRECTORY` from its subprocess env, fixing a flaky `TestCreateProjectAPI` failure under the pre-push hook (where `git push` sets `GIT_DIR`, causing git to reinitialize the parent repo instead of creating `.git` in the new project dir).

## Test Plan

- [x] `GOOS=windows go build ./...` compiles clean
- [x] All existing tests pass natively
- [x] All tests pass with `GIT_DIR` set (simulating push hook environment)
- [x] Pre-push hook passes end-to-end
