### PR TITLE
feat: option selector buttons for assistant messages

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2986,56 +2986,11 @@ Please review this PR and provide feedback.`;
       return `${esc(msg.content)}${time}`;
     },
 
-    // Detect numbered/lettered options in assistant messages for the option selector UI
+    // Detect numbered/lettered options in assistant messages for the option selector UI.
+    // Logic lives in option-selector.js (loaded as <script type="module">) for testability.
     extractOptions(content) {
-      if (!content) return [];
-      const options = [];
-      const lines = content.split('\n');
-      // Strip markdown formatting from a line
-      const strip = (s) => s.replace(/^\s*#{1,6}\s*/, '').replace(/\*\*/g, '').replace(/\*/g, '').replace(/^[-*]\s+/, '').replace(/:$/, '').trim();
-
-      for (const line of lines) {
-        const c = strip(line);
-        if (!c) continue;
-        let m;
-
-        // "Option A: Title", "Option B - Title", "Option 1: Title" etc.
-        m = c.match(/^option\s+([a-zA-Z]|\d+)\s*[:\-.]\s*(.+)/i);
-        if (m) {
-          const label = `Option ${m[1].toUpperCase()}`;
-          const title = strip(m[2]);
-          options.push({ label, text: title ? `${label}: ${title}` : label });
-          continue;
-        }
-
-        // "Option A" alone (no separator/title)
-        m = c.match(/^option\s+([a-zA-Z]|\d+)\s*$/i);
-        if (m) {
-          const label = `Option ${m[1].toUpperCase()}`;
-          options.push({ label, text: label });
-          continue;
-        }
-
-        // "A. Title" or "B. Title" (capital letter + dot — letter-choice style)
-        m = c.match(/^([A-Z])\.\s+(.+)/);
-        if (m) {
-          const label = m[1];
-          const title = strip(m[2]);
-          options.push({ label, text: `${label}. ${title}` });
-          continue;
-        }
-
-        // "a) Title" / "A) Title" / "1) Title" (parenthesis style)
-        m = c.match(/^([a-zA-Z]|\d+)\)\s+(.+)/);
-        if (m) {
-          const label = m[1];
-          const title = strip(m[2]);
-          options.push({ label, text: `${label}) ${title}` });
-          continue;
-        }
-      }
-
-      return options.length >= 2 ? options : [];
+      if (typeof window._ccExtractOptions === 'function') return window._ccExtractOptions(content);
+      return [];
     },
 
     // Time formatting

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -277,6 +277,13 @@ document.addEventListener('alpine:init', () => {
       this.$watch('mobileMenuOpen', (open) => {
         document.body.style.overflow = open ? 'hidden' : '';
       });
+      // Option selector: handle clicks on detected option buttons (rendered via x-html)
+      document.addEventListener('click', (e) => {
+        const btn = e.target.closest('[data-option-send]');
+        if (!btn) return;
+        this.inputText = btn.dataset.optionSend;
+        this.$nextTick(() => this.handleInput());
+      });
     },
 
     // Auth
@@ -2948,7 +2955,18 @@ Please review this PR and provide feedback.`;
           };
           const html = marked.parse(msg.content || '', { renderer: r, breaks: true });
           const eyebrow = msg.command ? `<div class="command-label">${esc(msg.command)}</div>` : '';
-          return `${imgHtml}${eyebrow}<div class="markdown-content">${html}</div>${time}`;
+          let optionsHtml = '';
+          if (msg.role === 'assistant') {
+            const opts = this.extractOptions(msg.content);
+            if (opts.length > 0) {
+              optionsHtml = '<div class="option-buttons">' + opts.map(o => {
+                const safe = o.text.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                const display = o.label.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                return `<button class="option-btn" data-option-send="${safe}">${display}</button>`;
+              }).join('') + '</div>';
+            }
+          }
+          return `${imgHtml}${eyebrow}<div class="markdown-content">${html}</div>${optionsHtml}${time}`;
         }
         return `${imgHtml}${esc(msg.content)}${time}`;
       }
