### PR TITLE
fix: reset turn count in UI after /clear command

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1134,6 +1134,8 @@ document.addEventListener('alpine:init', () => {
             } else {
               this.chatMessages = [];
               this.clearAgentInvocations();
+              const sess = this.sessions.find(s => s.id === this.selectedSessionId);
+              if (sess) sess.turn_count = 0;
             }
           } catch (e) {
             this.chatMessages.push({ role: 'system', content: `Clear failed: ${e.message}`, msg_type: 'text', timestamp: new Date().toISOString() });


### PR DESCRIPTION
## Summary
- The `/clear` command correctly resets `turn_count` to 0 in the database, but the frontend never updated its local session object
- The turn display stayed stale (e.g. "4/50") until the next turn completed and an SSE `turn_count` event arrived
- Now resets `sess.turn_count = 0` immediately on successful clear

## Test plan
- [ ] Open a managed session and send a few messages to increment the turn counter
- [ ] Run `/clear` — verify turn display resets to 0/50 immediately