### PR TITLE
fix: detect em/en dash option format in option selector

### DIFF
--- a/server/web/static/option-selector.js
+++ b/server/web/static/option-selector.js
@@ -28,8 +28,8 @@ export function extractOptions(content) {
     if (!c) continue;
     let m;
 
-    // "Option A: Title", "Option B - Title", "Option 1. Title" etc.
-    m = c.match(/^option\s+([a-zA-Z]|\d+)\s*[:\-.]\s*(.+)/i);
+    // "Option A: Title", "Option B - Title", "Option A — Title" etc.
+    m = c.match(/^option\s+([a-zA-Z]|\d+)\s*[:\-.—–]\s*(.+)/i);
     if (m) {
       const label = `Option ${m[1].toUpperCase()}`;
       const title = strip(m[2]);
@@ -51,6 +51,15 @@ export function extractOptions(content) {
       const label = m[1];
       const title = strip(m[2]);
       options.push({ label, text: `${label}. ${title}` });
+      continue;
+    }
+
+    // "A — Title" or "A – Title" (capital letter + em/en dash — Claude brainstorm style)
+    m = c.match(/^([A-Z])\s+[—–]\s+(.+)/);
+    if (m) {
+      const label = m[1];
+      const title = strip(m[2]);
+      options.push({ label, text: `${label} — ${title}` });
       continue;
     }
 

--- a/server/web/static/option-selector.test.mjs
+++ b/server/web/static/option-selector.test.mjs
@@ -40,6 +40,35 @@ test('detects options in markdown list items (- **Option A: ...**)', () => {
   assert.equal(result[0].text, 'Option A: Rewrite');
 });
 
+// --- Capital letter + em/en dash pattern (Claude brainstorm style) ---
+
+test('detects A — / B — / C — options (em dash)', () => {
+  const content = `**A — Make enrichIssue() async**\nSome description.\n\n**B — Separate pass after enrichment**\nAnother description.\n\n**C — Fetch in background.js**\nFinal description.`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].label, 'A');
+  assert.equal(result[0].text, 'A — Make enrichIssue() async');
+  assert.equal(result[1].label, 'B');
+  assert.equal(result[2].label, 'C');
+});
+
+test('detects A – / B – options (en dash)', () => {
+  const content = `A – First option\nB – Second option`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].label, 'A');
+  assert.equal(result[0].text, 'A — First option');
+  assert.equal(result[1].label, 'B');
+});
+
+test('detects Option A — Title (em dash with Option prefix)', () => {
+  const content = `Option A — Use SQLite\nOption B — Use PostgreSQL`;
+  const result = extractOptions(content);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].label, 'Option A');
+  assert.equal(result[0].text, 'Option A: Use SQLite');
+});
+
 // --- Capital letter + dot pattern ---
 
 test('detects A. / B. / C. options', () => {


### PR DESCRIPTION
## Summary
- Claude's brainstorm-style output uses `**A — Title**` headings (em dash separator)
- This format wasn't matched by any existing pattern in `option-selector.js`, so no buttons appeared
- Added a new `A — Title` / `A – Title` (em/en dash) pattern
- Also extended the `Option A — Title` separator class to include em/en dashes
- Added 3 new test cases covering all dash variants (17 total, all pass)

## Test Plan
- [x] `node --test option-selector.test.mjs` — 17/17 pass
- [ ] Manually verify option buttons appear for brainstorm-style Claude responses in the web UI