### PR TITLE
fix(ui): move pixel bar to its own row in session header

### DIFF
--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -187,24 +187,25 @@
                       : 'background:var(--border); color:var(--text-muted); cursor:default; opacity:0.5;'">
               Stop
             </button>
-            <template x-if="currentSession?.mode === 'managed' && agentInvocations.length > 0">
-              <div style="display:flex; align-items:center; gap:3px; flex-wrap:wrap; padding-left:4px; border-left:1px solid var(--border);">
-                <template x-for="(inv, i) in agentInvocations" :key="i">
-                  <div @click="agentViewOpen = true"
-                       :title="inv.label + ' · ' + inv.status + (inv.duration ? ' · ' + inv.duration : '')"
-                       class="agent-pixel"
-                       :class="{ 'agent-pixel-running': inv.status === 'running' }"
-                       :style="'background:' + (inv.status === 'running' ? '#f39c12' : '#22c55e')">
-                  </div>
-                </template>
-                <button @click="agentViewOpen = true"
-                        style="margin-left:6px; font-size:11px; color:var(--text-muted); background:none; border:none; cursor:pointer; padding:0; text-decoration:underline; flex-shrink:0;"
-                        x-text="agentInvocations.length + (agentInvocations.length === 1 ? ' tool call' : ' tool calls')">
-                </button>
-              </div>
-            </template>
           </div>
         </div>
+        <!-- Agent View Pixel Bar (managed sessions only) -->
+        <template x-if="currentSession?.mode === 'managed' && agentInvocations.length > 0">
+          <div style="display:flex; align-items:center; gap:3px; flex-wrap:wrap; width:100%; padding-top:6px;">
+            <template x-for="(inv, i) in agentInvocations" :key="i">
+              <div @click="agentViewOpen = true"
+                   :title="inv.label + ' · ' + inv.status + (inv.duration ? ' · ' + inv.duration : '')"
+                   class="agent-pixel"
+                   :class="{ 'agent-pixel-running': inv.status === 'running' }"
+                   :style="'background:' + (inv.status === 'running' ? '#f39c12' : '#22c55e')">
+              </div>
+            </template>
+            <button @click="agentViewOpen = true"
+                    style="margin-left:6px; font-size:11px; color:var(--text-muted); background:none; border:none; cursor:pointer; padding:0; text-decoration:underline; flex-shrink:0;"
+                    x-text="agentInvocations.length + (agentInvocations.length === 1 ? ' tool call' : ' tool calls')">
+            </button>
+          </div>
+        </template>
 
         <div class="main-content-split">
           <div class="chat-column" :class="{ 'has-viewer': viewerFile || selectedIssue || selectedPull }">

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -298,7 +298,7 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 .main-header h2 { font-size: 1rem; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .turns-monitor { display: flex; align-items: center; gap: 8px; margin-left: auto; font-size: 0.8rem; color: var(--text-muted); flex-shrink: 0; white-space: nowrap; }


### PR DESCRIPTION
## Summary
- Restores pixel bar as a full-width second row inside `main-header`, below the title/turns row
- Removes it from inline position next to the Stop button (previous attempt)
- Adds `flex-wrap: wrap` to `.main-header` so the pixel bar wraps naturally to its own row
- Pixel bar remains inside the sticky header — visible on mobile without scrolling

## Test plan
- [ ] In a managed session with tool calls, pixel bar appears on its own row below the session title
- [ ] Pixel bar is visible without scrolling on mobile
- [ ] Turns monitor, Stop button, and session name row are unaffected
- [ ] Pixel bar show/hide behavior and click-to-open-agent-view unchanged