### PR TITLE
fix: ignore Windows claude-controller.exe binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ xcuserdata/
 .env
 .superpowers/
 server/claude-controller
+server/claude-controller.exe
 .playwright-mcp/
 .worktrees/
 shortcuts.json


### PR DESCRIPTION
## Summary
- Adds `server/claude-controller.exe` to `.gitignore` so the compiled Windows binary is not tracked
- The macOS/Linux binary (`server/claude-controller`) was already ignored; this covers the Windows equivalent

## Test plan
- [ ] Verify `git status` shows no untracked `claude-controller.exe` on Windows after building

🤖 Generated with [Claude Code](https://claude.com/claude-code)