### PR TITLE
fix: wire up turn counter to persist across session switches

### DIFF
--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -304,6 +304,11 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 						mu.Unlock()
 					}
 				}
+				// Increment persisted turn count
+				if newCount, err := s.store.IncrementTurnCount(sessionID); err == nil {
+					turnMsg, _ := json.Marshal(map[string]interface{}{"type": "turn_count", "turn_count": newCount})
+					broadcaster.Send(string(turnMsg))
+				}
 				// Compute and persist turn cost from the result event's usage data
 				cost := extractCostFromResult(line, sess.Model)
 				if cost > 0 {

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -28,12 +28,13 @@ type Session struct {
 	ClaudeSessionID       string  `json:"claude_session_id,omitempty"`
 	MaxContinuations      int     `json:"max_continuations"`
 	ActivityState         string  `json:"activity_state"`
+	TurnCount             int     `json:"turn_count"`
 	Name                  string  `json:"name"`
 	CompactEveryNContinues int    `json:"compact_every_n_continues"`
 	Model                  string `json:"-"`
 }
 
-const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), max_continuations, COALESCE(activity_state,'idle'), COALESCE(name,''), compact_every_n_continues, COALESCE(model,'')`
+const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), max_continuations, COALESCE(activity_state,'idle'), turn_count, COALESCE(name,''), compact_every_n_continues, COALESCE(model,'')`
 
 func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, error) {
 	var sess Session
@@ -43,7 +44,7 @@ func scanSession(scanner interface{ Scan(...interface{}) error }) (Session, erro
 		&sess.Status, &sess.CreatedAt, &sess.LastSeenAt, &archived,
 		&sess.Mode, &sess.CWD, &sess.AllowedTools, &sess.MaxTurns, &sess.MaxBudgetUSD, &initialized,
 		&sess.ClaudeSessionID, &sess.MaxContinuations, &sess.ActivityState,
-		&sess.Name, &sess.CompactEveryNContinues, &sess.Model,
+		&sess.TurnCount, &sess.Name, &sess.CompactEveryNContinues, &sess.Model,
 	)
 	if err != nil {
 		return sess, err
@@ -166,7 +167,7 @@ func (s *Store) ClearSession(id string) error {
 	if _, err := tx.Exec(`UPDATE messages SET cleared_at = datetime('now') WHERE session_id = ? AND cleared_at IS NULL`, id); err != nil {
 		return fmt.Errorf("clear messages: %w", err)
 	}
-	if _, err := tx.Exec(`UPDATE sessions SET claude_session_id = ?, initialized = 0, activity_state = 'idle' WHERE id = ?`, newClaudeSessionID, id); err != nil {
+	if _, err := tx.Exec(`UPDATE sessions SET claude_session_id = ?, initialized = 0, activity_state = 'idle', turn_count = 0 WHERE id = ?`, newClaudeSessionID, id); err != nil {
 		return fmt.Errorf("reset session state: %w", err)
 	}
 	return tx.Commit()
@@ -207,6 +208,17 @@ func (s *Store) SetArchived(id string, archived bool) error {
 
 func (s *Store) SetSessionStatus(id, status string) error {
 	_, err := s.db.Exec("UPDATE sessions SET status = ? WHERE id = ?", status, id)
+	return err
+}
+
+func (s *Store) IncrementTurnCount(id string) (int, error) {
+	var count int
+	err := s.db.QueryRow(`UPDATE sessions SET turn_count = turn_count + 1 WHERE id = ? AND deleted_at IS NULL RETURNING turn_count`, id).Scan(&count)
+	return count, err
+}
+
+func (s *Store) ResetTurnCount(id string) error {
+	_, err := s.db.Exec(`UPDATE sessions SET turn_count = 0 WHERE id = ? AND deleted_at IS NULL`, id)
 	return err
 }
 

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2045,6 +2045,12 @@ document.addEventListener('alpine:init', () => {
             return;
           }
 
+          if (data.type === 'turn_count') {
+            const sess = this.sessions.find(s => s.id === sessionId);
+            if (sess) sess.turn_count = data.turn_count;
+            return;
+          }
+
           if (data.type === 'auto_continuing') {
             this.continuationCount = data.continuation_count || 0;
             this.chatMessages.push({


### PR DESCRIPTION
## Summary
- turn_count column existed in the DB schema but was never read or written by the Go backend, causing the frontend to always show 0/50
- Added IncrementTurnCount/ResetTurnCount DB methods; increment on each Claude result event and broadcast a turn_count SSE event for immediate UI update
- Turn count now persists in the sessions table, so switching between managed sessions preserves each session count; resets only on explicit session clear

## Test plan
- [ ] Create a managed session, send a message, verify turn counter increments from 0
- [ ] Switch to another session and back — verify turn count is preserved
- [ ] Clear a session — verify turn count resets to 0
- [ ] Verify auto-continue increments turn count across continuations