### PR TITLE
feat(cost): show project name in cost details

### DIFF
--- a/server/api/cost.go
+++ b/server/api/cost.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -39,6 +40,7 @@ type CostSummary struct {
 // SessionCostDetail represents cost for a single session with per-model breakdown
 type SessionCostDetail struct {
 	SessionID string             `json:"id"`
+	Name      string             `json:"name"`
 	TotalCost float64            `json:"total_cost"`
 	ByModel   map[string]float64 `json:"by_model"`
 }
@@ -46,7 +48,8 @@ type SessionCostDetail struct {
 // aggregateCosts sums costs from messages in the given time window, grouped by session + model
 func (s *Server) aggregateCosts(windowStart, windowEnd time.Time, limit float64) (*CostSummary, error) {
 	query := `
-	SELECT COALESCE(m.session_id, '') as session_id, COALESCE(ms.model, '') as model, SUM(COALESCE(m.cost, 0)) as total
+	SELECT COALESCE(m.session_id, '') as session_id, COALESCE(ms.model, '') as model, SUM(COALESCE(m.cost, 0)) as total,
+	       COALESCE(ms.name, '') as sess_name, COALESCE(ms.cwd, '') as sess_cwd
 	FROM messages m
 	LEFT JOIN sessions ms ON m.session_id = ms.id
 	WHERE m.created_at >= ? AND m.created_at < ? AND m.cost > 0
@@ -65,15 +68,20 @@ func (s *Server) aggregateCosts(windowStart, windowEnd time.Time, limit float64)
 	sessionMap := make(map[string]*SessionCostDetail)
 
 	for rows.Next() {
-		var sessionID, model string
+		var sessionID, model, sessName, sessCWD string
 		var cost float64
-		if err := rows.Scan(&sessionID, &model, &cost); err != nil {
+		if err := rows.Scan(&sessionID, &model, &cost, &sessName, &sessCWD); err != nil {
 			return nil, err
 		}
 
 		if _, exists := sessionMap[sessionID]; !exists {
+			displayName := sessName
+			if displayName == "" && sessCWD != "" {
+				displayName = filepath.Base(sessCWD)
+			}
 			sessionMap[sessionID] = &SessionCostDetail{
 				SessionID: sessionID,
+				Name:      displayName,
 				ByModel:   make(map[string]float64),
 			}
 		}

--- a/server/api/cost_test.go
+++ b/server/api/cost_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestHandleCostSummary_ValidSession(t *testing.T) {
@@ -51,6 +53,73 @@ func TestHandleCostSummary_ValidSession(t *testing.T) {
 	}
 	if _, ok := body["seven_day"]; !ok {
 		t.Error("expected seven_day in response")
+	}
+}
+
+func TestAggregateCosts_UsesSessionName(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := openTestDB(t, tmpDir)
+	if err != nil {
+		t.Fatalf("openTestDB failed: %v", err)
+	}
+
+	sess, err := store.CreateManagedSession(tmpDir, "", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession failed: %v", err)
+	}
+	if err := store.UpdateSessionName(sess.ID, "my-project"); err != nil {
+		t.Fatalf("UpdateSessionName failed: %v", err)
+	}
+
+	// Add a cost message so the session appears in results
+	store.CreateMessage(sess.ID, "cost", "0.010000", 0.01)
+
+	server := &Server{store: store, envPath: tmpDir + "/.env"}
+
+	now := time.Now().UTC()
+	summary, err := server.aggregateCosts(now.Add(-time.Hour), now.Add(time.Hour), 5.0)
+	if err != nil {
+		t.Fatalf("aggregateCosts failed: %v", err)
+	}
+
+	if len(summary.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(summary.Sessions))
+	}
+	if summary.Sessions[0].Name != "my-project" {
+		t.Errorf("expected Name 'my-project', got %q", summary.Sessions[0].Name)
+	}
+}
+
+func TestAggregateCosts_FallsBackToCWDBasename(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := openTestDB(t, tmpDir)
+	if err != nil {
+		t.Fatalf("openTestDB failed: %v", err)
+	}
+
+	// CreateManagedSession sets cwd = tmpDir, name stays empty
+	sess, err := store.CreateManagedSession(tmpDir, "", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession failed: %v", err)
+	}
+
+	store.CreateMessage(sess.ID, "cost", "0.010000", 0.01)
+
+	server := &Server{store: store, envPath: tmpDir + "/.env"}
+
+	now := time.Now().UTC()
+	summary, err := server.aggregateCosts(now.Add(-time.Hour), now.Add(time.Hour), 5.0)
+	if err != nil {
+		t.Fatalf("aggregateCosts failed: %v", err)
+	}
+
+	if len(summary.Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(summary.Sessions))
+	}
+	// Name should be the basename of tmpDir when session name is empty
+	expectedName := filepath.Base(tmpDir)
+	if summary.Sessions[0].Name != expectedName {
+		t.Errorf("expected Name %q (cwd basename), got %q", expectedName, summary.Sessions[0].Name)
 	}
 }
 

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -122,7 +122,7 @@
                       <template x-for="session in usageData.five_hour.sessions" :key="session.id">
                         <tr style="border-bottom:1px solid var(--border);">
                           <td style="padding:3px 4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:120px;"
-                              :title="session.id" x-text="session.id.substring(0, 12)"></td>
+                              :title="session.name || session.id" x-text="session.name || session.id.substring(0, 12)"></td>
                           <td style="text-align:right; padding:3px 4px; font-variant-numeric:tabular-nums; font-weight:500;" x-text="'$' + session.total_cost.toFixed(2)"></td>
                         </tr>
                       </template>
@@ -140,7 +140,7 @@
                       <template x-for="session in usageData.seven_day.sessions" :key="session.id">
                         <tr style="border-bottom:1px solid var(--border);">
                           <td style="padding:3px 4px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:120px;"
-                              :title="session.id" x-text="session.id.substring(0, 12)"></td>
+                              :title="session.name || session.id" x-text="session.name || session.id.substring(0, 12)"></td>
                           <td style="text-align:right; padding:3px 4px; font-variant-numeric:tabular-nums; font-weight:500;" x-text="'$' + session.total_cost.toFixed(2)"></td>
                         </tr>
                       </template>


### PR DESCRIPTION
## Summary
- Cost details panel now shows project/session names instead of truncated UUIDs
- Falls back to `filepath.Base(cwd)` when session has no custom name, then to truncated ID
- `aggregateCosts` query JOINs sessions table to fetch `name` and `cwd`
- Added `Name string` field to `SessionCostDetail` struct

## Test plan
- [x] `TestAggregateCosts_UsesSessionName` — verifies `name` field populated from session name
- [x] `TestAggregateCosts_FallsBackToCWDBasename` — verifies fallback to cwd basename
- [x] All existing tests pass (`go test ./...`)
- [x] Playwright verified: cost details show "claude-control" and "404-checker" instead of UUIDs