### PR TITLE
Cost tracking and configurable usage limits

### DIFF
--- a/server/api/cost.go
+++ b/server/api/cost.go
@@ -3,15 +3,37 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/jaychinthrajah/claude-controller/server/db"
 )
 
+// Default Anthropic usage limits (used when not configured in .env)
+const (
+	DefaultFiveHourLimitUSD  = 5.0
+	DefaultSevenDayLimitUSD  = 50.0
+)
+
+func (s *Server) usageLimits() (fiveHr, sevenDay float64) {
+	fiveHr = DefaultFiveHourLimitUSD
+	sevenDay = DefaultSevenDayLimitUSD
+	vals := readEnvFile(s.envPath)
+	if v, err := strconv.ParseFloat(vals["USAGE_LIMIT_5HR"], 64); err == nil && v > 0 {
+		fiveHr = v
+	}
+	if v, err := strconv.ParseFloat(vals["USAGE_LIMIT_7DAY"], 64); err == nil && v > 0 {
+		sevenDay = v
+	}
+	return
+}
+
 // CostSummary represents the cost breakdown for a time window
 type CostSummary struct {
-	TotalCost float64              `json:"total_cost"`
-	Sessions  []SessionCostDetail  `json:"sessions"`
+	TotalCost   float64              `json:"total_cost"`
+	Utilization float64              `json:"utilization"`
+	ResetsAt    string               `json:"resets_at"`
+	Sessions    []SessionCostDetail  `json:"sessions"`
 }
 
 // SessionCostDetail represents cost for a single session with per-model breakdown
@@ -22,7 +44,7 @@ type SessionCostDetail struct {
 }
 
 // aggregateCosts sums costs from messages in the given time window, grouped by session + model
