### PR TITLE
feat: multi-image upload (up to 7 images per message)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-multi-image-upload.md
+++ b/docs/superpowers/plans/2026-05-17-multi-image-upload.md
@@ -1,0 +1,778 @@
+# Multi-Image Upload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to attach up to 7 images per message in a managed Claude session, uploading each to the existing `/upload` endpoint and sending all image IDs together in a single `claude -p` turn.
+
+**Architecture:** Sequential per-file uploads to the existing `/upload` endpoint accumulate into a `pendingImages` array on the frontend. On send, all IDs are passed as `image_ids []string` to the message handler, which loads each file from disk and builds a multi-image content block array for the Claude turn. The backend removes the one-at-a-time upload constraint and the `formatUserTurnWithImage` function is replaced by `formatUserTurnWithImages` accepting a slice.
+
+**Tech Stack:** Go 1.22, Alpine.js (CDN), vanilla HTML/CSS; no new dependencies.
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `server/api/upload.go` | Add `imageData` struct; rename `formatUserTurnWithImage` → `formatUserTurnWithImages` accepting `[]imageData`; remove one-at-a-time dir cleanup (lines 87–93) |
+| `server/api/upload_test.go` | Update existing format tests to use new function; add multi-image format test; add multi-upload accumulation test |
+| `server/api/managed_sessions.go` | `ImageID string` → `ImageIDs []string`; replace single-image load with loop; update `displayMsg` and turn-send code |
+| `server/web/static/app.js` | Replace scalar pending-image state with `pendingImages []`; rewrite `uploadImage()`; add `removePendingImage(index)`; rename `clearPendingImage()` → `clearPendingImages()`; update `sendManagedMessage()`; update `bubbleHTML()` |
+| `server/web/static/index.html` | Add `multiple` to file input; replace single-thumbnail preview div with multi-thumbnail strip; update send button disabled binding |
+
+---
+
+### Task 1: Add `imageData` type and `formatUserTurnWithImages` (TDD)
+
+**Files:**
+- Modify: `server/api/upload.go`
+- Modify: `server/api/upload_test.go`
+
+- [ ] **Step 1: Write failing tests for the new function**
+
+In `server/api/upload_test.go`, replace `TestFormatUserTurnWithImage` and `TestFormatUserTurnImageOnly` and add `TestFormatUserTurnWithMultipleImages`:
+
+```go
+func TestFormatUserTurnWithImages_SingleWithText(t *testing.T) {
+	images := []imageData{{base64: "abc123", mediaType: "image/png"}}
+	result := formatUserTurnWithImages("describe this", images)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed["type"] != "user" {
+		t.Errorf("type=%v, want user", parsed["type"])
+	}
+	msg := parsed["message"].(map[string]interface{})
+	content := msg["content"].([]interface{})
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(content))
+	}
+	imgBlock := content[0].(map[string]interface{})
+	if imgBlock["type"] != "image" {
+		t.Errorf("first block type=%v, want image", imgBlock["type"])
+	}
+	source := imgBlock["source"].(map[string]interface{})
+	if source["media_type"] != "image/png" {
+		t.Errorf("media_type=%v, want image/png", source["media_type"])
+	}
+	textBlock := content[1].(map[string]interface{})
+	if textBlock["type"] != "text" || textBlock["text"] != "describe this" {
+		t.Errorf("unexpected text block: %v", textBlock)
+	}
+}
+
+func TestFormatUserTurnWithImages_ImageOnly(t *testing.T) {
+	images := []imageData{{base64: "abc123", mediaType: "image/png"}}
+	result := formatUserTurnWithImages("", images)
+
+	var parsed map[string]interface{}
+	json.Unmarshal([]byte(result), &parsed)
+	msg := parsed["message"].(map[string]interface{})
+	content := msg["content"].([]interface{})
+	if len(content) != 1 {
+		t.Fatalf("expected 1 content block (image only), got %d", len(content))
+	}
+	if content[0].(map[string]interface{})["type"] != "image" {
+		t.Error("expected image block")
+	}
+}
+
+func TestFormatUserTurnWithImages_MultipleImages(t *testing.T) {
+	images := []imageData{
+		{base64: "data1", mediaType: "image/png"},
+		{base64: "data2", mediaType: "image/jpeg"},
+	}
+	result := formatUserTurnWithImages("compare these", images)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	msg := parsed["message"].(map[string]interface{})
+	content := msg["content"].([]interface{})
+	// 2 image blocks + 1 text block
+	if len(content) != 3 {
+		t.Fatalf("expected 3 content blocks, got %d", len(content))
+	}
+	if content[0].(map[string]interface{})["type"] != "image" {
+		t.Errorf("block 0 should be image")
+	}
+	if content[1].(map[string]interface{})["type"] != "image" {
+		t.Errorf("block 1 should be image")
+	}
+	src0 := content[0].(map[string]interface{})["source"].(map[string]interface{})
+	if src0["media_type"] != "image/png" {
+		t.Errorf("block 0 media_type=%v, want image/png", src0["media_type"])
+	}
+	src1 := content[1].(map[string]interface{})["source"].(map[string]interface{})
+	if src1["media_type"] != "image/jpeg" {
+		t.Errorf("block 1 media_type=%v, want image/jpeg", src1["media_type"])
+	}
+	textBlock := content[2].(map[string]interface{})
+	if textBlock["type"] != "text" || textBlock["text"] != "compare these" {
+		t.Errorf("unexpected text block: %v", textBlock)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd server && go test ./api/ -v -run "TestFormatUserTurnWithImages"
+```
+
+Expected: compile error — `imageData` undefined and `formatUserTurnWithImages` undefined.
+
+- [ ] **Step 3: Add `imageData` type and `formatUserTurnWithImages` to `upload.go`**
+
+In `server/api/upload.go`, add after the `extensionToMIME` map (after line 30):
+
+```go
+// imageData holds base64-encoded image bytes and its MIME type.
+type imageData struct {
+	base64    string
+	mediaType string
+}
+```
+
+Then replace the existing `formatUserTurnWithImage` function (lines 174–204) with:
+
+```go
+// formatUserTurnWithImages builds a stream-json user turn with one image content
+// block per entry in images, followed by an optional text block.
+func formatUserTurnWithImages(message string, images []imageData) string {
+	var content []interface{}
+	for _, img := range images {
+		content = append(content, map[string]interface{}{
+			"type": "image",
+			"source": map[string]string{
+				"type":       "base64",
+				"media_type": img.mediaType,
+				"data":       img.base64,
+			},
+		})
+	}
+	if message != "" {
+		content = append(content, map[string]string{
+			"type": "text",
+			"text": message,
+		})
+	}
+	turn := map[string]interface{}{
+		"type": "user",
+		"message": map[string]interface{}{
+			"role":    "user",
+			"content": content,
+		},
+	}
+	b, _ := json.Marshal(turn)
+	return string(b)
+}
+```
+
+Keep `formatImageUploadMessage` unchanged. Delete the old `formatUserTurnWithImage` function entirely.
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd server && go test ./api/ -v -run "TestFormatUserTurnWithImages"
+```
+
+Expected: all three `TestFormatUserTurnWithImages_*` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd server && git add api/upload.go api/upload_test.go
+git commit -m "feat(api): add imageData type and formatUserTurnWithImages for multi-image support"
+```
+
+---
+
+### Task 2: Remove one-at-a-time upload constraint (TDD)
+
+**Files:**
+- Modify: `server/api/upload.go`
+- Modify: `server/api/upload_test.go`
+
+- [ ] **Step 1: Write failing test for multi-upload accumulation**
+
+In `server/api/upload_test.go`, add:
+
+```go
+func TestUploadMultipleImagesAccumulate(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	cwd := t.TempDir()
+	body := `{"cwd": "` + cwd + `"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/create", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	var sess map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&sess)
+	resp.Body.Close()
+	sessID := sess["id"].(string)
+
+	uploadOnePNG := func() string {
+		pngData := createTestPNG()
+		multiBody, contentType := createMultipartBody("test.png", pngData)
+		uploadReq, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sessID+"/upload", multiBody)
+		uploadReq.Header.Set("Authorization", "Bearer test-api-key")
+		uploadReq.Header.Set("Content-Type", contentType)
+		uploadResp, err := http.DefaultClient.Do(uploadReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer uploadResp.Body.Close()
+		if uploadResp.StatusCode != 200 {
+			t.Fatalf("upload status=%d, want 200", uploadResp.StatusCode)
+		}
+		var result map[string]interface{}
+		json.NewDecoder(uploadResp.Body).Decode(&result)
+		return result["image_id"].(string)
+	}
+
+	id1 := uploadOnePNG()
+	id2 := uploadOnePNG()
+
+	// Both files should exist on disk
+	dir := filepath.Join(cwd, ".claude-controller-uploads", sessID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read upload dir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 files in upload dir, got %d", len(entries))
+	}
+
+	// Both IDs should be findable
+	path1, _ := findUploadedImage(cwd, sessID, id1)
+	if path1 == "" {
+		t.Error("image 1 not found after second upload")
+	}
+	path2, _ := findUploadedImage(cwd, sessID, id2)
+	if path2 == "" {
+		t.Error("image 2 not found after second upload")
+	}
+}
+```
+
+- [ ] **Step 2: Run test — confirm it fails**
+
+```bash
+cd server && go test ./api/ -v -run "TestUploadMultipleImagesAccumulate"
+```
+
+Expected: FAIL — second upload deletes the first file, so `len(entries)` is 1, not 2.
+
+- [ ] **Step 3: Remove one-at-a-time cleanup from `handleUploadImage`**
+
+In `server/api/upload.go`, delete lines 87–93 (the comment and loop that removes existing files):
+
+```go
+// Delete these 7 lines:
+	// Remove any existing files in the dir (one image at a time).
+	existing, _ := os.ReadDir(dir)
+	for _, entry := range existing {
+		if !entry.IsDir() {
+			os.Remove(filepath.Join(dir, entry.Name()))
+		}
+	}
+```
+
+The `MkdirAll` call on line 82 stays; the UUID assignment on line 96 stays.
+
+- [ ] **Step 4: Run all upload tests — confirm everything passes**
+
+```bash
+cd server && go test ./api/ -v -run "TestUpload"
+```
+
+Expected: all `TestUpload*` tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd server && git add api/upload.go api/upload_test.go
+git commit -m "feat(api): allow multiple images to accumulate in session upload dir"
+```
+
+---
+
+### Task 3: Update message handler to accept `image_ids []string`
+
+**Files:**
+- Modify: `server/api/managed_sessions.go`
+
+- [ ] **Step 1: Update the request struct**
+
+In `server/api/managed_sessions.go` around line 145, change:
+
+```go
+// Before
+var req struct {
+    Message string `json:"message"`
+    ImageID string `json:"image_id"`
+    Model   string `json:"model"`
+}
+```
+
+To:
+
+```go
+// After
+var req struct {
+    Message  string   `json:"message"`
+    ImageIDs []string `json:"image_ids"`
+    Model    string   `json:"model"`
+}
+```
+
+- [ ] **Step 2: Update the empty-body validation**
+
+Change line 154:
+
+```go
+// Before
+if req.Message == "" && req.ImageID == "" {
+    http.Error(w, "message or image_id is required", http.StatusBadRequest)
+    return
+}
+
+// After
+if req.Message == "" && len(req.ImageIDs) == 0 {
+    http.Error(w, "message or image_ids is required", http.StatusBadRequest)
+    return
+}
+```
+
+- [ ] **Step 3: Replace single-image load with multi-image loop**
+
+Replace lines 187–201 (the `// Load uploaded image if provided` block):
+
+```go
+// Before
+var imageBase64, imageMediaType string
+if req.ImageID != "" {
+    imgPath, mediaType := findUploadedImage(sess.CWD, sessionID, req.ImageID)
+    if imgPath != "" {
+        imgData, readErr := os.ReadFile(imgPath)
+        if readErr == nil {
+            imageBase64 = base64.StdEncoding.EncodeToString(imgData)
+            imageMediaType = mediaType
+        } else {
+            log.Printf("session %s: failed to read image %s: %v", sessionID, req.ImageID, readErr)
+        }
+    } else {
+        log.Printf("session %s: uploaded image %s not found", sessionID, req.ImageID)
+    }
+}
+```
+
+With:
+
+```go
+// After
+var images []imageData
+for _, id := range req.ImageIDs {
+    imgPath, mediaType := findUploadedImage(sess.CWD, sessionID, id)
+    if imgPath == "" {
+        log.Printf("session %s: uploaded image %s not found", sessionID, id)
+        continue
+    }
+    imgBytes, readErr := os.ReadFile(imgPath)
+    if readErr != nil {
+        log.Printf("session %s: failed to read image %s: %v", sessionID, id, readErr)
+        continue
+    }
+    images = append(images, imageData{
+        base64:    base64.StdEncoding.EncodeToString(imgBytes),
+        mediaType: mediaType,
+    })
+}
+```
+
+- [ ] **Step 4: Update `displayMsg` assignment**
+
+Replace lines 204–207:
+
+```go
+// Before
+displayMsg := req.Message
+if imageBase64 != "" {
+    displayMsg = formatImageUploadMessage(req.Message, req.ImageID)
+}
+```
+
+With:
+
+```go
+// After
+displayMsg := req.Message
+if len(images) > 0 {
+    label := fmt.Sprintf("%d image", len(images))
+    if len(images) > 1 {
+        label += "s"
+    }
+    displayMsg = formatImageUploadMessage(req.Message, label)
+}
+```
+
+- [ ] **Step 5: Update the turn-send code inside the goroutine**
+
+Replace lines 344–350 (inside the `for` loop in the goroutine):
+
+```go
+// Before
+var userTurn string
+if imageBase64 != "" {
+    userTurn = formatUserTurnWithImage(currentMessage, imageBase64, imageMediaType)
+    imageBase64 = "" // Only include image on the first turn, not auto-continues
+} else {
+    userTurn = formatUserTurn(currentMessage)
+}
+```
+
+With:
+
+```go
+// After
+var userTurn string
+if len(images) > 0 {
+    userTurn = formatUserTurnWithImages(currentMessage, images)
+    images = nil // Only include images on the first turn, not auto-continues
+} else {
+    userTurn = formatUserTurn(currentMessage)
+}
+```
+
+- [ ] **Step 6: Build to confirm no compile errors**
+
+```bash
+cd server && go build ./...
+```
+
+Expected: exits 0, no errors.
+
+- [ ] **Step 7: Run all API tests**
+
+```bash
+cd server && go test ./api/ -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd server && git add api/managed_sessions.go
+git commit -m "feat(api): accept image_ids []string in message handler for multi-image turns"
+```
+
+---
+
+### Task 4: Update frontend state, upload handler, and send logic in `app.js`
+
+**Files:**
+- Modify: `server/web/static/app.js`
+
+- [ ] **Step 1: Replace scalar pending-image state with array**
+
+Find lines 159–163 (the image upload state comment block):
+
+```js
+// Image upload state
+pendingImageId: null,
+pendingImagePreview: null,
+pendingImageFilename: null,
+imageUploading: false,
+```
+
+Replace with:
+
+```js
+// Image upload state
+pendingImages: [],   // [{id, preview, filename}]
+imageUploading: false,
+```
+
+- [ ] **Step 2: Rewrite `uploadImage()`**
+
+Find the `uploadImage(event)` method (around line 1663) and replace the entire function body:
+
+```js
+async uploadImage(event) {
+    const files = Array.from(event.target.files || []);
+    if (!files.length || !this.selectedSessionId) return;
+
+    if (this.pendingImages.length + files.length > 7) {
+        this.toast('Maximum 7 images per message');
+        event.target.value = '';
+        return;
+    }
+
+    this.imageUploading = true;
+    for (const file of files) {
+        if (!file.type.startsWith('image/')) {
+            this.toast(`${file.name}: not an image, skipped`);
+            continue;
+        }
+        if (file.size > 20 * 1024 * 1024) {
+            this.toast(`${file.name}: must be under 20MB, skipped`);
+            continue;
+        }
+        try {
+            const formData = new FormData();
+            formData.append('image', file);
+            const res = await fetch(`/api/sessions/${this.selectedSessionId}/upload`, {
+                method: 'POST',
+                headers: { 'Authorization': 'Bearer ' + this.apiKey },
+                body: formData
+            });
+            if (!res.ok) throw new Error(await res.text());
+            const data = await res.json();
+            const preview = await new Promise(resolve => {
+                const reader = new FileReader();
+                reader.onload = (e) => resolve(e.target.result);
+                reader.readAsDataURL(file);
+            });
+            this.pendingImages.push({ id: data.image_id, preview, filename: data.filename });
+        } catch (e) {
+            this.toast('Upload failed: ' + e.message);
+        }
+    }
+    this.imageUploading = false;
+    event.target.value = '';
+},
+```
+
+- [ ] **Step 3: Replace `clearPendingImage()` with `clearPendingImages()` and add `removePendingImage()`**
+
+Find the `clearPendingImage()` method (around line 1704) and replace it with two methods:
+
+```js
+clearPendingImages() {
+    this.pendingImages = [];
+},
+
+removePendingImage(index) {
+    this.pendingImages.splice(index, 1);
+},
+```
+
+- [ ] **Step 4: Update `sendManagedMessage()`**
+
+Around line 1711, find the guard:
+
+```js
+if ((!this.inputText.trim() && !this.pendingImageId) || !this.selectedSessionId) return;
+```
+
+Change to:
+
+```js
+if ((!this.inputText.trim() && !this.pendingImages.length) || !this.selectedSessionId) return;
+```
+
+Around lines 1718–1725, replace the snapshot and clear block:
+
+```js
+// Before
+const imageId = this.pendingImageId;
+const imagePreview = this.pendingImagePreview;
+const imageFilename = this.pendingImageFilename;
+this.clearPendingImage();
+
+try {
+    const body = { message: msg, model: this.selectedModel };
+    if (imageId) body.image_id = imageId;
+```
+
+With:
+
+```js
+// After
+const images = [...this.pendingImages];
+this.clearPendingImages();
+
+try {
+    const body = { message: msg, model: this.selectedModel };
+    if (images.length) body.image_ids = images.map(img => img.id);
+```
+
+Around lines 1735–1739, replace the optimistic message construction:
+
+```js
+// Before
+const userMsg = { role: 'user', content: msg || `[Screenshot: ${imageFilename}]`, msg_type: 'text', timestamp: new Date().toISOString() };
+if (imagePreview) {
+    userMsg.imagePreview = imagePreview;
+    userMsg.imageFilename = imageFilename;
+}
+```
+
+With:
+
+```js
+// After
+const label = images.length === 1 ? `[Screenshot: ${images[0].filename}]` : `[${images.length} images]`;
+const userMsg = { role: 'user', content: msg || label, msg_type: 'text', timestamp: new Date().toISOString() };
+if (images.length) {
+    userMsg.images = images.map(img => ({ preview: img.preview, filename: img.filename }));
+}
+```
+
+- [ ] **Step 5: Update `bubbleHTML()` to render multi-image thumbnails**
+
+Around line 3012, replace the single-image preview block:
+
+```js
+// Before
+let imgHtml = '';
+if (msg.imagePreview) {
+    imgHtml = `<img src="${msg.imagePreview}" style="max-width:200px;max-height:150px;border-radius:6px;margin-bottom:4px;cursor:pointer;display:block" onclick="window.open(this.src,'_blank')">`;
+}
+```
+
+With:
+
+```js
+// After
+let imgHtml = '';
+if (msg.images && msg.images.length) {
+    imgHtml = msg.images.map(img =>
+        `<img src="${img.preview}" style="max-width:200px;max-height:150px;border-radius:6px;margin-bottom:4px;margin-right:4px;cursor:pointer;display:inline-block" onclick="window.open(this.src,'_blank')" title="${esc(img.filename)}">`
+    ).join('');
+} else if (msg.imagePreview) {
+    // backward compat: messages sent before this change
+    imgHtml = `<img src="${msg.imagePreview}" style="max-width:200px;max-height:150px;border-radius:6px;margin-bottom:4px;cursor:pointer;display:block" onclick="window.open(this.src,'_blank')">`;
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/web/static/app.js
+git commit -m "feat(ui): update pending-image state to array for multi-image upload"
+```
+
+---
+
+### Task 5: Update HTML — file input and preview strip
+
+**Files:**
+- Modify: `server/web/static/index.html`
+
+- [ ] **Step 1: Add `multiple` to the file input**
+
+Find line 321–322:
+
+```html
+<input type="file" x-ref="imageInput" accept="image/*"
+       @change="uploadImage($event)" style="display:none">
+```
+
+Change to:
+
+```html
+<input type="file" x-ref="imageInput" accept="image/*" multiple
+       @change="uploadImage($event)" style="display:none">
+```
+
+- [ ] **Step 2: Replace single-thumbnail preview strip**
+
+Find lines 340–345:
+
+```html
+<!-- Image preview -->
+<div class="image-preview-strip" x-show="pendingImagePreview" x-cloak>
+    <img :src="pendingImagePreview" class="image-preview-thumb">
+    <span class="image-preview-name" x-text="pendingImageFilename"></span>
+    <button class="image-preview-remove" @click="clearPendingImage()" title="Remove image">&times;</button>
+</div>
+```
+
+Replace with:
+
+```html
+<!-- Multi-image preview strip -->
+<div class="image-preview-strip" x-show="pendingImages.length > 0" x-cloak style="display:flex;flex-wrap:wrap;gap:6px;padding:6px 0">
+    <template x-for="(img, idx) in pendingImages" :key="idx">
+        <div class="image-preview-item" style="position:relative;display:inline-flex;flex-direction:column;align-items:center;gap:2px">
+            <img :src="img.preview" class="image-preview-thumb">
+            <span class="image-preview-name" x-text="img.filename"></span>
+            <button class="image-preview-remove" @click="removePendingImage(idx)" title="Remove image">&times;</button>
+        </div>
+    </template>
+</div>
+```
+
+- [ ] **Step 3: Update send button disabled binding**
+
+Find line 355:
+
+```html
+<button class="btn btn-primary btn-sm" :disabled="(!inputText.trim() && !pendingImageId) || inputSending"
+```
+
+Change to:
+
+```html
+<button class="btn btn-primary btn-sm" :disabled="(!inputText.trim() && !pendingImages.length) || inputSending"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/web/static/index.html
+git commit -m "feat(ui): multi-thumbnail preview strip with per-image remove buttons"
+```
+
+---
+
+### Task 6: Build and smoke-test
+
+- [ ] **Step 1: Build the Go server**
+
+```bash
+cd server && go build -o claude-controller .
+```
+
+Expected: exits 0, binary created.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+cd server && go test ./... -v
+```
+
+Expected: all tests PASS, zero failures.
+
+- [ ] **Step 3: Search for any remaining references to old single-image identifiers**
+
+```bash
+grep -rn "pendingImageId\|pendingImagePreview\|pendingImageFilename\|clearPendingImage()\|image_id\b" server/web/static/
+```
+
+Expected: zero hits (the only `image_id` remaining should be inside the `uploadImage` response parse: `data.image_id`).
+
+- [ ] **Step 4: Commit build artifact cleanup (delete binary)**
+
+```bash
+rm server/claude-controller
+git status
+```
+
+Expected: working tree clean after binary removal (binary should be gitignored; if not, add it).
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -p  # stage only if anything remains
+git commit -m "chore: verify multi-image upload build and tests pass"
+```

