### PR TITLE
fix: preserve cost data when clearing sessions

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -151,6 +151,7 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE scheduled_tasks ADD COLUMN model TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE messages ADD COLUMN cost REAL DEFAULT 0`,
+		`ALTER TABLE messages ADD COLUMN cleared_at DATETIME`,
 	}
 
 	for _, m := range migrations {

--- a/server/db/messages.go
+++ b/server/db/messages.go
@@ -53,7 +53,7 @@ func (s *Store) CreateMessageWithExitCode(sessionID, role, content string, exitC
 }
 
 func (s *Store) ListMessages(sessionID string) ([]Message, error) {
-	rows, err := s.db.Query(`SELECT id, session_id, seq, role, content, exit_code, created_at, cost FROM messages WHERE session_id = ? ORDER BY seq`, sessionID)
+	rows, err := s.db.Query(`SELECT id, session_id, seq, role, content, exit_code, created_at, cost FROM messages WHERE session_id = ? AND cleared_at IS NULL ORDER BY seq`, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("list messages: %w", err)
 	}

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -161,8 +161,8 @@ func (s *Store) ClearSession(id string) error {
 		return fmt.Errorf("begin clear transaction: %w", err)
 	}
 	defer tx.Rollback()
-	if _, err := tx.Exec(`DELETE FROM messages WHERE session_id = ?`, id); err != nil {
-		return fmt.Errorf("delete messages: %w", err)
+	if _, err := tx.Exec(`UPDATE messages SET cleared_at = datetime('now') WHERE session_id = ? AND cleared_at IS NULL`, id); err != nil {
+		return fmt.Errorf("clear messages: %w", err)
 	}
 	if _, err := tx.Exec(`UPDATE sessions SET claude_session_id = ?, initialized = 0, activity_state = 'idle' WHERE id = ?`, newClaudeSessionID, id); err != nil {
 		return fmt.Errorf("reset session state: %w", err)


### PR DESCRIPTION
## Summary

- Add  column to messages table for soft-delete capability
- Update `ClearSession` to set `cleared_at` instead of hard-deleting messages
- Filter `cleared_at IS NULL` in `ListMessages` to hide cleared messages from chat UI while preserving cost data

When clearing a session, cost data is now preserved since messages are soft-deleted. The cost aggregation query doesn't filter by `cleared_at`, so project names persist in cost details.

## Test Plan

- [x] All existing tests pass (TestClearSession, TestListMessagesAPI, TestClearSessionAPI)
- [x] Cost aggregation still works with soft-deleted messages
- [x] ListMessages returns only non-cleared messages