### PR TITLE
fix: new folder Create button too wide in session modal

### DIFF
--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1152,6 +1152,7 @@
                    @keydown.escape.prevent="showNewFolderInput = false; newProjectName = ''">
             <button class="btn btn-sm btn-primary" @click="createNewProject()"
                     :disabled="!isValidNewProjectName || newProjectCreating"
+                    style="width:auto; white-space:nowrap;"
                     x-text="newProjectCreating ? 'Creating...' : 'Create'"></button>
             <button class="btn btn-sm" @click="showNewFolderInput = false; newProjectName = ''">&times;</button>
           </div>


### PR DESCRIPTION
## Summary
- The global `.btn-primary { width: 100% }` rule was overriding the flex layout, causing the Create button to stretch across the full row
- Added `width:auto; white-space:nowrap;` inline to restore natural button sizing, so the input takes the available space

## Test plan
- [ ] Open New Session modal
- [ ] Click "+ New Folder" to expand the input row
- [ ] Verify text input is wide and Create button is compact