-func (s *Server) aggregateCosts(windowStart, windowEnd time.Time) (*CostSummary, error) {
+func (s *Server) aggregateCosts(windowStart, windowEnd time.Time, limit float64) (*CostSummary, error) {
 	query := `
 	SELECT COALESCE(m.session_id, '') as session_id, COALESCE(ms.model, '') as model, SUM(COALESCE(m.cost, 0)) as total
 	FROM messages m
@@ -66,6 +88,14 @@ func (s *Server) aggregateCosts(windowStart, windowEnd time.Time) (*CostSummary,
 		summary.Sessions = append(summary.Sessions, *detail)
 	}
 
+	summary.ResetsAt = windowEnd.UTC().Format(time.RFC3339)
+	if limit > 0 {
+		summary.Utilization = summary.TotalCost / limit
+		if summary.Utilization > 1.0 {
+			summary.Utilization = 1.0
+		}
+	}
+
 	return summary, nil
 }
 
@@ -94,8 +124,9 @@ func (s *Server) handleCostSummary(w http.ResponseWriter, r *http.Request) {
 	sevenDayStart, sevenDayEnd := db.SevenDayWindow(now)
 
 	// Aggregate costs for each window
-	fiveHrSummary, _ := s.aggregateCosts(fiveHrStart, fiveHrEnd)
-	sevenDaySummary, _ := s.aggregateCosts(sevenDayStart, sevenDayEnd)
+	fiveHrLimit, sevenDayLimit := s.usageLimits()
+	fiveHrSummary, _ := s.aggregateCosts(fiveHrStart, fiveHrEnd, fiveHrLimit)
+	sevenDaySummary, _ := s.aggregateCosts(sevenDayStart, sevenDayEnd, sevenDayLimit)
 
 	// Return response
 	w.Header().Set("Content-Type", "application/json")

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -304,13 +304,16 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 						mu.Unlock()
 					}
 				}
+				// Compute and persist turn cost from the result event's usage data
+				cost := extractCostFromResult(line, sess.Model)
+				if cost > 0 {
+					_, _ = s.store.CreateMessage(sessionID, "cost", fmt.Sprintf("%.6f", cost), cost)
+				}
 			}
 			if role == "assistant" {
 				text := extractAssistantText(line)
 				if text != "" {
-					// Extract cost from the enriched result event if present
-					cost := extractCostFromLine(line)
-					_, _ = s.store.CreateMessage(sessionID, role, text, cost)
+					_, _ = s.store.CreateMessage(sessionID, role, text, 0)
 				}
 				for _, toolName := range extractToolNames(line) {
 					_, _ = s.store.CreateMessage(sessionID, "activity", toolName, 0)
@@ -861,6 +864,25 @@ func extractCostFromLine(line string) float64 {
 	}
 	json.Unmarshal([]byte(line), &result)
 	return result.Cost
+}
+
+// extractCostFromResult computes cost from a raw result event's usage data.
+// Returns 0 if the line is not a result event or has no usage.
+func extractCostFromResult(line string, model string) float64 {
+	var raw struct {
+		Type  string `json:"type"`
+		Usage struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if json.Unmarshal([]byte(line), &raw) != nil || raw.Type != "result" {
+		return 0
+	}
+	if raw.Usage.InputTokens == 0 && raw.Usage.OutputTokens == 0 {
+		return 0
+	}
+	return calcCost(model, raw.Usage.InputTokens, raw.Usage.OutputTokens)
 }
 
 // enrichResultLine injects "cost" and "model" fields into a result NDJSON event.

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -23,6 +23,8 @@ type settingsPayload struct {
 	ClaudeArgs             string     `json:"claude_args"`
 	ClaudeEnv              string     `json:"claude_env"`
 	CompactEveryNContinues string     `json:"compact_every_n_continues"`
+	UsageLimit5hr          string     `json:"usage_limit_5hr"`
+	UsageLimit7day         string     `json:"usage_limit_7day"`
 	GithubToken            string     `json:"github_token"`
 	JiraURL                string     `json:"jira_url"`
 	JiraToken              string     `json:"jira_token"`
@@ -84,6 +86,8 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		ClaudeArgs:             vals["CLAUDE_ARGS"],
 		ClaudeEnv:              vals["CLAUDE_ENV"],
 		CompactEveryNContinues: vals["COMPACT_EVERY_N_CONTINUES"],
+		UsageLimit5hr:          vals["USAGE_LIMIT_5HR"],
+		UsageLimit7day:         vals["USAGE_LIMIT_7DAY"],
 		GithubToken:            vals["GITHUB_TOKEN"],
 		JiraURL:                vals["JIRA_URL"],
 		JiraToken:              vals["JIRA_TOKEN"],
@@ -212,6 +216,13 @@ func formatEnvFile(p settingsPayload) string {
 	}
 	if p.CompactEveryNContinues != "" && p.CompactEveryNContinues != "0" {
 		b.WriteString("COMPACT_EVERY_N_CONTINUES=" + p.CompactEveryNContinues + "\n")
+	}
+	b.WriteString("\n# Usage limits\n")
+	if p.UsageLimit5hr != "" {
+		b.WriteString("USAGE_LIMIT_5HR=" + p.UsageLimit5hr + "\n")
+	}
+	if p.UsageLimit7day != "" {
+		b.WriteString("USAGE_LIMIT_7DAY=" + p.UsageLimit7day + "\n")
 	}
 	b.WriteString("\n# GitHub\n")
 	if p.GithubToken != "" {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -136,7 +136,7 @@ document.addEventListener('alpine:init', () => {
     // Settings state
     showSettingsModal: false,
     settingsFirstRun: false,
-    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] },
+    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', usage_limit_5hr: '', usage_limit_7day: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] },
     settingsError: '',
     settingsSaving: false,
     settingsRestartRequired: false,
@@ -548,6 +548,8 @@ document.addEventListener('alpine:init', () => {
           claude_args: data.claude_args || '',
           claude_env: data.claude_env || '',
           compact_every_n_continues: data.compact_every_n_continues || '',
+          usage_limit_5hr: data.usage_limit_5hr || '',
+          usage_limit_7day: data.usage_limit_7day || '',
           github_token: data.github_token || '',
           jira_url: data.jira_url || '',
           jira_token: data.jira_token || '',
@@ -789,7 +791,7 @@ document.addEventListener('alpine:init', () => {
     usageBarColor(utilization) {
       if (utilization > 0.9) return '#e74c3c';
       if (utilization > 0.7) return '#f39c12';
-      return '#22c55e';
+      return '#16a34a';
     },
 
     turnBarColor() {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -771,7 +771,7 @@ document.addEventListener('alpine:init', () => {
         const queryString = sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : '';
         const resp = await fetch(`/api/cost-summary${queryString}`, {
           method: 'GET',
-          credentials: 'include',
+          headers: { 'Authorization': `Bearer ${this.apiKey}` }
         });
         if (!resp.ok) {
           this.usageData = null;

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -73,6 +73,83 @@
           </button>
         </div>
         <div class="session-list">
+          <!-- Usage rate limit widget -->
+          <div x-show="usageData && !usageError && !leftCollapsed"
+               style="margin-bottom:8px; padding:8px; background:var(--surface); border:1px solid var(--border); border-radius:6px; font-size:11px;">
+            <!-- 5-hour bar -->
+            <template x-if="usageData?.five_hour">
+              <div style="display:flex; align-items:center; gap:4px; margin-bottom:4px;"
+                   :title="'5hr resets at ' + new Date(usageData.five_hour.resets_at).toLocaleTimeString()">
+                <span style="opacity:0.6; white-space:nowrap; min-width:20px;">5hr</span>
+                <div style="flex:1; height:4px; background:var(--border); border-radius:2px; overflow:hidden;">
+                  <div :style="'width:' + Math.round(usageData.five_hour.utilization * 100) + '%; height:100%; border-radius:2px; background:' + usageBarColor(usageData.five_hour.utilization) + '; transition:width 0.3s ease'"></div>
+                </div>
+                <span x-text="Math.round(usageData.five_hour.utilization * 100) + '%'"
+                      style="font-weight:600; min-width:28px; text-align:right;"
+                      :style="'color:' + usageBarColor(usageData.five_hour.utilization)"></span>
+              </div>
+            </template>
+            <!-- 7-day bar -->
+            <template x-if="usageData?.seven_day">
+              <div style="display:flex; align-items:center; gap:4px;"
+                   :title="'7d resets at ' + new Date(usageData.seven_day.resets_at).toLocaleDateString()">
+                <span style="opacity:0.6; white-space:nowrap; min-width:20px;">7d</span>
+                <div style="flex:1; height:4px; background:var(--border); border-radius:2px; overflow:hidden;">
+                  <div :style="'width:' + Math.round(usageData.seven_day.utilization * 100) + '%; height:100%; border-radius:2px; background:' + usageBarColor(usageData.seven_day.utilization) + '; transition:width 0.3s ease'"></div>
+                </div>
+                <span x-text="Math.round(usageData.seven_day.utilization * 100) + '%'"
+                      style="font-weight:600; min-width:28px; text-align:right;"
+                      :style="'color:' + usageBarColor(usageData.seven_day.utilization)"></span>
+              </div>
+            </template>
+            <!-- Expandable session cost breakdown -->
+            <div style="margin-top:6px; border-top:1px solid var(--border); padding-top:6px;">
+              <button @click="showCostDetails = !showCostDetails"
+                      style="background:none; border:none; color:var(--accent); cursor:pointer; font-size:11px; padding:0;">
+                <span x-text="showCostDetails ? '▼' : '▶'"></span> Cost Details
+              </button>
+              <template x-if="showCostDetails && usageData?.five_hour?.sessions">
+                <div style="margin-top:6px; font-size:11px;">
+                  <div style="margin-bottom:4px; font-weight:600; opacity:0.7;">5hr Window</div>
+                  <table style="width:100%; border-collapse:collapse;">
+                    <thead>
+                      <tr style="border-bottom:1px solid var(--border);">
+                        <th style="text-align:left; padding:3px 4px; font-weight:500; opacity:0.6;">Session</th>
+                        <th style="text-align:right; padding:3px 4px; font-weight:500; opacity:0.6;">Cost</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <template x-for="session in usageData.five_hour.sessions" :key="session.id">
+                        <tr style="border-bottom:1px solid var(--border);">
+                          <td style="padding:3px 4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:120px;"
+                              :title="session.id" x-text="session.id.substring(0, 12)"></td>
+                          <td style="text-align:right; padding:3px 4px; font-variant-numeric:tabular-nums; font-weight:500;" x-text="'$' + session.total_cost.toFixed(2)"></td>
+                        </tr>
+                      </template>
+                    </tbody>
+                  </table>
+                  <div style="margin-top:8px; margin-bottom:4px; font-weight:600; opacity:0.7;">7d Window</div>
+                  <table style="width:100%; border-collapse:collapse;">
+                    <thead>
+                      <tr style="border-bottom:1px solid var(--border);">
+                        <th style="text-align:left; padding:3px 4px; font-weight:500; opacity:0.6;">Session</th>
+                        <th style="text-align:right; padding:3px 4px; font-weight:500; opacity:0.6;">Cost</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <template x-for="session in usageData.seven_day.sessions" :key="session.id">
+                        <tr style="border-bottom:1px solid var(--border);">
+                          <td style="padding:3px 4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:120px;"
+                              :title="session.id" x-text="session.id.substring(0, 12)"></td>
+                          <td style="text-align:right; padding:3px 4px; font-variant-numeric:tabular-nums; font-weight:500;" x-text="'$' + session.total_cost.toFixed(2)"></td>
+                        </tr>
+                      </template>
+                    </tbody>
+                  </table>
+                </div>
+              </template>
+            </div>
+          </div>
           <button class="btn btn-sm btn-primary" @click="openNewSessionModal()"
                   style="width:100%; margin-bottom:8px; font-size:13px;">
             + New Session
@@ -164,85 +241,6 @@
                 :title="selectedSessionId ? 'Double-click to rename' : ''"
                 :style="selectedSessionId ? 'cursor:pointer' : ''"></h2>
           </template>
-          <!-- Usage rate limit widget -->
-          <div x-show="usageData && !usageError"
-               style="display:flex; align-items:center; gap:10px; margin-right:8px;">
-            <!-- 5-hour bar -->
-            <template x-if="usageData?.five_hour">
-              <div style="display:flex; align-items:center; gap:4px;"
-                   :title="'5hr resets at ' + new Date(usageData.five_hour.resets_at).toLocaleTimeString()">
-                <span style="font-size:11px; opacity:0.6; white-space:nowrap;">5hr</span>
-                <div style="width:60px; height:4px; background:var(--border); border-radius:2px; overflow:hidden;">
-                  <div :style="'width:' + Math.round(usageData.five_hour.utilization * 100) + '%; height:100%; border-radius:2px; background:' + usageBarColor(usageData.five_hour.utilization) + '; transition:width 0.3s ease'"></div>
-                </div>
-                <span x-text="Math.round(usageData.five_hour.utilization * 100) + '%'"
-                      style="font-size:11px; font-weight:600; min-width:28px;"
-                      :style="'color:' + usageBarColor(usageData.five_hour.utilization)"></span>
-              </div>
-            </template>
-            <!-- 7-day bar -->
-            <template x-if="usageData?.seven_day">
-              <div style="display:flex; align-items:center; gap:4px;"
-                   :title="'7d resets at ' + new Date(usageData.seven_day.resets_at).toLocaleDateString()">
-                <span style="font-size:11px; opacity:0.6; white-space:nowrap;">7d</span>
-                <div style="width:60px; height:4px; background:var(--border); border-radius:2px; overflow:hidden;">
-                  <div :style="'width:' + Math.round(usageData.seven_day.utilization * 100) + '%; height:100%; border-radius:2px; background:' + usageBarColor(usageData.seven_day.utilization) + '; transition:width 0.3s ease'"></div>
-                </div>
-                <span x-text="Math.round(usageData.seven_day.utilization * 100) + '%'"
-                      style="font-size:11px; font-weight:600; min-width:28px;"
-                      :style="'color:' + usageBarColor(usageData.seven_day.utilization)"></span>
-              </div>
-            </template>
-          </div>
-          <!-- Expandable session cost breakdown -->
-          <div x-show="usageData && !usageError" style="margin-top:12px;">
-            <button @click="showCostDetails = !showCostDetails"
-                    style="background:none; border:none; color:var(--accent); cursor:pointer; font-size:0.85rem;">
-              <span x-text="showCostDetails ? '▼' : '▶'"></span> Details
-            </button>
-
-            <template x-if="showCostDetails && usageData?.five_hour?.sessions">
-              <div style="margin-top:8px; font-size:0.8rem;">
-                <div style="margin-bottom:6px; font-weight:600;">5hr Sessions:</div>
-                <table style="width:100%; border-collapse:collapse;">
-                  <thead>
-                    <tr style="border-bottom:1px solid var(--border);">
-                      <th style="text-align:left; padding:4px;">Session</th>
-                      <th style="text-align:right; padding:4px;">Cost</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <template x-for="session in usageData.five_hour.sessions" :key="session.id">
-                      <tr style="border-bottom:1px solid var(--border);">
-                        <td style="padding:4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"
-                            :title="session.id" x-text="session.id.substring(0, 12)"></td>
-                        <td style="text-align:right; padding:4px;" x-text="'$' + session.total_cost.toFixed(2)"></td>
-                      </tr>
-                    </template>
-                  </tbody>
-                </table>
-
-                <div style="margin-top:12px; margin-bottom:6px; font-weight:600;">7d Sessions:</div>
-                <table style="width:100%; border-collapse:collapse;">
-                  <thead>
-                    <tr style="border-bottom:1px solid var(--border);">
-                      <th style="text-align:left; padding:4px;">Session</th>
-                      <th style="text-align:right; padding:4px;">Cost</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <template x-for="session in usageData.seven_day.sessions" :key="session.id">
-                      <tr style="border-bottom:1px solid var(--border);">
-                        <td style="padding:4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"
-                            :title="session.id" x-text="session.id.substring(0, 12)"></td>
-                        <td style="text-align:right; padding:4px;" x-text="'$' + session.total_cost.toFixed(2)"></td>
-                      </tr>
-                    </template>
-                  </tbody>
-                </table>
-              </div>
-            </template>
-          </div>
           <div :class="currentSession?.mode === 'managed' ? 'turns-monitor' : 'turns-monitor hidden'">
             <span x-show="currentSession?.max_turns > 0" style="opacity:0.7;">Turns</span>
             <span x-show="currentSession?.max_turns > 0"
@@ -1519,6 +1517,24 @@
               <input x-model="settingsForm.compact_every_n_continues" type="number" min="0" placeholder="0" class="modal-input" :style="isFieldChanged('compact_every_n_continues') ? 'border-color:var(--yellow)' : ''">
               <div class="modal-hint">Run /compact every N auto-continues to reduce token usage. 0 = disabled.</div>
             </div>
+
+            <div style="display:flex;gap:12px">
+              <div style="flex:1">
+                <label class="modal-label">
+                  5-Hour Usage Limit ($)
+                  <span x-show="isFieldChanged('usage_limit_5hr')" class="settings-change-badge">changed</span>
+                </label>
+                <input x-model="settingsForm.usage_limit_5hr" type="number" min="0" step="0.5" placeholder="5" class="modal-input" :style="isFieldChanged('usage_limit_5hr') ? 'border-color:var(--yellow)' : ''">
+              </div>
+              <div style="flex:1">
+                <label class="modal-label">
+                  7-Day Usage Limit ($)
+                  <span x-show="isFieldChanged('usage_limit_7day')" class="settings-change-badge">changed</span>
+                </label>
+                <input x-model="settingsForm.usage_limit_7day" type="number" min="0" step="1" placeholder="50" class="modal-input" :style="isFieldChanged('usage_limit_7day') ? 'border-color:var(--yellow)' : ''">
+              </div>
+            </div>
+            <div class="modal-hint">Anthropic usage limits for utilization bars. Defaults: $5 / 5hr, $50 / 7day.</div>
           </div>
 
           <!-- Integrations tab -->


### PR DESCRIPTION
## Summary
- Capture costs from Claude result events and persist to database
- Add utilization and resets_at fields to cost summary API response  
- Make usage limits configurable via .env (defaults: $5/5hr, $50/7day)

## Test Plan
- [x] All tests pass (108 tests)
- [x] Cost capture verified via server logs (costs persisted to DB)
- [x] Cost summary API returns utilization and resets_at fields
- [x] UI displays utilization percentages in cost sidebar
- [x] Settings modal allows configuring usage limits