### PR TITLE
feat: autofocus prompt input after send and session switch

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -949,6 +949,10 @@ document.addEventListener('alpine:init', () => {
       } catch (e) {}
     },
 
+    focusPromptInput() {
+      this.$nextTick(() => this.$refs.promptInput?.focus());
+    },
+
     // Actions
     async respondToPrompt(promptId, response) {
       // Use the prompt's own session_id, not selectedSessionId, to avoid mismatches

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -926,6 +926,7 @@ document.addEventListener('alpine:init', () => {
         this.githubPullsError = null;
         this.fetchGithubPulls(this.selectedSessionId);
       }
+      this.focusPromptInput();
     },
 
     async deleteSession(id) {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1694,6 +1694,7 @@ document.addEventListener('alpine:init', () => {
         this.toast('Error: ' + e.message);
       }
       this.inputSending = false;
+      this.focusPromptInput();
     },
 
     async executeShell() {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1747,6 +1747,7 @@ document.addEventListener('alpine:init', () => {
         this.toast('Error: ' + e.message);
       }
       this.inputSending = false;
+      this.focusPromptInput();
     },
 
     toggleVoiceChat() {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1375,6 +1375,7 @@ document.addEventListener('alpine:init', () => {
         }
       } catch (e) {}
       this.inputSending = false;
+      this.focusPromptInput();
     },
 
     async openNewSessionModal() {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -295,7 +295,7 @@
                     <button class="image-preview-remove" @click="clearPendingImage()" title="Remove image">&times;</button>
                   </div>
 
-                  <textarea x-model="inputText" rows="1"
+                  <textarea x-ref="promptInput" x-model="inputText" rows="1"
                          :placeholder="shellMode ? 'Run a command...' : (voiceChatActive ? (isListening ? 'Listening...' : 'Voice chat paused...') : (currentSession?.mode === 'managed' ? 'Send a message... (/ for commands)' : 'Send instruction (delivered on next stop)...'))"
                          :class="{ 'shell-input': shellMode }"
                          @keydown="handleSlashKeydown($event)"


### PR DESCRIPTION
## Summary

- Adds `x-ref="promptInput"` to the instruction-bar textarea so Alpine can reference it directly
- Adds `focusPromptInput()` helper that uses `$nextTick` + `$refs.promptInput?.focus()` for safe, DOM-settled focusing
- Calls `focusPromptInput()` after four user actions: sending a managed message, sending a shell command, sending a hook-mode instruction, and switching sessions

## Why

Reduces friction in the conversation flow — the user no longer needs to click back into the prompt box after every interaction.

## Test Plan

- [ ] Switch to a session — cursor lands in the prompt textarea automatically
- [ ] Send a managed message — cursor returns to textarea after send
- [ ] Send a shell command (shell mode) — cursor returns to textarea after send
- [ ] Send a hook-mode instruction — cursor returns to textarea after send
- [ ] Confirm the hook-mode response textarea (shown on pending prompts) is NOT affected