### PR TITLE
feat: add Skills section to sidebar between Files and Issues

### DIFF
--- a/server/api/router.go
+++ b/server/api/router.go
@@ -86,6 +86,9 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 	apiMux.HandleFunc("GET /api/files/content", s.handleGetFileContent)
 	apiMux.HandleFunc("GET /api/files/diff", s.handleFileDiff)
 
+	// Skills endpoint
+	apiMux.HandleFunc("GET /api/sessions/{id}/skills", s.handleListSkills)
+
 	// GitHub endpoints
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues", s.handleListGithubIssues)
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues/{number}", s.handleGetGithubIssue)

--- a/server/api/skills.go
+++ b/server/api/skills.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type skillResponse struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Dir         string `json:"dir"` // which directory it came from: "project", "user", or "bb"
+}
+
+// handleListSkills scans known skill directories and returns parsed skill metadata.
+// Directories scanned (in order):
+//   - <session-cwd>/.claude/skills/   (project-level)
+//   - ~/.claude/skills/               (user-level)
+//   - ~/.claud-bb/skills/             (bb-level)
+func (s *Server) handleListSkills(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		jsonError(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	// For managed sessions use CWD; for hook sessions use ProjectPath.
+	cwd := sess.CWD
+	if cwd == "" {
+		cwd = sess.ProjectPath
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+
+	dirs := []struct {
+		path  string
+		label string
+	}{
+		{filepath.Join(cwd, ".claude", "skills"), "project"},
+		{filepath.Join(home, ".claude", "skills"), "user"},
+		{filepath.Join(home, ".claud-bb", "skills"), "bb"},
+	}
+
+	seen := map[string]bool{} // deduplicate by skill name
+	skills := []skillResponse{}
+
+	for _, d := range dirs {
+		entries, err := os.ReadDir(d.path)
+		if err != nil {
+			continue // directory doesn't exist or isn't readable — skip silently
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			skillFile := filepath.Join(d.path, entry.Name(), "SKILL.md")
+			data, err := os.ReadFile(skillFile)
+			if err != nil {
+				continue
+			}
+			name, desc := parseSkillFrontmatter(data)
+			if name == "" {
+				name = entry.Name()
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			skills = append(skills, skillResponse{Name: name, Description: desc, Dir: d.label})
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(skills)
+}
+
+// parseSkillFrontmatter extracts name and description from YAML frontmatter.
+// Frontmatter is delimited by "---" lines. Returns empty strings on any parse error.
+func parseSkillFrontmatter(data []byte) (name, description string) {
+	content := string(data)
+	if !strings.HasPrefix(content, "---") {
+		return
+	}
+	// Find closing ---
+	rest := content[3:]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		return
+	}
+	block := rest[:end]
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if k, v, ok := strings.Cut(line, ":"); ok {
+			k = strings.TrimSpace(k)
+			v = strings.TrimSpace(v)
+			// Strip surrounding quotes if present
+			if len(v) >= 2 && ((v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'')) {
+				v = v[1 : len(v)-1]
+			}
+			switch k {
+			case "name":
+				name = v
+			case "description":
+				description = v
+			}
+		}
+	}
+	return
+}

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -102,6 +102,13 @@ document.addEventListener('alpine:init', () => {
     selectedPull: null,
     selectedPullLoading: false,
     _searchPullsTimer: null,
+
+    // Skills state
+    skills: [],
+    skillsExpanded: false,
+    skillsLoading: false,
+    skillsError: null,
+
     viewerFile: null,
     viewerMode: 'diff',
     viewerDiffs: [],
@@ -984,6 +991,9 @@ document.addEventListener('alpine:init', () => {
         this.githubPullsError = null;
         this.fetchGithubPulls(this.selectedSessionId);
       }
+      this.skills = [];
+      this.skillsError = null;
+      this.fetchSkills(this.selectedSessionId);
       this.focusPromptInput();
     },
 
@@ -2438,6 +2448,34 @@ document.addEventListener('alpine:init', () => {
         console.error('Failed to fetch messages:', e);
       }
       this.chatLoading = false;
+    },
+
+    // Skills methods
+    async fetchSkills(sessionId) {
+      if (!sessionId) return;
+      this.skillsLoading = true;
+      this.skillsError = null;
+      try {
+        const resp = await fetch(`/api/sessions/${sessionId}/skills`, {
+          headers: { 'Authorization': 'Bearer ' + this.apiKey }
+        });
+        if (resp.status === 401) { this.disconnect(); return; }
+        if (!resp.ok) {
+          this.skillsError = 'Failed to load skills';
+          return;
+        }
+        this.skills = await resp.json() || [];
+      } catch (e) {
+        this.skillsError = e.message || 'Failed to load skills';
+      } finally {
+        this.skillsLoading = false;
+      }
+    },
+
+    sendSkill(skillName) {
+      if (!this.selectedSessionId || !skillName) return;
+      this.inputText = '/' + skillName;
+      this.$nextTick(() => this.handleInput());
     },
 
     // GitHub Issues methods

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -673,6 +673,32 @@
           </div>
         </div>
 
+        <!-- Skills Section -->
+        <div class="issues-section" x-show="selectedSessionId">
+          <div class="issues-header" @click="skillsExpanded = !skillsExpanded" style="cursor:pointer">
+            <span class="issues-title">
+              <span class="issues-toggle" x-text="skillsExpanded ? '▼' : '▶'"></span>
+              Skills
+            </span>
+            <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
+          </div>
+          <div x-show="skillsExpanded" x-collapse>
+            <div x-show="skillsLoading" class="issues-loading">Loading...</div>
+            <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
+            <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
+            <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
+              <template x-for="skill in skills" :key="skill.name">
+                <div class="issue-row" @click="sendSkill(skill.name)">
+                  <div class="issue-row-content">
+                    <div class="issue-row-title" x-text="skill.name"></div>
+                    <div class="issue-row-meta" x-show="skill.description" x-text="skill.description"></div>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </div>
+
         <!-- Provider Tab Bar -->
         <div class="provider-tab-bar" x-show="sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
           <button class="provider-tab" :class="{ active: issuesProvider === 'github' }"
@@ -1060,6 +1086,37 @@
         </template>
       </div>
 
+      <!-- Skills Tab -->
+      <div x-show="mobileTab === 'skills'" style="flex:1;overflow-y:auto;padding:8px;">
+        <template x-if="!selectedSessionId">
+          <div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-muted);font-size:14px;">
+            Select a session to view skills
+          </div>
+        </template>
+        <template x-if="selectedSessionId">
+          <div>
+            <div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;">
+              <span style="font-weight:600;font-size:14px;">Skills</span>
+              <span class="file-count-badge" x-show="skills.length > 0" x-text="skills.length"></span>
+              <button class="file-tree-refresh" @click="fetchSkills(selectedSessionId)" title="Refresh">&#8635;</button>
+            </div>
+            <div x-show="skillsLoading" class="issues-loading">Loading...</div>
+            <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
+            <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
+            <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
+              <template x-for="skill in skills" :key="skill.name">
+                <div class="issue-row" @click="mobileMenuOpen=false; sendSkill(skill.name)">
+                  <div class="issue-row-content">
+                    <div class="issue-row-title" x-text="skill.name"></div>
+                    <div class="issue-row-meta" x-show="skill.description" x-text="skill.description"></div>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </template>
+      </div>
+
       <!-- Tasks Tab -->
       <div x-show="mobileTab === 'tasks'" style="flex:1;overflow-y:auto;padding:8px;">
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
@@ -1175,6 +1232,13 @@
           <circle cx="10" cy="10" r="3"/>
         </svg>
         <span>Issues</span>
+      </button>
+      <button class="mobile-tab" :class="{ active: mobileTab === 'skills' }"
+              @click="mobileTab = 'skills'" role="tab" :aria-selected="mobileTab === 'skills'">
+        <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M10 2l1.5 4.5H16l-3.5 2.5 1.5 4.5L10 11l-4 2.5 1.5-4.5L4 6.5h4.5L10 2z"/>
+        </svg>
+        <span>Skills</span>
       </button>
       <button class="mobile-tab" :class="{ active: mobileTab === 'tasks' }"
               @click="mobileTab = 'tasks'" role="tab" :aria-selected="mobileTab === 'tasks'">

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -682,7 +682,7 @@
             </span>
             <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
           </div>
-          <div x-show="skillsExpanded" x-collapse>
+          <div x-show="skillsExpanded" x-collapse style="padding-top:6px">
             <div x-show="skillsLoading" class="issues-loading">Loading...</div>
             <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
             <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
@@ -738,7 +738,7 @@
                       @click="toggleIssueState('closed')">Closed</button>
             </div>
           </div>
-          <div x-show="issuesExpanded" x-collapse>
+          <div x-show="issuesExpanded" x-collapse style="padding-top:6px">
             <input type="text" class="issues-search" placeholder="Search issues..."
                    x-model="githubIssuesSearch"
                    @input="searchIssues()">
@@ -779,7 +779,7 @@
                       @click="togglePullState('closed')">Closed</button>
             </div>
           </div>
-          <div x-show="pullsExpanded" x-collapse>
+          <div x-show="pullsExpanded" x-collapse style="padding-top:6px">
             <input type="text" class="issues-search" placeholder="Search pull requests..."
                    x-model="githubPullsSearch"
                    @input="searchPulls()">

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -688,10 +688,9 @@
             <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
             <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
               <template x-for="skill in skills" :key="skill.name">
-                <div class="issue-row" @click="sendSkill(skill.name)">
+                <div class="issue-row" @click="sendSkill(skill.name)" :title="skill.description || skill.name">
                   <div class="issue-row-content">
                     <div class="issue-row-title" x-text="skill.name"></div>
-                    <div class="issue-row-meta" x-show="skill.description" x-text="skill.description"></div>
                   </div>
                 </div>
               </template>
@@ -1105,10 +1104,9 @@
             <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
             <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
               <template x-for="skill in skills" :key="skill.name">
-                <div class="issue-row" @click="mobileMenuOpen=false; sendSkill(skill.name)">
+                <div class="issue-row" @click="mobileMenuOpen=false; sendSkill(skill.name)" :title="skill.description || skill.name">
                   <div class="issue-row-content">
                     <div class="issue-row-title" x-text="skill.name"></div>
-                    <div class="issue-row-meta" x-show="skill.description" x-text="skill.description"></div>
                   </div>
                 </div>
               </template>

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -673,28 +673,29 @@
           </div>
         </div>
 
-        <!-- Provider Tab Bar -->
-        <div class="provider-tab-bar" x-show="sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
-          <button class="provider-tab" :class="{ active: issuesProvider === 'github' }"
-                  @click="issuesProvider = 'github'" title="GitHub"
-                  x-show="settingsForm.github_token">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-          </button>
-          <button class="provider-tab" :class="{ active: issuesProvider === 'jira' }"
-                  @click="issuesProvider = 'jira'" title="Jira"
-                  x-show="settingsForm.jira_url && settingsForm.jira_token">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M15.09 7.39L8.61.91 8 .3l-5.09 5.1a.5.5 0 000 .7L7.65 10.84a.5.5 0 00.7 0l6.74-6.74a.5.5 0 000-.71zM8 10.13L5.17 7.3 8 4.47l2.83 2.83L8 10.13z" fill="#2684FF"/><path d="M8 4.47a3.93 3.93 0 01-.01-5.56l-5.08 5.1 2.83 2.83L8 4.47z" fill="url(#jira-grad-a)"/><path d="M10.84 7.29L8 10.13a3.93 3.93 0 010 5.56l5.1-5.1-2.84-2.83-.42.53z" fill="url(#jira-grad-b)"/><defs><linearGradient id="jira-grad-a" x1="7.53" y1="2.56" x2="4.28" y2="5.62" gradientUnits="userSpaceOnUse"><stop stop-color="#0052CC" stop-opacity=".4"/><stop offset="1" stop-color="#2684FF"/></linearGradient><linearGradient id="jira-grad-b" x1="8.49" y1="10.05" x2="11.74" y2="6.99" gradientUnits="userSpaceOnUse"><stop stop-color="#0052CC" stop-opacity=".4"/><stop offset="1" stop-color="#2684FF"/></linearGradient></defs></svg>
-          </button>
-          <button class="provider-tab" :class="{ active: issuesProvider === 'asana' }"
-                  @click="issuesProvider = 'asana'" title="Asana"
-                  x-show="settingsForm.asana_token">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="4.5" r="2.8" fill="#F06A6A"/><circle cx="3.5" cy="11.5" r="2.8" fill="#F06A6A"/><circle cx="12.5" cy="11.5" r="2.8" fill="#F06A6A"/></svg>
-          </button>
-          <button class="provider-tab" :class="{ active: issuesProvider === 'google_tasks' }"
-                  @click="issuesProvider = 'google_tasks'" title="Google Tasks"
-                  x-show="settingsForm.google_tasks_token">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="#4285F4" stroke-width="1.5" fill="none"/><path d="M5 8l2 2 4-4" stroke="#4285F4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></svg>
-          </button>
+        <!-- Skills Section -->
+        <div class="issues-section" x-show="selectedSessionId">
+          <div class="issues-header" @click="skillsExpanded = !skillsExpanded" style="cursor:pointer">
+            <span class="issues-title">
+              <span class="issues-toggle" x-text="skillsExpanded ? '▼' : '▶'"></span>
+              Skills
+            </span>
+            <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
+          </div>
+          <div x-show="skillsExpanded" x-collapse style="padding:0 12px 8px 12px">
+            <div x-show="skillsLoading" class="issues-loading">Loading...</div>
+            <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
+            <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
+            <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
+              <template x-for="skill in skills" :key="skill.name">
+                <div class="issue-row" @click="sendSkill(skill.name)" :title="skill.description || skill.name">
+                  <div class="issue-row-content">
+                    <div class="issue-row-title" x-text="skill.name"></div>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
         </div>
 
         <!-- GitHub Issues Section -->
@@ -805,31 +806,6 @@
           </div>
           <div class="provider-placeholder-title">Connected to Google Tasks</div>
           <div class="provider-placeholder-msg">Task browsing coming in a future update</div>
-        </div>
-
-        <!-- Skills Section -->
-        <div class="issues-section" x-show="selectedSessionId">
-          <div class="issues-header" @click="skillsExpanded = !skillsExpanded" style="cursor:pointer">
-            <span class="issues-title">
-              <span class="issues-toggle" x-text="skillsExpanded ? '▼' : '▶'"></span>
-              Skills
-            </span>
-            <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
-          </div>
-          <div x-show="skillsExpanded" x-collapse style="padding:0 12px 8px 12px">
-            <div x-show="skillsLoading" class="issues-loading">Loading...</div>
-            <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
-            <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
-            <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
-              <template x-for="skill in skills" :key="skill.name">
-                <div class="issue-row" @click="sendSkill(skill.name)" :title="skill.description || skill.name">
-                  <div class="issue-row-content">
-                    <div class="issue-row-title" x-text="skill.name"></div>
-                  </div>
-                </div>
-              </template>
-            </div>
-          </div>
         </div>
       </div>
     </div>

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -682,7 +682,7 @@
             </span>
             <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
           </div>
-          <div x-show="skillsExpanded" x-collapse style="padding-top:6px">
+          <div x-show="skillsExpanded" x-collapse style="padding:0 12px 8px 12px">
             <div x-show="skillsLoading" class="issues-loading">Loading...</div>
             <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
             <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -673,31 +673,6 @@
           </div>
         </div>
 
-        <!-- Skills Section -->
-        <div class="issues-section" x-show="selectedSessionId">
-          <div class="issues-header" @click="skillsExpanded = !skillsExpanded" style="cursor:pointer">
-            <span class="issues-title">
-              <span class="issues-toggle" x-text="skillsExpanded ? '▼' : '▶'"></span>
-              Skills
-            </span>
-            <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
-          </div>
-          <div x-show="skillsExpanded" x-collapse style="padding:0 12px 8px 12px">
-            <div x-show="skillsLoading" class="issues-loading">Loading...</div>
-            <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
-            <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
-            <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
-              <template x-for="skill in skills" :key="skill.name">
-                <div class="issue-row" @click="sendSkill(skill.name)" :title="skill.description || skill.name">
-                  <div class="issue-row-content">
-                    <div class="issue-row-title" x-text="skill.name"></div>
-                  </div>
-                </div>
-              </template>
-            </div>
-          </div>
-        </div>
-
         <!-- Provider Tab Bar -->
         <div class="provider-tab-bar" x-show="sessions.find(s => s.id === selectedSessionId)?.mode === 'managed'">
           <button class="provider-tab" :class="{ active: issuesProvider === 'github' }"
@@ -830,6 +805,31 @@
           </div>
           <div class="provider-placeholder-title">Connected to Google Tasks</div>
           <div class="provider-placeholder-msg">Task browsing coming in a future update</div>
+        </div>
+
+        <!-- Skills Section -->
+        <div class="issues-section" x-show="selectedSessionId">
+          <div class="issues-header" @click="skillsExpanded = !skillsExpanded" style="cursor:pointer">
+            <span class="issues-title">
+              <span class="issues-toggle" x-text="skillsExpanded ? '▼' : '▶'"></span>
+              Skills
+            </span>
+            <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
+          </div>
+          <div x-show="skillsExpanded" x-collapse style="padding:0 12px 8px 12px">
+            <div x-show="skillsLoading" class="issues-loading">Loading...</div>
+            <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
+            <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
+            <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
+              <template x-for="skill in skills" :key="skill.name">
+                <div class="issue-row" @click="sendSkill(skill.name)" :title="skill.description || skill.name">
+                  <div class="issue-row-content">
+                    <div class="issue-row-title" x-text="skill.name"></div>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -821,7 +821,7 @@ body {
 .provider-tab-bar {
   display: flex;
   gap: 2px;
-  padding: 6px 12px;
+  padding: 0 12px;
   border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
   background: var(--bg);

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -822,9 +822,6 @@ body {
   display: flex;
   gap: 2px;
   padding: 0 12px;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
 }
 
 .provider-tab {

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -899,7 +899,6 @@ body {
 
 /* GitHub Issues Section */
 .issues-section {
-  padding: 8px 12px;
   border-top: 1px solid var(--border);
 }
 
@@ -908,6 +907,7 @@ body {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 0;
+  padding: 8px 12px;
 }
 
 .issues-title {

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -817,50 +817,6 @@ body {
 .git-clean { color: var(--text-muted); font-size: 11px; }
 .git-clean-text { font-style: italic; }
 
-/* Provider Tab Bar */
-.provider-tab-bar {
-  display: flex;
-  gap: 2px;
-  padding: 0 12px;
-}
-
-.provider-tab {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 28px;
-  border: none;
-  background: transparent;
-  border-radius: 6px;
-  cursor: pointer;
-  color: var(--text-muted);
-  opacity: 0.5;
-  transition: opacity 0.15s, background 0.15s;
-  position: relative;
-}
-
-.provider-tab:hover {
-  opacity: 0.8;
-  background: var(--bg-secondary);
-}
-
-.provider-tab.active {
-  opacity: 1;
-  background: var(--bg-secondary);
-}
-
-.provider-tab.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 4px;
-  right: 4px;
-  height: 2px;
-  background: var(--accent);
-  border-radius: 1px;
-}
-
 /* Provider Placeholder */
 .provider-placeholder {
   display: flex;

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -907,7 +907,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 8px;
+  margin-bottom: 0;
 }
 
 .issues-title {


### PR DESCRIPTION
Closes #170

## Summary

- **`GET /api/sessions/{id}/skills`** — new Go endpoint in `server/api/skills.go` that scans `.claude/skills/`, `~/.claude/skills/`, and `~/.claud-bb/skills/` for `SKILL.md` files, parses YAML frontmatter (`name`, `description`), deduplicates by name (project overrides user, user overrides bb), and returns a JSON array
- **Skills section in right sidebar** — collapsible section between the git status bar and provider tab bar; fetches on session select, renders skill name only with description shown on hover via title attribute; clicking sends `/<name>` to the active session
- **Skills mobile tab** — new tab between Files and Issues with a count badge and refresh button; same click-to-send behavior, closes mobile menu before sending

## Test Plan

- [ ] Expand Skills section in sidebar — should list all skills (name only)
- [ ] Hover over a skill — tooltip shows description
- [ ] Click a skill row — should prefill input with `/<name>` and submit it
- [ ] Refresh button reloads the list
- [ ] Session with no skills directories shows "No skills found" empty state
- [ ] Mobile: Skills tab appears between Files and Issues; same list, hover tooltip, and click behavior
- [ ] Hook-mode sessions show skills (falls back to `ProjectPath` for CWD)