--- a/docs/superpowers/specs/2026-05-17-multi-image-upload-design.md
+++ b/docs/superpowers/specs/2026-05-17-multi-image-upload-design.md
@@ -1,0 +1,169 @@
+# Multi-Image Upload Design
+
+**Date:** 2026-05-17
+**Status:** Approved
+**Approach:** Sequential uploads, array state
+
+## Overview
+
+Extend the managed-session message input to support up to 7 images per message. Each image is uploaded individually to the existing `/upload` endpoint, held in a `pendingImages` array, and sent together in a single `claude -p` turn via an updated `image_ids` payload field.
+
+## Architecture
+
+### Frontend (`server/web/static/`)
+
+**State change — `app.js`**
+
+Replace the three scalar pending-image fields with a single array:
+
+```js
+// Remove
+pendingImageId: null,
+pendingImagePreview: null,
+pendingImageFilename: null,
+
+// Add
+pendingImages: [],  // [{id, preview, filename}]
+// imageUploading: false — unchanged
+```
+
+**Upload handler — `uploadImage(event)`**
+
+- File input gains `multiple` attribute
+- Handler loops over `event.target.files`
+- Before uploading, checks `pendingImages.length + newFiles.length > 7`; if exceeded, toasts "Maximum 7 images per message" and aborts
+- Each file is validated (type must be `image/*`, size must be under 20 MB) then uploaded sequentially to the existing `POST /api/sessions/{id}/upload` endpoint
+- On success, appends `{id, preview, filename}` to `pendingImages`
+- On per-file failure, toasts the error and continues with remaining files
+- `imageUploading` is set `true` for the whole batch and `false` when the loop finishes
+
+**Guard in `sendManagedMessage`**
+
+```js
+// Before
+if ((!this.inputText.trim() && !this.pendingImageId) || ...)
+
+// After
+if ((!this.inputText.trim() && !this.pendingImages.length) || ...)
+```
+
+**Send payload**
+
+```js
+const body = { message: msg, model: this.selectedModel };
+if (this.pendingImages.length) {
+  body.image_ids = this.pendingImages.map(img => img.id);
+}
+```
+
+**Optimistic chat message**
+
+The user message pushed to `chatMessages` gets an `images` array (one entry per attached image with `{preview, filename}`) so all thumbnails render inline, consistent with current single-image behavior.
+
+**Clear helper**
+
+`clearPendingImage()` renamed to `clearPendingImages()`, resets `pendingImages` to `[]`.
+
+### UI — `index.html`
+
+- File input: add `multiple` attribute
+- Preview strip: replace single-image preview div with a horizontally scrolling strip that renders one thumbnail per `pendingImages` entry
+- Each thumbnail has a filename label and an ✕ button calling `removePendingImage(index)`
+- Strip shows when `pendingImages.length > 0`
+- Send button disabled when `!inputText.trim() && !pendingImages.length`
+
+### Backend (`server/api/`)
+
+**`upload.go` — remove one-at-a-time constraint**
+
+Lines 87–89 currently delete all existing files in the session upload dir before saving a new one. Remove this cleanup block. Files now accumulate per session until the message is sent or the session is deleted. Cleanup-on-delete is unchanged.
+
+**`managed_sessions.go` — widen request struct**
+
+```go
+// Before
+ImageID string `json:"image_id"`
+
+// After
+ImageIDs []string `json:"image_ids"`
+```
+
+Validation: `req.Message == "" && len(req.ImageIDs) == 0` → 400.
+
+Image loading loop:
+
+```go
+var images []imageData
+for _, id := range req.ImageIDs {
+    imgPath, mediaType := findUploadedImage(sess.CWD, sessionID, id)
+    if imgPath == "" {
+        log.Printf("session %s: uploaded image %s not found", sessionID, id)
+        continue
+    }
+    imgData, err := os.ReadFile(imgPath)
+    if err != nil {
+        log.Printf("session %s: failed to read image %s: %v", sessionID, id, err)
+        continue
+    }
+    images = append(images, imageData{
+        base64:    base64.StdEncoding.EncodeToString(imgData),
+        mediaType: mediaType,
+    })
+}
+```
+
+**`upload.go` — update `formatUserTurnWithImage`**
+
+Rename to `formatUserTurnWithImages(message string, images []imageData) string`. Emits one image content block per entry, followed by a text block (omitted if message is empty). Single-image behavior is preserved when `len(images) == 1`.
+
+## Data Flow
+
+```
+User selects files
+  → uploadImage() loops files
+  → POST /upload (one per file)
+  → append to pendingImages[]
+  → preview strip renders thumbnails
+
+User clicks Send
+  → snapshot pendingImages, clear state
+  → POST /message { message, image_ids: [...] }
+  → backend loads each image from disk
+  → formatUserTurnWithImages() builds content blocks
+  → passed to claude -p as user turn
+  → optimistic chat message with all thumbnails appended
+```
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| File not image type | Toast, skip that file, continue |
+| File > 20 MB | Toast, skip that file, continue |
+| > 7 images selected | Toast "Maximum 7 images per message", abort entire selection |
+| Upload request fails | Toast error, skip that image, continue |
+| Image missing on send | Log warning server-side, skip that image, proceed with remaining |
+
+## Constraints
+
+- Max 7 images per message (client-side enforcement)
+- Max 20 MB per image (unchanged from current)
+- Allowed types: png, jpg, gif, webp (unchanged)
+- Upload-on-send order: images appear in content blocks in the order they were uploaded
+- `imageUploading` flag disables the attach button for the duration of the batch upload
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `server/web/static/app.js` | State array, upload loop, send payload, clear helper |
+| `server/web/static/index.html` | `multiple` on input, multi-thumbnail preview strip |
+| `server/api/upload.go` | Remove one-at-a-time cleanup; rename/update `formatUserTurnWithImages` |
+| `server/api/managed_sessions.go` | `ImageIDs []string`, image loading loop |
+
+## Out of Scope
+
+- Hook-mode sessions (upload already returns 400 for hook mode; unchanged)
+- iOS app (separate client; not modified)
+- Drag-and-drop image attachment
+- Reordering images before send

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -343,7 +343,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			// Send the user message via stdin
 			var userTurn string
 			if imageBase64 != "" {
-				userTurn = formatUserTurnWithImage(currentMessage, imageBase64, imageMediaType)
+				userTurn = formatUserTurnWithImages(currentMessage, []imageData{{base64: imageBase64, mediaType: imageMediaType}})
 				imageBase64 = "" // Only include image on the first turn, not auto-continues
 			} else {
 				userTurn = formatUserTurn(currentMessage)

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -143,16 +143,16 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
 
 	var req struct {
-		Message string `json:"message"`
-		ImageID string `json:"image_id"`
-		Model   string `json:"model"`
+		Message  string   `json:"message"`
+		ImageIDs []string `json:"image_ids"`
+		Model    string   `json:"model"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
 		return
 	}
-	if req.Message == "" && req.ImageID == "" {
-		http.Error(w, "message or image_id is required", http.StatusBadRequest)
+	if req.Message == "" && len(req.ImageIDs) == 0 {
+		http.Error(w, "message or image_ids is required", http.StatusBadRequest)
 		return
 	}
 
@@ -184,26 +184,31 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 		_ = s.store.UpdateActivityState(sessionID, "waiting")
 	}
 
-	// Load uploaded image if provided
-	var imageBase64, imageMediaType string
-	if req.ImageID != "" {
-		imgPath, mediaType := findUploadedImage(sess.CWD, sessionID, req.ImageID)
-		if imgPath != "" {
-			imgData, readErr := os.ReadFile(imgPath)
-			if readErr == nil {
-				imageBase64 = base64.StdEncoding.EncodeToString(imgData)
-				imageMediaType = mediaType
-			} else {
-				log.Printf("session %s: failed to read image %s: %v", sessionID, req.ImageID, readErr)
-			}
-		} else {
-			log.Printf("session %s: uploaded image %s not found", sessionID, req.ImageID)
+	var images []imageData
+	for _, id := range req.ImageIDs {
+		imgPath, mediaType := findUploadedImage(sess.CWD, sessionID, id)
+		if imgPath == "" {
+			log.Printf("session %s: uploaded image %s not found", sessionID, id)
+			continue
 		}
+		imgBytes, readErr := os.ReadFile(imgPath)
+		if readErr != nil {
+			log.Printf("session %s: failed to read image %s: %v", sessionID, id, readErr)
+			continue
+		}
+		images = append(images, imageData{
+			base64:    base64.StdEncoding.EncodeToString(imgBytes),
+			mediaType: mediaType,
+		})
 	}
 
 	displayMsg := req.Message
-	if imageBase64 != "" {
-		displayMsg = formatImageUploadMessage(req.Message, req.ImageID)
+	if len(images) > 0 {
+		label := fmt.Sprintf("%d image", len(images))
+		if len(images) > 1 {
+			label += "s"
+		}
+		displayMsg = formatImageUploadMessage(req.Message, label)
 	}
 	_, _ = s.store.CreateMessage(sessionID, "user", displayMsg)
 	_ = s.store.Heartbeat(sessionID) // Update last_seen_at so sidebar highlights recently active sessions
@@ -342,9 +347,9 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 			// Send the user message via stdin
 			var userTurn string
-			if imageBase64 != "" {
-				userTurn = formatUserTurnWithImages(currentMessage, []imageData{{base64: imageBase64, mediaType: imageMediaType}})
-				imageBase64 = "" // Only include image on the first turn, not auto-continues
+			if len(images) > 0 {
+				userTurn = formatUserTurnWithImages(currentMessage, images)
+				images = nil // Only include images on the first turn, not auto-continues
 			} else {
 				userTurn = formatUserTurn(currentMessage)
 			}

--- a/server/api/upload.go
+++ b/server/api/upload.go
@@ -29,6 +29,12 @@ var extensionToMIME = map[string]string{
 	".webp": "image/webp",
 }
 
+// imageData holds base64-encoded image bytes and its MIME type.
+type imageData struct {
+	base64    string
+	mediaType string
+}
+
 // uploadDir returns the directory where uploaded images are stored for a session.
 func uploadDir(sessionCWD, sessionID string) string {
 	return filepath.Join(sessionCWD, ".claude-controller-uploads", sessionID)
@@ -171,27 +177,26 @@ func findUploadedImage(sessionCWD, sessionID, imageID string) (string, string) {
 	return "", ""
 }
 
-// formatUserTurnWithImage builds a stream-json user turn with an image content block
-// and an optional text block, matching the structure of formatUserTurn.
-func formatUserTurnWithImage(message, imageBase64, mediaType string) string {
+// formatUserTurnWithImages builds a stream-json user turn with one image content
+// block per entry in images, followed by an optional text block.
+func formatUserTurnWithImages(message string, images []imageData) string {
 	var content []interface{}
-
-	content = append(content, map[string]interface{}{
-		"type": "image",
-		"source": map[string]string{
-			"type":       "base64",
-			"media_type": mediaType,
-			"data":       imageBase64,
-		},
-	})
-
+	for _, img := range images {
+		content = append(content, map[string]interface{}{
+			"type": "image",
+			"source": map[string]string{
+				"type":       "base64",
+				"media_type": img.mediaType,
+				"data":       img.base64,
+			},
+		})
+	}
 	if message != "" {
 		content = append(content, map[string]string{
 			"type": "text",
 			"text": message,
 		})
 	}
-
 	turn := map[string]interface{}{
 		"type": "user",
 		"message": map[string]interface{}{

--- a/server/api/upload.go
+++ b/server/api/upload.go
@@ -90,14 +90,6 @@ func (s *Server) handleUploadImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remove any existing files in the dir (one image at a time).
-	existing, _ := os.ReadDir(dir)
-	for _, entry := range existing {
-		if !entry.IsDir() {
-			os.Remove(filepath.Join(dir, entry.Name()))
-		}
-	}
-
 	// Save with UUID filename + original extension.
 	imageID := uuid.New().String()
 	ext := strings.ToLower(filepath.Ext(header.Filename))

--- a/server/api/upload_test.go
+++ b/server/api/upload_test.go
@@ -178,24 +178,22 @@ func TestUploadImageHookMode(t *testing.T) {
 	}
 }
 
-func TestFormatUserTurnWithImage(t *testing.T) {
-	result := formatUserTurnWithImage("describe this", "abc123base64data", "image/png")
+func TestFormatUserTurnWithImages_SingleWithText(t *testing.T) {
+	images := []imageData{{base64: "abc123", mediaType: "image/png"}}
+	result := formatUserTurnWithImages("describe this", images)
 
 	var parsed map[string]interface{}
 	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
 		t.Fatal(err)
 	}
-
 	if parsed["type"] != "user" {
 		t.Errorf("type=%v, want user", parsed["type"])
 	}
-
 	msg := parsed["message"].(map[string]interface{})
 	content := msg["content"].([]interface{})
 	if len(content) != 2 {
 		t.Fatalf("expected 2 content blocks, got %d", len(content))
 	}
-
 	imgBlock := content[0].(map[string]interface{})
 	if imgBlock["type"] != "image" {
 		t.Errorf("first block type=%v, want image", imgBlock["type"])
@@ -204,29 +202,61 @@ func TestFormatUserTurnWithImage(t *testing.T) {
 	if source["media_type"] != "image/png" {
 		t.Errorf("media_type=%v, want image/png", source["media_type"])
 	}
-
 	textBlock := content[1].(map[string]interface{})
-	if textBlock["type"] != "text" {
-		t.Errorf("second block type=%v, want text", textBlock["type"])
-	}
-	if textBlock["text"] != "describe this" {
-		t.Errorf("text=%v, want 'describe this'", textBlock["text"])
+	if textBlock["type"] != "text" || textBlock["text"] != "describe this" {
+		t.Errorf("unexpected text block: %v", textBlock)
 	}
 }
 
-func TestFormatUserTurnImageOnly(t *testing.T) {
-	result := formatUserTurnWithImage("", "abc123base64data", "image/png")
+func TestFormatUserTurnWithImages_ImageOnly(t *testing.T) {
+	images := []imageData{{base64: "abc123", mediaType: "image/png"}}
+	result := formatUserTurnWithImages("", images)
 
 	var parsed map[string]interface{}
 	json.Unmarshal([]byte(result), &parsed)
 	msg := parsed["message"].(map[string]interface{})
 	content := msg["content"].([]interface{})
-
 	if len(content) != 1 {
 		t.Fatalf("expected 1 content block (image only), got %d", len(content))
 	}
 	if content[0].(map[string]interface{})["type"] != "image" {
 		t.Error("expected image block")
+	}
+}
+
+func TestFormatUserTurnWithImages_MultipleImages(t *testing.T) {
+	images := []imageData{
+		{base64: "data1", mediaType: "image/png"},
+		{base64: "data2", mediaType: "image/jpeg"},
+	}
+	result := formatUserTurnWithImages("compare these", images)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	msg := parsed["message"].(map[string]interface{})
+	content := msg["content"].([]interface{})
+	if len(content) != 3 {
+		t.Fatalf("expected 3 content blocks, got %d", len(content))
+	}
+	if content[0].(map[string]interface{})["type"] != "image" {
+		t.Errorf("block 0 should be image")
+	}
+	if content[1].(map[string]interface{})["type"] != "image" {
+		t.Errorf("block 1 should be image")
+	}
+	src0 := content[0].(map[string]interface{})["source"].(map[string]interface{})
+	if src0["media_type"] != "image/png" {
+		t.Errorf("block 0 media_type=%v, want image/png", src0["media_type"])
+	}
+	src1 := content[1].(map[string]interface{})["source"].(map[string]interface{})
+	if src1["media_type"] != "image/jpeg" {
+		t.Errorf("block 1 media_type=%v, want image/jpeg", src1["media_type"])
+	}
+	textBlock := content[2].(map[string]interface{})
+	if textBlock["type"] != "text" || textBlock["text"] != "compare these" {
+		t.Errorf("unexpected text block: %v", textBlock)
 	}
 }
 

--- a/server/api/upload_test.go
+++ b/server/api/upload_test.go
@@ -260,6 +260,65 @@ func TestFormatUserTurnWithImages_MultipleImages(t *testing.T) {
 	}
 }
 
+func TestUploadMultipleImagesAccumulate(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	cwd := t.TempDir()
+	body := `{"cwd": "` + cwd + `"}`
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/create", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	var sess map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&sess)
+	resp.Body.Close()
+	sessID := sess["id"].(string)
+
+	uploadOnePNG := func() string {
+		pngData := createTestPNG()
+		multiBody, contentType := createMultipartBody("test.png", pngData)
+		uploadReq, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sessID+"/upload", multiBody)
+		uploadReq.Header.Set("Authorization", "Bearer test-api-key")
+		uploadReq.Header.Set("Content-Type", contentType)
+		uploadResp, err := http.DefaultClient.Do(uploadReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer uploadResp.Body.Close()
+		if uploadResp.StatusCode != 200 {
+			t.Fatalf("upload status=%d, want 200", uploadResp.StatusCode)
+		}
+		var result map[string]interface{}
+		json.NewDecoder(uploadResp.Body).Decode(&result)
+		return result["image_id"].(string)
+	}
+
+	id1 := uploadOnePNG()
+	id2 := uploadOnePNG()
+
+	// Both files should exist on disk
+	dir := filepath.Join(cwd, ".claude-controller-uploads", sessID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read upload dir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("expected 2 files in upload dir, got %d", len(entries))
+	}
+
+	// Both IDs should be findable
+	path1, _ := findUploadedImage(cwd, sessID, id1)
+	if path1 == "" {
+		t.Error("image 1 not found after second upload")
+	}
+	path2, _ := findUploadedImage(cwd, sessID, id2)
+	if path2 == "" {
+		t.Error("image 2 not found after second upload")
+	}
+}
+
 func TestDeleteSessionCleansUpUploads(t *testing.T) {
 	ts, store := setupTestServer(t)
 	defer ts.Close()

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1688,9 +1688,10 @@ document.addEventListener('alpine:init', () => {
           });
           if (!res.ok) throw new Error(await res.text());
           const data = await res.json();
-          const preview = await new Promise(resolve => {
+          const preview = await new Promise((resolve, reject) => {
             const reader = new FileReader();
             reader.onload = (e) => resolve(e.target.result);
+            reader.onerror = () => reject(new Error('Failed to read file'));
             reader.readAsDataURL(file);
           });
           this.pendingImages.push({ id: data.image_id, preview, filename: data.filename });
@@ -3012,7 +3013,7 @@ Please review this PR and provide feedback.`;
         let imgHtml = '';
         if (msg.images && msg.images.length) {
           imgHtml = msg.images.map(img =>
-            `<img src="${img.preview}" style="max-width:200px;max-height:150px;border-radius:6px;margin-bottom:4px;margin-right:4px;cursor:pointer;display:inline-block" onclick="window.open(this.src,'_blank')" title="${esc(img.filename)}">`
+            `<img src="${esc(img.preview)}" style="max-width:200px;max-height:150px;border-radius:6px;margin-bottom:4px;margin-right:4px;cursor:pointer;display:inline-block" onclick="window.open(this.src,'_blank')" title="${esc(img.filename)}">`
           ).join('');
         } else if (msg.imagePreview) {
           // backward compat: messages sent before this change

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -157,9 +157,7 @@ document.addEventListener('alpine:init', () => {
     isCompacting: false,
 
     // Image upload state
-    pendingImageId: null,
-    pendingImagePreview: null,
-    pendingImageFilename: null,
+    pendingImages: [],   // [{id, preview, filename}]
     imageUploading: false,
 
     // Shell mode
@@ -1661,68 +1659,71 @@ document.addEventListener('alpine:init', () => {
     },
 
     async uploadImage(event) {
-      const file = event.target.files?.[0];
-      if (!file || !this.selectedSessionId) return;
+      const files = Array.from(event.target.files || []);
+      if (!files.length || !this.selectedSessionId) return;
 
-      if (!file.type.startsWith('image/')) {
-        this.toast('Please select an image file');
-        event.target.value = '';
-        return;
-      }
-      if (file.size > 20 * 1024 * 1024) {
-        this.toast('Image must be under 20MB');
+      if (this.pendingImages.length + files.length > 7) {
+        this.toast('Maximum 7 images per message');
         event.target.value = '';
         return;
       }
 
       this.imageUploading = true;
-      try {
-        const formData = new FormData();
-        formData.append('image', file);
-
-        const res = await fetch(`/api/sessions/${this.selectedSessionId}/upload`, {
-          method: 'POST',
-          headers: { 'Authorization': 'Bearer ' + this.apiKey },
-          body: formData
-        });
-        if (!res.ok) throw new Error(await res.text());
-
-        const data = await res.json();
-        this.pendingImageId = data.image_id;
-        this.pendingImageFilename = data.filename;
-
-        const reader = new FileReader();
-        reader.onload = (e) => { this.pendingImagePreview = e.target.result; };
-        reader.readAsDataURL(file);
-      } catch (e) {
-        this.toast('Upload failed: ' + e.message);
+      for (const file of files) {
+        if (!file.type.startsWith('image/')) {
+          this.toast(`${file.name}: not an image, skipped`);
+          continue;
+        }
+        if (file.size > 20 * 1024 * 1024) {
+          this.toast(`${file.name}: must be under 20MB, skipped`);
+          continue;
+        }
+        try {
+          const formData = new FormData();
+          formData.append('image', file);
+          const res = await fetch(`/api/sessions/${this.selectedSessionId}/upload`, {
+            method: 'POST',
+            headers: { 'Authorization': 'Bearer ' + this.apiKey },
+            body: formData
+          });
+          if (!res.ok) throw new Error(await res.text());
+          const data = await res.json();
+          const preview = await new Promise(resolve => {
+            const reader = new FileReader();
+            reader.onload = (e) => resolve(e.target.result);
+            reader.readAsDataURL(file);
+          });
+          this.pendingImages.push({ id: data.image_id, preview, filename: data.filename });
+        } catch (e) {
+          this.toast('Upload failed: ' + e.message);
+        }
       }
       this.imageUploading = false;
       event.target.value = '';
     },
 
-    clearPendingImage() {
-      this.pendingImageId = null;
-      this.pendingImagePreview = null;
-      this.pendingImageFilename = null;
+    clearPendingImages() {
+      this.pendingImages = [];
+    },
+
+    removePendingImage(index) {
+      this.pendingImages.splice(index, 1);
     },
 
     async sendManagedMessage() {
-      if ((!this.inputText.trim() && !this.pendingImageId) || !this.selectedSessionId) return;
+      if ((!this.inputText.trim() && !this.pendingImages.length) || !this.selectedSessionId) return;
       const msg = this.inputText.trim();
       this.inputText = '';
       this.$nextTick(() => { if (this.$refs.promptInput) this.$refs.promptInput.style.height = 'auto'; });
       this.interimTranscript = '';
       this.inputSending = true;
 
-      const imageId = this.pendingImageId;
-      const imagePreview = this.pendingImagePreview;
-      const imageFilename = this.pendingImageFilename;
-      this.clearPendingImage();
+      const images = [...this.pendingImages];
+      this.clearPendingImages();
 
       try {
         const body = { message: msg, model: this.selectedModel };
-        if (imageId) body.image_id = imageId;
+        if (images.length) body.image_ids = images.map(img => img.id);
 
         const res = await fetch(`/api/sessions/${this.selectedSessionId}/message`, {
           method: 'POST',
@@ -1732,10 +1733,10 @@ document.addEventListener('alpine:init', () => {
         if (!res.ok) throw new Error(await res.text());
 
         // Add user message to chat immediately
-        const userMsg = { role: 'user', content: msg || `[Screenshot: ${imageFilename}]`, msg_type: 'text', timestamp: new Date().toISOString() };
-        if (imagePreview) {
-          userMsg.imagePreview = imagePreview;
-          userMsg.imageFilename = imageFilename;
+        const label = images.length === 1 ? `[Screenshot: ${images[0].filename}]` : `[${images.length} images]`;
+        const userMsg = { role: 'user', content: msg || label, msg_type: 'text', timestamp: new Date().toISOString() };
+        if (images.length) {
+          userMsg.images = images.map(img => ({ preview: img.preview, filename: img.filename }));
         }
         this.chatMessages.push(userMsg);
         this.$nextTick(() => this.scrollToBottom(true));
@@ -3009,7 +3010,12 @@ Please review this PR and provide feedback.`;
 
       if (msg.msg_type === 'text') {
         let imgHtml = '';
-        if (msg.imagePreview) {
+        if (msg.images && msg.images.length) {
+          imgHtml = msg.images.map(img =>
+            `<img src="${img.preview}" style="max-width:200px;max-height:150px;border-radius:6px;margin-bottom:4px;margin-right:4px;cursor:pointer;display:inline-block" onclick="window.open(this.src,'_blank')" title="${esc(img.filename)}">`
+          ).join('');
+        } else if (msg.imagePreview) {
+          // backward compat: messages sent before this change
           imgHtml = `<img src="${msg.imagePreview}" style="max-width:200px;max-height:150px;border-radius:6px;margin-bottom:4px;cursor:pointer;display:block" onclick="window.open(this.src,'_blank')">`;
         }
         if ((msg.role === 'assistant' || msg.role === 'user' || msg.command) && typeof marked !== 'undefined') {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -318,7 +318,7 @@
 
             <!-- Input bar (managed mode messages OR hook-mode instructions) -->
             <div class="instruction-bar" x-show="selectedSessionId && !currentPendingPrompt" style="position:relative">
-              <input type="file" x-ref="imageInput" accept="image/*"
+              <input type="file" x-ref="imageInput" accept="image/*" multiple
                      @change="uploadImage($event)" style="display:none">
 
               <!-- Slash command autocomplete -->
@@ -337,11 +337,15 @@
 
               <div class="input-row">
                 <div class="input-wrapper">
-                  <!-- Image preview -->
-                  <div class="image-preview-strip" x-show="pendingImagePreview" x-cloak>
-                    <img :src="pendingImagePreview" class="image-preview-thumb">
-                    <span class="image-preview-name" x-text="pendingImageFilename"></span>
-                    <button class="image-preview-remove" @click="clearPendingImage()" title="Remove image">&times;</button>
+                  <!-- Multi-image preview strip -->
+                  <div class="image-preview-strip" x-show="pendingImages.length > 0" x-cloak style="display:flex;flex-wrap:wrap;gap:6px;padding:6px 0">
+                    <template x-for="(img, idx) in pendingImages" :key="idx">
+                      <div class="image-preview-item" style="position:relative;display:inline-flex;flex-direction:column;align-items:center;gap:2px">
+                        <img :src="img.preview" class="image-preview-thumb">
+                        <span class="image-preview-name" x-text="img.filename"></span>
+                        <button class="image-preview-remove" @click="removePendingImage(idx)" title="Remove image">&times;</button>
+                      </div>
+                    </template>
                   </div>
 
                   <textarea x-ref="promptInput" x-model="inputText" rows="1"
@@ -352,7 +356,7 @@
                          @blur="setTimeout(() => showSlashMenu = false, 150)"
                          :disabled="inputSending"></textarea>
                 </div>
-                <button class="btn btn-primary btn-sm" :disabled="(!inputText.trim() && !pendingImageId) || inputSending"
+                <button class="btn btn-primary btn-sm" :disabled="(!inputText.trim() && !pendingImages.length) || inputSending"
                         @click="handleInput()" style="width:auto">
                   <span x-show="!inputSuccess">Send</span>
                   <span x-show="inputSuccess" style="color:#16a34a">Sent!</span>


### PR DESCRIPTION
## Summary

- **Backend:** Added `imageData` type and `formatUserTurnWithImages` replacing the single-image function; removed the one-at-a-time upload dir constraint so multiple files accumulate; widened `handleSendMessage` to accept `image_ids []string` instead of `image_id string`
- **Frontend:** Replaced scalar `pendingImage*` state with a `pendingImages[]` array; rewrote `uploadImage()` to loop over all selected files sequentially (max 7, 20MB each); added `removePendingImage(idx)` for per-image removal
- **UI:** Added `multiple` attribute to file input; replaced single-thumbnail preview with an `x-for` strip with per-image ✕ buttons; updated send button guard to `pendingImages.length`

## Test Plan

- [ ] Select multiple images via the attach button — all thumbnails appear in the preview strip
- [ ] Click ✕ on individual thumbnails — only that image is removed
- [ ] Send a message with 2–3 images — all images appear in the chat bubble and are passed to Claude in a single turn
- [ ] Verify single-image flow still works (no regression)
- [ ] Try selecting 8+ images — toast "Maximum 7 images per message" appears
- [ ] Try attaching a non-image file — toast warns and skips it
- [ ] `cd server && go test ./... -v` — all tests pass