### PR TITLE
feat: make quickstart — one-command setup for non-technical users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 
 SERVER_BIN := server/claude-controller$(EXE)
 
-.PHONY: help build build-windows test run stop open local run-docker run-docker-bg stop-docker logs ngrok hooks clean all
+.PHONY: help quickstart build build-windows test run stop open local run-docker run-docker-bg stop-docker logs ngrok hooks clean all
 
 .DEFAULT_GOAL := help
 
@@ -28,6 +28,61 @@ SERVER_BIN := server/claude-controller$(EXE)
 
 help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+quickstart: ## First-time setup: check Go, install deps, build, and open the app at http://localhost:9999
+ifeq ($(OS),Windows_NT)
+	@where go >NUL 2>&1 || (echo. & echo Go is not installed. & echo Please download and install it from https://go.dev/dl/ then re-run this command. & echo. & exit 1)
+	@echo Go found.
+	@echo.
+	@if not exist .env (copy .env.example .env >NUL & powershell -Command "(Get-Content .env) -replace 'PORT=8080','PORT=9999' | Set-Content .env" & echo Created .env with PORT=9999) else (echo .env already exists, skipping)
+	@echo.
+	@echo Downloading dependencies...
+	cd server && go mod download
+	@echo.
+	@echo Building server...
+	cd server && go build -o claude-controller.exe .
+	@echo.
+	@echo Stopping any existing server...
+	-taskkill /F /IM claude-controller.exe $(DEVNULL)
+	@echo.
+	@echo Starting Claude Controller on http://localhost:9999 ...
+	@echo Press Ctrl+C to stop.
+	@echo.
+	start /B powershell -Command "Start-Sleep 2; Start-Process 'http://localhost:9999'"
+	$(SERVER_BIN) --port 9999
+else
+	@command -v go >/dev/null 2>&1 || { \
+		echo ""; \
+		echo "Go is not installed. Please install it first:"; \
+		echo "  macOS:  brew install go"; \
+		echo "  Or visit https://go.dev/dl/ to download the installer."; \
+		echo ""; \
+		exit 1; \
+	}
+	@echo "✓ Go found: $$(go version)"
+	@echo ""
+	@if [ ! -f .env ]; then \
+		sed 's/PORT=8080/PORT=9999/' .env.example > .env; \
+		echo "✓ Created .env with PORT=9999"; \
+	else \
+		echo "✓ .env already exists, skipping"; \
+	fi
+	@echo ""
+	@echo "==> Downloading dependencies..."
+	@cd server && go mod download
+	@echo ""
+	@echo "==> Building server..."
+	@cd server && go build -o claude-controller .
+	@echo ""
+	@echo "==> Stopping any existing server..."
+	@-pkill -f 'claude-controller' $(DEVNULL) || true
+	@echo ""
+	@echo "==> Starting Claude Controller at http://localhost:9999 ..."
+	@echo "    Press Ctrl+C to stop."
+	@echo ""
+	@(sleep 2 && $(OPEN_CMD) http://localhost:9999) &
+	@$(SERVER_BIN) --port 9999
+endif
 
 ##@ Server
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ Two modes of operation:
 | Hooks | Bash (macOS) + PowerShell (Windows) | `hooks/` |
 | iOS App | Swift / SwiftUI (iOS 17+) | `ios/` |
 
+## New? Start Here
+
+If you're setting up Claude Controller for the first time, one command does everything:
+
+```bash
+make quickstart
+```
+
+This checks for Go, installs dependencies, builds the server, and opens the web UI at **http://localhost:9999** automatically.
+
+See **[docs/getting-started.md](docs/getting-started.md)** for a full walkthrough including prerequisites, troubleshooting, and ngrok setup for remote access.
+
+---
+
 ## Quick Start
 
 ### 1. Start the server

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,194 @@
+# Getting Started with Claude Controller
+
+Claude Controller lets you control Claude Code sessions from any browser — including your phone. This guide walks you through getting it running on your computer in just a few steps.
+
+---
+
+## Prerequisites
+
+You need two things before you start:
+
+1. **Claude Code installed** — Claude Controller works alongside Claude Code. If you don't have it yet, [download Claude Code here](https://claude.ai/download).
+
+2. **Go installed** — Go is the programming language Claude Controller is built with. If you don't have it:
+   - **Mac:** Open Terminal and run `brew install go`
+     - (If you don't have Homebrew, install it first at [brew.sh](https://brew.sh))
+   - **Windows:** Download and run the installer from [go.dev/dl](https://go.dev/dl/)
+   - After installing, close and reopen your terminal before continuing.
+
+That's it. You do not need to know how to code.
+
+---
+
+## Quickstart (Mac and Linux)
+
+### Step 1 — Download Claude Controller
+
+Open **Terminal** (on Mac, press `Cmd + Space`, type "Terminal", hit Enter).
+
+Paste this command and press Enter:
+
+```bash
+git clone https://github.com/jaychinthrajah/claude-controller.git
+cd claude-controller
+```
+
+> **No git?** On Mac, running the command above will prompt you to install it automatically. On Windows, download [Git for Windows](https://git-scm.com/download/win) first.
+
+### Step 2 — Run the quickstart command
+
+Still in the same Terminal window, paste this and press Enter:
+
+```bash
+make quickstart
+```
+
+That's it. This single command will:
+
+- Check that all required tools are installed
+- Set up your configuration file
+- Download all dependencies
+- Build and start the server on port 9999
+- Open Claude Controller in your browser automatically
+
+The first run takes about 30–60 seconds while it downloads and builds everything. Subsequent runs are much faster.
+
+### Step 3 — Install the hooks
+
+In a new Terminal tab (press `Cmd + T`), paste this and press Enter:
+
+```bash
+make hooks
+```
+
+This connects Claude Code to Claude Controller so your sessions appear in the web UI. After running it, restart any Claude Code windows you have open.
+
+### Step 4 — You're done
+
+Claude Controller is now running at **http://localhost:9999**. Open that address in any browser.
+
+To stop the server, press `Ctrl + C` in the Terminal window where it's running.
+
+To start it again next time, just run:
+
+```bash
+make quickstart
+```
+
+---
+
+## Quickstart (Windows)
+
+### Step 1 — Download Claude Controller
+
+Open **PowerShell** (press `Win + X`, choose "Windows PowerShell" or "Terminal").
+
+Paste this and press Enter:
+
+```powershell
+git clone https://github.com/jaychinthrajah/claude-controller.git
+cd claude-controller
+```
+
+### Step 2 — Run the quickstart command
+
+```powershell
+make quickstart
+```
+
+> **Note:** If `make` is not recognized, install it via `winget install GnuWin32.Make` and reopen PowerShell.
+
+### Step 3 — Install the hooks
+
+In a new PowerShell window:
+
+```powershell
+make hooks
+```
+
+Restart any Claude Code windows after this step.
+
+### Step 4 — You're done
+
+Claude Controller is running at **http://localhost:9999**. Open it in any browser.
+
+---
+
+## Troubleshooting
+
+**"command not found: go"**
+Go is not installed or not on your PATH. Quit and reopen your terminal after installing Go, then try again.
+
+**"Port 9999 already in use"**
+Another program is using that port. Stop it, or run `make stop` then `make quickstart` again.
+
+**The browser opened but shows an error**
+The server may still be starting. Wait 5 seconds and refresh the page.
+
+**Claude sessions aren't showing up**
+Make sure you ran `make hooks` and restarted Claude Code afterward.
+
+---
+
+## Setting Up ngrok (Remote Access)
+
+By default, Claude Controller only runs on your local computer. If you want to access it from your phone, another computer, or from anywhere in the world, you can use **ngrok** to create a secure public link.
+
+### What is ngrok?
+
+ngrok is a free tool that creates a temporary public web address for your computer. When you share that address with your phone, it connects securely back to Claude Controller running on your Mac or PC — no complicated network setup required.
+
+### Step 1 — Create a free ngrok account
+
+Go to [ngrok.com](https://ngrok.com) and sign up for a free account.
+
+### Step 2 — Download and install ngrok
+
+After signing up, ngrok will show you a download page with instructions for your operating system. Follow those steps.
+
+- **Mac (recommended):** `brew install ngrok/ngrok/ngrok`
+- **Windows:** Download the installer from [ngrok.com/download](https://ngrok.com/download) and run it.
+
+### Step 3 — Connect your account
+
+In your ngrok dashboard, find your **authtoken** — it's a long string of letters and numbers on the "Your Authtoken" page.
+
+Run this command, replacing `YOUR_TOKEN` with your actual token:
+
+```bash
+ngrok config add-authtoken YOUR_TOKEN
+```
+
+You only need to do this once.
+
+### Step 4 — Start ngrok
+
+With Claude Controller already running (`make quickstart`), open a second Terminal window and run:
+
+```bash
+make ngrok
+```
+
+ngrok will display a public URL that looks something like:
+
+```
+Forwarding   https://abc123.ngrok-free.app -> http://localhost:9999
+```
+
+### Step 5 — Access Claude Controller remotely
+
+Open that `https://abc123.ngrok-free.app` URL on your phone or any other device. It connects directly to your Claude Controller.
+
+> **Security note:** Anyone with this URL can access your Claude Controller. Keep it private. ngrok free accounts generate a new URL each time you start it. Stop ngrok (Ctrl+C) when you're not using remote access.
+
+### Tip: Using the iOS app
+
+If you have the Claude Controller iOS app, scan the QR code that appears in the Terminal when Claude Controller starts. The QR code contains everything the app needs to connect — including the ngrok URL.
+
+---
+
+## What's Next?
+
+- **Hook mode** — Claude Code sessions you run in your terminal appear in the web UI automatically (after `make hooks`)
+- **Managed mode** — Start new Claude sessions directly from the browser, with full control over tools, turn limits, and more
+- **iOS app** — Pair the iPhone app to manage sessions from anywhere


### PR DESCRIPTION
Closes #65

## Summary

- Adds **`make quickstart`** — a single command that gets Claude Controller running for anyone, regardless of technical background:
  - Checks Go is installed (prints clear install instructions if not)
  - Copies `.env.example` to `.env` with PORT=9999 on first run (idempotent)
  - Downloads Go module dependencies
  - Builds the server binary
  - Stops any existing server process
  - Starts the server on port 9999
  - Opens http://localhost:9999 in the default browser automatically
  - Works on macOS, Linux, and Windows

- Adds **`docs/getting-started.md`** written for non-technical users:
  - Prerequisites section (Claude Code + Go, with plain-English install instructions)
  - Step-by-step quickstart for Mac/Linux and Windows
  - Troubleshooting section for common errors
  - Full section on downloading, installing, and configuring ngrok for remote access

## Test plan

- [ ] Run `make quickstart` on a fresh clone (macOS) — verify .env is created, deps download, server starts, browser opens at http://localhost:9999
- [ ] Run `make quickstart` a second time — verify it does not error (idempotency)
- [ ] Remove Go from PATH and run `make quickstart` — verify clear error message with install instructions
- [ ] Read through `docs/getting-started.md` as a non-technical user — check all steps are clear and complete