@@ -2966,6 +2984,58 @@ Please review this PR and provide feedback.`;
         return `<div class="tool-label">Bash</div><div>${esc(msg.content)}</div>${cmd}${time}`;
       }
       return `${esc(msg.content)}${time}`;
+    },
+
+    // Detect numbered/lettered options in assistant messages for the option selector UI
+    extractOptions(content) {
+      if (!content) return [];
+      const options = [];
+      const lines = content.split('\n');
+      // Strip markdown formatting from a line
+      const strip = (s) => s.replace(/^\s*#{1,6}\s*/, '').replace(/\*\*/g, '').replace(/\*/g, '').replace(/^[-*]\s+/, '').replace(/:$/, '').trim();
+
+      for (const line of lines) {
+        const c = strip(line);
+        if (!c) continue;
+        let m;
+
+        // "Option A: Title", "Option B - Title", "Option 1: Title" etc.
+        m = c.match(/^option\s+([a-zA-Z]|\d+)\s*[:\-.]\s*(.+)/i);
+        if (m) {
+          const label = `Option ${m[1].toUpperCase()}`;
+          const title = strip(m[2]);
+          options.push({ label, text: title ? `${label}: ${title}` : label });
+          continue;
+        }
+
+        // "Option A" alone (no separator/title)
+        m = c.match(/^option\s+([a-zA-Z]|\d+)\s*$/i);
+        if (m) {
+          const label = `Option ${m[1].toUpperCase()}`;
+          options.push({ label, text: label });
+          continue;
+        }
+
+        // "A. Title" or "B. Title" (capital letter + dot — letter-choice style)
+        m = c.match(/^([A-Z])\.\s+(.+)/);
+        if (m) {
+          const label = m[1];
+          const title = strip(m[2]);
+          options.push({ label, text: `${label}. ${title}` });
+          continue;
+        }
+
+        // "a) Title" / "A) Title" / "1) Title" (parenthesis style)
+        m = c.match(/^([a-zA-Z]|\d+)\)\s+(.+)/);
+        if (m) {
+          const label = m[1];
+          const title = strip(m[2]);
+          options.push({ label, text: `${label}) ${title}` });
+          continue;
+        }
+      }
+
+      return options.length >= 2 ? options : [];
     },
 
     // Time formatting

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script type="module" src="/option-selector.js"></script>
   <script defer src="/app.js"></script>
   <script defer src="/alpine.min.js"></script>
 </head>

--- a/server/web/static/option-selector.js
+++ b/server/web/static/option-selector.js
@@ -1,0 +1,74 @@
+/**
+ * Option Selector — detects numbered/lettered choices in assistant messages
+ * and returns structured option objects for rendering as clickable buttons.
+ *
+ * Dual-mode: ESM export for tests/Node.js, browser global for app.js.
+ *
+ * Detected patterns:
+ *   Option A: Title  |  Option 1: Title  |  Option A (alone)
+ *   A. Title         (capital letter + dot)
+ *   a) Title  |  A) Title  |  1) Title   (parenthesis)
+ */
+export function extractOptions(content) {
+  if (!content) return [];
+  const options = [];
+  const lines = content.split('\n');
+
+  // Strip markdown formatting from a line for clean matching
+  const strip = (s) => s
+    .replace(/^\s*#{1,6}\s*/, '')  // heading markers
+    .replace(/\*\*/g, '')           // bold
+    .replace(/\*/g, '')             // italic
+    .replace(/^[-*]\s+/, '')        // list bullet
+    .replace(/:$/, '')              // trailing colon
+    .trim();
+
+  for (const line of lines) {
+    const c = strip(line);
+    if (!c) continue;
+    let m;
+
+    // "Option A: Title", "Option B - Title", "Option 1. Title" etc.
+    m = c.match(/^option\s+([a-zA-Z]|\d+)\s*[:\-.]\s*(.+)/i);
+    if (m) {
+      const label = `Option ${m[1].toUpperCase()}`;
+      const title = strip(m[2]);
+      options.push({ label, text: title ? `${label}: ${title}` : label });
+      continue;
+    }
+
+    // "Option A" alone (no separator or title)
+    m = c.match(/^option\s+([a-zA-Z]|\d+)\s*$/i);
+    if (m) {
+      const label = `Option ${m[1].toUpperCase()}`;
+      options.push({ label, text: label });
+      continue;
+    }
+
+    // "A. Title" or "B. Title" (capital letter + dot — letter-choice style)
+    m = c.match(/^([A-Z])\.\s+(.+)/);
+    if (m) {
+      const label = m[1];
+      const title = strip(m[2]);
+      options.push({ label, text: `${label}. ${title}` });
+      continue;
+    }
+
+    // "a) Title" / "A) Title" / "1) Title" (parenthesis style)
+    m = c.match(/^([a-zA-Z]|\d+)\)\s+(.+)/);
+    if (m) {
+      const label = m[1];
+      const title = strip(m[2]);
+      options.push({ label, text: `${label}) ${title}` });
+      continue;
+    }
+  }
+
+  return options.length >= 2 ? options : [];
+}
+
+// Browser global — allows app.js (loaded as a regular script) to call this
+// function after this module has been loaded via <script type="module">.
+if (typeof window !== 'undefined') {
+  window._ccExtractOptions = extractOptions;
+}

--- a/server/web/static/option-selector.test.mjs
+++ b/server/web/static/option-selector.test.mjs
@@ -1,0 +1,118 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractOptions } from './option-selector.js';
+
+// --- "Option A/B/C:" pattern ---
+
+test('detects Option A/B with titles', () => {
+  const content = `Here are your choices:\n\n**Option A: Deploy with Docker**\nFast setup.\n\n**Option B: Deploy on bare metal**\nMore control.`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].label, 'Option A');
+  assert.equal(result[0].text, 'Option A: Deploy with Docker');
+  assert.equal(result[1].label, 'Option B');
+  assert.equal(result[1].text, 'Option B: Deploy with Docker'.replace('Docker', 'bare metal').replace('Deploy with', 'Deploy on'));
+});
+
+test('detects Option 1/2/3 with titles', () => {
+  const content = `Option 1: Use SQLite\nOption 2: Use PostgreSQL\nOption 3: Use MySQL`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].label, 'Option 1');
+  assert.equal(result[0].text, 'Option 1: Use SQLite');
+  assert.equal(result[1].label, 'Option 2');
+  assert.equal(result[2].label, 'Option 3');
+});
+
+test('detects Option A alone (no title)', () => {
+  const content = `Option A\nOption B\nOption C`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].text, 'Option A');
+  assert.equal(result[1].text, 'Option B');
+});
+
+test('detects options in markdown list items (- **Option A: ...**)', () => {
+  const content = `Pick one:\n- **Option A: Rewrite**\n- **Option B: Patch**`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].label, 'Option A');
+  assert.equal(result[0].text, 'Option A: Rewrite');
+});
+
+// --- Capital letter + dot pattern ---
+
+test('detects A. / B. / C. options', () => {
+  const content = `A. Rewrite the module\nB. Patch the existing code\nC. Remove it entirely`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].label, 'A');
+  assert.equal(result[0].text, 'A. Rewrite the module');
+  assert.equal(result[2].text, 'C. Remove it entirely');
+});
+
+// --- Parenthesis pattern ---
+
+test('detects a) / b) / c) options', () => {
+  const content = `a) Keep the current approach\nb) Switch to the new API\nc) Hybrid approach`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].label, 'a');
+  assert.equal(result[0].text, 'a) Keep the current approach');
+});
+
+test('detects 1) / 2) / 3) options', () => {
+  const content = `1) Fast but risky\n2) Slow but safe\n3) Somewhere in between`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].text, '1) Fast but risky');
+  assert.equal(result[1].text, '2) Slow but safe');
+});
+
+// --- Minimum count guard ---
+
+test('returns empty array when fewer than 2 options detected', () => {
+  const content = `Option A: The only option`;
+  const result = extractOptions(content);
+  assert.deepEqual(result, []);
+});
+
+test('returns empty array for plain prose with no options', () => {
+  const content = `Here is the summary of your project. Everything looks good.`;
+  const result = extractOptions(content);
+  assert.deepEqual(result, []);
+});
+
+// --- Markdown stripping ---
+
+test('strips bold markers from option titles', () => {
+  const content = `**Option A: **Deploy with Docker****\n**Option B: Use Kubernetes**`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 2);
+  assert.ok(!result[0].text.includes('**'), `expected no ** in: ${result[0].text}`);
+});
+
+test('strips heading markers from option lines', () => {
+  const content = `## Option A: First choice\n## Option B: Second choice`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].label, 'Option A');
+});
+
+// --- Edge cases ---
+
+test('returns empty array for empty string', () => {
+  assert.deepEqual(extractOptions(''), []);
+});
+
+test('returns empty array for null/undefined', () => {
+  assert.deepEqual(extractOptions(null), []);
+  assert.deepEqual(extractOptions(undefined), []);
+});
+
+test('does not treat regular numbered list (1. 2. 3.) as options', () => {
+  const content = `Steps:\n1. Install dependencies\n2. Run the server\n3. Open the browser`;
+  const result = extractOptions(content);
+  // "1." pattern is NOT detected — only "1)" parenthesis and "Option N:" forms are
+  assert.deepEqual(result, []);
+});

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -443,6 +443,32 @@ body {
 }
 .chat-bubble.user .bubble-time { color: rgba(255,255,255,0.7); }
 
