### PR TITLE
fix: auto-scroll chat to bottom when new messages arrive

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -467,8 +467,10 @@ document.addEventListener('alpine:init', () => {
               });
             }
           }
+          const hadMessages = this.chatMessages.length;
+          const hasNewMessages = messages.length > hadMessages;
           this.chatMessages = messages;
-          this.$nextTick(() => this.scrollToBottom(forceScroll));
+          this.$nextTick(() => this.scrollToBottom(forceScroll || hasNewMessages));
         }
       } catch (e) {}
       this.chatLoading = false;


### PR DESCRIPTION
## Summary
- In hook mode, `fetchTranscript` called `scrollToBottom(false)` on every SSE tick, so chat only scrolled if user was already within 150px of bottom
- New Claude messages would appear off-screen, requiring manual scrolling
- Fixed by detecting when message count increases and forcing scroll to bottom

## Test Plan
- [ ] Open a hook-mode session and scroll up in the chat
- [ ] Send a message and wait for Claude reply — chat should auto-scroll to the new message
- [ ] Verify scrolled-up position is preserved when no new messages arrive