### PR TITLE
fix: use aggregate cost from API in status line

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -961,6 +961,8 @@ document.addEventListener('alpine:init', () => {
         if (sess.activity_state === 'working') {
           this.startSessionSSE(this.selectedSessionId);
         }
+        // Fetch cost summary immediately when switching to a managed session
+        await this.fetchCostSummary();
       } else {
         await this.fetchTranscript(this.selectedSessionId, true);
       }

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -483,7 +483,7 @@
               <template x-if="statusLineConfig.cost">
                 <span class="status-line-item">
                   <span class="status-line-label">Cost</span>
-                  <span x-text="sessionCost != null ? '$' + sessionCost.toFixed(4) : '$0.0000'"></span>
+                  <span x-text="usageData?.five_hour?.total_cost != null ? '$' + usageData.five_hour.total_cost.toFixed(4) : '$0.0000'"></span>
                 </span>
               </template>
               <template x-if="statusLineConfig.turns && currentSession?.max_turns > 0">


### PR DESCRIPTION
## Summary
The status line cost widget now uses the same aggregate cost from the `/api/cost-summary` endpoint instead of client-side accumulated costs.

## Changes
- Status line displays `usageData.five_hour.total_cost` from the API
- Immediately fetches cost summary when switching to a managed session
- Cost data is now consistent between status line and usage widget

## Testing
- Cost displayed in status line updates when new sessions start
- Cost remains accurate when switching between managed sessions