+/* Option selector buttons — rendered below assistant messages with detected choices */
+.option-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.625rem;
+}
+
+.option-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: 1.5px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.option-btn:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
 .chat-bubble.waiting {
   border-color: var(--green);
   background: var(--card-pending-bg);


### PR DESCRIPTION
Closes #139

## Summary
- Detects numbered/lettered options in assistant messages using pattern matching (e.g. `Option A: ...`, `Option B: ...`, `A. Title`, `a) Title`, `1) Title`)
- Renders large, easy-to-click buttons below the message bubble when 2+ options are detected
- Clicking a button populates the input with the option label + title and submits it
- Purely client-side — no backend changes

## Patterns detected
| Pattern | Example |
|---------|---------|
| `Option A/B/C: Title` | `Option A: Deploy with Docker` |
| `Option 1/2/3: Title` | `Option 1: Use SQLite` |
| `A. Title` (capital letter) | `A. Rewrite the module` |
| `a) / A) / 1) Title` | `a) Keep the current approach` |
| `Option A` alone | `Option A` |

## Test plan
- [ ] Start a managed session and ask Claude to present options (e.g. "give me 3 options for X")
- [ ] Verify buttons appear below the assistant message
- [ ] Click a button and verify it sends `Option A: Title` into the chat
- [ ] Verify no buttons appear for regular non-option messages
- [ ] Verify hook-mode sessions work the same way (client-side only)