### PR TITLE
feat: clickable HTML file links in chat messages

### DIFF
--- a/server/api/files.go
+++ b/server/api/files.go
@@ -247,8 +247,8 @@ func (s *Server) handleGetFileContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate resolved path is within session CWD
-	if sess.CWD != "" {
+	// Validate resolved path is within session CWD or /tmp/
+	if sess.CWD != "" && !strings.HasPrefix(resolved, os.TempDir()+string(filepath.Separator)) {
 		resolvedCWD, err := filepath.EvalSymlinks(sess.CWD)
 		if err != nil {
 			resolvedCWD = sess.CWD

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -265,6 +265,7 @@ document.addEventListener('alpine:init', () => {
     },
 
     async init() {
+      window._ccOpenFile = (path) => this.openFileViewer(path);
       // Detect Web Speech API support
       this.voiceChatSupported = !!(window.SpeechRecognition || window.webkitSpeechRecognition) && !!window.speechSynthesis;
       // Load status line config from localStorage
@@ -3049,7 +3050,8 @@ Please review this PR and provide feedback.`;
             const titleAttr = t ? ` title="${t}"` : '';
             return `<a href="${h}" target="_blank" rel="noopener noreferrer"${titleAttr}>${tx}</a>`;
           };
-          const html = marked.parse(msg.content || '', { renderer: r, breaks: true });
+          let html = marked.parse(msg.content || '', { renderer: r, breaks: true });
+          html = this.linkifyFilePaths(html);
           const eyebrow = msg.command ? `<div class="command-label">${esc(msg.command)}</div>` : '';
           let optionsHtml = '';
           if (msg.role === 'assistant') {
@@ -3590,6 +3592,15 @@ Please review this PR and provide feedback.`;
         const hrs = Math.floor(mins / 60);
         if (hrs < 24) return hrs + 'h ago';
         return Math.floor(hrs / 24) + 'd ago';
+    },
+
+    linkifyFilePaths(html) {
+      const re = /(<a\s[^>]*>[\s\S]*?<\/a>|<[^>]+>)|(\/(?:tmp|var|Users|home)\/[^\s<"'`,;)}\]]+\.html)\b/g;
+      return html.replace(re, (match, tag, path) => {
+        if (tag) return match;
+        const escaped = path.replace(/'/g, "\\'");
+        return `<a href="#" class="file-link" onclick="event.preventDefault();window._ccOpenFile('${escaped}')">${match}</a>`;
+      });
     },
 
     renderHTMLPreview(content) {

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -416,6 +416,16 @@ body {
   word-break: break-all;
 }
 
+.file-link {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  cursor: pointer;
+}
+.file-link:hover {
+  text-decoration-style: solid;
+}
+
 .diff-block {
   margin-top: 0.375rem;
   font-family: monospace;


### PR DESCRIPTION
## Summary
- Detect `.html` file paths in assistant chat messages (under `/tmp`, `/var`, `/Users`, `/home`) and render them as clickable links
- Clicking a link opens the existing file viewer sidebar with the rendered HTML preview (iframe/srcdoc)
- Allow the `/api/files/content` endpoint to serve files from the OS temp directory so `/tmp` previews work

## Test plan
- [ ] Send a managed session message that mentions `/tmp/test.html` — verify it renders as a clickable link
- [ ] Click the link — verify the file viewer opens with the rendered HTML preview
- [ ] Verify paths inside existing `<a>` tags or HTML attributes are not double-linkified
- [ ] Verify files within the session CWD still work as before
- [ ] Verify files outside both CWD and `/tmp/` are still rejected with 403