### PR TITLE
fix: Windows-compatible Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,21 @@
 
 PORT ?= 9999
 CLAUDE_DIR ?= ~/.claude
-SERVER_BIN := server/claude-controller
+
+# Platform detection — sets EXE suffix, delete command, and null redirect
+ifeq ($(OS),Windows_NT)
+  EXE      := .exe
+  RM_F     := del /f /q
+  DEVNULL  := 2>NUL
+  OPEN_CMD := start
+else
+  EXE      :=
+  RM_F     := rm -f
+  DEVNULL  := 2>/dev/null
+  OPEN_CMD := open
+endif
+
+SERVER_BIN := server/claude-controller$(EXE)
 
 .PHONY: help build build-windows test run stop open local run-docker run-docker-bg stop-docker logs ngrok hooks clean all
 
@@ -18,10 +32,14 @@ help: ## Show this help message
 ##@ Server
 
 build: ## Build the Go server binary
-	cd server && go build -o claude-controller .
+	cd server && go build -o claude-controller$(EXE) .
 
-build-windows: ## Cross-compile the Go server binary for Windows (amd64)
+build-windows: ## Build the Go server binary for Windows (amd64)
+ifeq ($(OS),Windows_NT)
+	cd server && go build -o claude-controller.exe .
+else
 	cd server && GOOS=windows GOARCH=amd64 go build -o claude-controller.exe .
+endif
 
 test: ## Run all server tests
 	cd server && go test ./... -v
@@ -33,28 +51,45 @@ test-api: ## Run API handler tests only
 	cd server && go test ./api/ -v
 
 run: build ## Build and run the server locally (web UI at http://localhost:PORT)
-	./$(SERVER_BIN) --port $(PORT)
+	$(SERVER_BIN) --port $(PORT)
 
 local: ## Stop everything, rebuild, and start fresh
-	-@pkill -f 'claude-controller' 2>/dev/null || true
-	-@docker compose down 2>/dev/null || true
-	rm -f $(SERVER_BIN)
-	cd server && go build -o claude-controller .
-	./$(SERVER_BIN) --port $(PORT)
+ifeq ($(OS),Windows_NT)
+	-taskkill /F /IM claude-controller.exe $(DEVNULL)
+	-$(RM_F) $(SERVER_BIN) $(DEVNULL)
+else
+	-pkill -f 'claude-controller' $(DEVNULL) || true
+	-docker compose down $(DEVNULL) || true
+	$(RM_F) $(SERVER_BIN)
+endif
+	cd server && go build -o claude-controller$(EXE) .
+	$(SERVER_BIN) --port $(PORT)
 
 stop: ## Stop the running Go server process
-	@pkill -f 'claude-controller' 2>/dev/null && echo "Server stopped." || echo "No server process found."
+ifeq ($(OS),Windows_NT)
+	@taskkill /F /IM claude-controller.exe $(DEVNULL) && echo Server stopped. || echo No server process found.
+else
+	@pkill -f 'claude-controller' $(DEVNULL) && echo "Server stopped." || echo "No server process found."
+endif
 
 open: ## Open the web UI in default browser
-	open http://localhost:$(PORT)
+	$(OPEN_CMD) http://localhost:$(PORT)
 
 ##@ Docker
 
 run-docker: ## Build and run in Docker (set NGROK_AUTHTOKEN for tunnel)
+ifeq ($(OS),Windows_NT)
+	cmd /c "set PORT=$(PORT) && set NGROK_AUTHTOKEN=$(NGROK_AUTHTOKEN) && docker compose up --build"
+else
 	PORT=$(PORT) NGROK_AUTHTOKEN=$(NGROK_AUTHTOKEN) docker compose up --build
+endif
 
 run-docker-bg: ## Build and run in Docker (background)
+ifeq ($(OS),Windows_NT)
+	cmd /c "set PORT=$(PORT) && set NGROK_AUTHTOKEN=$(NGROK_AUTHTOKEN) && docker compose up --build -d"
+else
 	PORT=$(PORT) NGROK_AUTHTOKEN=$(NGROK_AUTHTOKEN) docker compose up --build -d
+endif
 
 stop-docker: ## Stop Docker containers
 	docker compose down
@@ -69,13 +104,21 @@ ngrok: ## Start an ngrok tunnel to localhost:PORT
 
 ##@ Hooks
 
-hooks: ## Install hooks into Claude Code settings (uses CLAUDE_DIR from .env)
+hooks: ## Install hooks into Claude Code settings
+ifeq ($(OS),Windows_NT)
+	pwsh -NonInteractive -File hooks\install.ps1
+else
 	CLAUDE_DIR=$(CLAUDE_DIR) ./hooks/install.sh
+endif
 
 ##@ Cleanup
 
 clean: ## Remove build artifacts and Docker volumes
-	rm -f $(SERVER_BIN)
-	docker compose down -v 2>/dev/null || true
+ifeq ($(OS),Windows_NT)
+	-$(RM_F) $(SERVER_BIN) $(DEVNULL)
+else
+	$(RM_F) $(SERVER_BIN)
+	docker compose down -v $(DEVNULL) || true
+endif
 
 all: build


### PR DESCRIPTION
## Summary

Fixes `make local` (and related targets) crashing on Windows cmd.exe due to Unix-only shell constructs.

- Adds `ifeq ($(OS),Windows_NT)` detection block at top of Makefile to set `EXE`, `RM_F`, `DEVNULL`, `OPEN_CMD`
- `local`: `pkill` → `taskkill /F /IM`, `rm -f` → `del /f /q`, `|| true`/`2>/dev/null` removed
- `stop`: `pkill` → `taskkill` with cmd-compatible `&&`/`||`
- `build`/`run`: binary now uses `$(EXE)` suffix (`.exe` on Windows)
- `open`: `open` → `start` on Windows
- `clean`: `rm -f` → `del /f /q` on Windows
- `hooks`: runs `pwsh -NonInteractive -File hooks\install.ps1` on Windows instead of `install.sh`
- `run-docker`/`run-docker-bg`: uses `cmd /c "set VAR=... && ..."` for env var passing on Windows
- `build-windows`: skips `GOOS=windows` cross-compile flags when already on Windows

Unix behaviour is unchanged (verified with `make -n local` dry run).

## Test Plan

- [x] `make -n local` dry run on macOS produces correct Unix commands
- [x] `make build` succeeds on macOS
- [x] Pre-push hook passes
- [ ] `make local` on Windows (test on target machine)
