### PR TITLE
fix: skip ngrok entirely when NGROK_AUTHTOKEN is not set

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -130,12 +130,16 @@ func main() {
 	ngrokDone := make(chan struct{})
 	go func() {
 		defer close(ngrokDone)
+		if os.Getenv("NGROK_AUTHTOKEN") == "" {
+			log.Printf("Server is running locally only at http://%s", addr)
+			log.Printf("To expose via ngrok, set NGROK_AUTHTOKEN environment variable")
+			return
+		}
 		var err error
 		tun, err = tunnel.Start(ctx)
 		if err != nil {
 			log.Printf("Warning: ngrok tunnel failed: %v", err)
 			log.Printf("Server is running locally only at http://%s", addr)
-			log.Printf("To expose via ngrok, set NGROK_AUTHTOKEN environment variable")
 			return
 		}
 		ngrokURL := tun.URL()


### PR DESCRIPTION
## Summary
- When \`NGROK_AUTHTOKEN\` env var is not set, skip \`tunnel.Start\` entirely instead of attempting to connect and retrying ~12 times with auth failure spam
- On no-token startup, logs a single clean message: \`Server is running locally only at http://localhost:PORT\`
- Removes the repeated ERR_NGROK_4018 spam that was confusing Windows users running locally

## Test plan
- [ ] Run server without \`NGROK_AUTHTOKEN\` set — confirm single clean log line, no retry spam
- [ ] Run server with \`NGROK_AUTHTOKEN\` set — confirm tunnel still connects normally