### PR TITLE
Rewrite managed sessions to drive interactive Claude Code instead of claude -p

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,12 @@ gh pr create                               # Open a PR when ready
 - Long-poll: server holds HTTP connection up to 30s, hook retries indefinitely until user responds
 
 ### Managed Mode
-- Each message spawns a separate `claude -p` process; `--resume <uuid>` handles context continuity between turns
+- Two backends selected via `MANAGED_MODE` env: `interactive` (default) and `print` (legacy rollback path; forced on Windows)
+- **Interactive backend** (`server/managed/interactive.go`): one long-lived interactive `claude` process per session under a PTY (`creack/pty`), so usage bills against the Claude Code subscription instead of the API. Prompts injected via bracketed paste; interrupts via ESC keystroke. Structured output comes from tailing the native transcript JSONL in `~/.claude/projects/` (`transcript.go`), forwarded raw to the existing SSE pipeline (shapes match stream-json). Turn lifecycle driven by per-session SessionStart/Stop/Notification hooks injected via a generated `--settings` file (`settings.go`); the hook command is the `claude-controller hook-signal` subcommand, which POSTs to `/api/sessions/{id}/hook-event`
+- Interactive feature parity: `--allowedTools` → `permissions.allow` in the generated settings file; turn limits → server counts assistant transcript entries and sends ESC; budget caps → server sums per-turn cost from transcript usage (`SessionCostTotal`). Known gaps: permission prompts for non-allowlisted tools surface only as notifications (no remote approve/deny), and images are referenced by file path in the prompt instead of inline
+- **Print backend** (legacy): each message uses a warm `claude -p --input-format stream-json` process; `--resume <uuid>` handles context continuity between turns; tool restrictions via `--allowedTools`, turn limits via `--max-turns`, budget caps via `--max-budget-usd`
 - Sessions have a `mode` field (`"hook"` or `"managed"`) — both coexist in the same database
-- NDJSON streaming from stdout → SSE to browser; messages persisted to `messages` table
-- Tool restrictions via `--allowedTools`, turn limits via server-side SIGINT, budget caps via `--max-budget-usd`
+- NDJSON/transcript streaming → SSE to browser; messages persisted to `messages` table
 - `/resume` command reads Claude Code's native `sessions-index.json` to let users continue previous CLI sessions in the web UI
 - `claude_session_id` field decouples the managed session's stable ID from the CLI session being resumed
 - `activity_state` field tracks session lifecycle: `working` (process running), `waiting` (process exited cleanly, awaiting input), `idle` (no process, error, or new session). Updated server-side at process start/exit. Frontend shows yellow pulsing dot (working), green dot (waiting), gray dot (idle). On server startup, stale `working` states are reset to `idle`.
@@ -95,3 +97,4 @@ gh pr create                               # Open a PR when ready
 - Status line plan: `docs/superpowers/plans/2026-04-19-status-line.md`
 - Model selection spec: `docs/superpowers/specs/2026-04-22-model-selection-design.md`
 - Model selection plan: `docs/superpowers/plans/2026-04-22-model-selection.md`
+- Interactive managed sessions plan: `docs/superpowers/plans/2026-06-11-interactive-managed-sessions.md`

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@
 PORT ?= 9999
 CLAUDE_DIR ?= ~/.claude
 
+# Managed session backend: "interactive" (long-lived interactive Claude Code,
+# billed via subscription) or "print" (legacy per-message claude -p, billed
+# via API). Toggle per-run: `make local MANAGED_MODE=print`. A MANAGED_MODE
+# line in .env also works (command line wins). See docs/managed-modes.md.
+MANAGED_MODE ?= interactive
+
 # Platform detection — sets EXE suffix, delete command, and null redirect
 ifeq ($(OS),Windows_NT)
   EXE      := .exe
@@ -105,8 +111,8 @@ test-db: ## Run database layer tests only
 test-api: ## Run API handler tests only
 	cd server && go test ./api/ -v
 
-run: build ## Build and run the server locally (web UI at http://localhost:PORT)
-	$(SERVER_BIN) --port $(PORT)
+run: build ## Build and run the server locally (web UI at http://localhost:PORT; MANAGED_MODE=interactive|print)
+	$(SERVER_BIN) --port $(PORT) --managed-mode $(MANAGED_MODE)
 
 #local: ## Stop everything, rebuild, and start fresh
 #ifeq ($(OS),Windows_NT)
@@ -120,7 +126,7 @@ run: build ## Build and run the server locally (web UI at http://localhost:PORT)
 #	cd server && go build -o claude-controller$(EXE) .
 #	$(SERVER_BIN) --port $(PORT)
 
-local: ## Stop everything, rebuild, start fresh
+local: ## Stop everything, rebuild, start fresh (make local MANAGED_MODE=print for legacy claude -p backend)
 local: stop build run
 
 stop: ## Stop the running Go server process

--- a/README.md
+++ b/README.md
@@ -105,15 +105,21 @@ Open the Claude Controller app on your iPhone and scan the QR code displayed in 
 
 1. Create a session in the web UI — pick a working directory and configure tool permissions
 2. Type a message in the chat interface
-3. The server spawns `claude -p "<message>" --session-id <uuid> --output-format stream-json`
-4. NDJSON output streams to the browser in real-time via SSE
-5. When Claude finishes, type another message — the server uses `--resume <uuid>` to continue the conversation
-6. Hit **Stop** to interrupt mid-turn (sends SIGINT); the session can resume on the next message
+3. The server drives a Claude Code process for the session and streams output to the browser in real-time via SSE
+4. When Claude finishes, type another message to continue the conversation
+5. Hit **Stop** to interrupt mid-turn; the session can resume on the next message
 
-**Key capabilities:**
+Managed sessions run on one of **two backends** — see **[docs/managed-modes.md](docs/managed-modes.md)** for the full comparison, toggle instructions, and troubleshooting:
+
+- **`interactive`** (default) — one long-lived interactive `claude` process per session under a PTY, with turn lifecycle driven by Claude Code hooks and output streamed from the native transcript. Usage bills against your **Claude Code subscription**.
+- **`print`** (legacy) — a warm `claude -p --output-format stream-json` process per session. Usage bills against the **Anthropic API**. Kept as a rollback path; always used on Windows.
+
+Toggle with `make local MANAGED_MODE=print`, a `MANAGED_MODE=print` line in `.env`, or the `--managed-mode` flag.
+
+**Key capabilities (both backends):**
 - **Tool restrictions** — each session has an allowed-tools list (e.g., read-only: `Read,Glob,Grep`)
-- **Turn limiting** — server counts assistant turns and sends SIGINT when the limit is hit
-- **Budget caps** — `--max-budget-usd` passed to the CLI for cost control
+- **Turn limiting** — the server interrupts Claude when the per-message turn limit is hit, with optional auto-continue
+- **Budget caps** — per-session USD limits for cost control
 - **Session resumption** — type `/resume` in the chat to pick up a previous Claude Code CLI session (see below)
 - **Session names** — assign custom names to sessions for easier identification (see below)
 

--- a/docs/managed-modes.md
+++ b/docs/managed-modes.md
@@ -1,0 +1,110 @@
+# Managed Session Backends: Interactive vs Print
+
+Managed sessions (the chat interface in the web UI / iOS app) can run on one of
+two backends. Both produce the same user experience — same chat UI, same SSE
+streaming, same session lifecycle — but they drive Claude Code very differently
+and **bill differently**.
+
+| | `interactive` (default) | `print` (legacy) |
+|---|---|---|
+| Process model | One long-lived interactive `claude` per session, under a PTY | Warm `claude -p --input-format stream-json` process per session |
+| Billing | Claude Code **subscription** | Anthropic **API** (metered) |
+| Output source | Tails the native transcript JSONL in `~/.claude/projects/` | Parses NDJSON from the process's stdout |
+| Turn boundaries | Stop hook fires → server ends the turn | `result` event on stdout |
+| Tool restrictions | `permissions.allow` in a generated per-session settings file | `--allowedTools` CLI flag |
+| Turn limits | Server counts assistant transcript entries, sends ESC | `--max-turns` CLI flag |
+| Budget caps | Server sums per-turn cost from transcript usage | `--max-budget-usd` CLI flag |
+| Interrupt | ESC keystroke to the PTY (process survives) | SIGINT to the process |
+| Permission prompts | Notification hook surfaces the prompt text (no remote approve/deny) | MCP bridge (`--permission-prompt-tool`) with approve/deny in the UI |
+| Images | Saved to disk, referenced by path in the prompt | Inline base64 via stream-json |
+| Platforms | macOS / Linux | All (forced on Windows — no ConPTY support yet) |
+
+> **Why two backends?** Pricing changes bill `claude -p` (headless) usage
+> against the Anthropic API instead of the Claude Code subscription. The
+> interactive backend keeps managed sessions on subscription billing. The
+> print backend is kept for one release as a rollback path (issue #174).
+
+## Choosing a mode
+
+Precedence: `--managed-mode` CLI flag > `MANAGED_MODE` environment variable
+(including `.env`) > default (`interactive`).
+
+```bash
+# Default — interactive backend
+make local
+
+# One-off run on the legacy claude -p backend
+make local MANAGED_MODE=print
+
+# Persistent choice — add to .env (the make command line still wins)
+echo "MANAGED_MODE=print" >> .env
+
+# Running the binary directly
+./server/claude-controller --port 9999 --managed-mode print
+MANAGED_MODE=print go run .   # from server/
+```
+
+On startup the mode is fixed for the server's lifetime; restart to switch.
+Existing sessions work in either mode — the session data (messages, turn
+counts, budget spend) is shared, only the process driving Claude changes.
+
+## How the interactive backend works
+
+1. **Spawn** — the first message to a session starts `claude --session-id <id>`
+   (or `--resume <claude-session-id>` for resumed sessions) under a
+   pseudo-terminal (`creack/pty`), with `--settings` pointing at a generated
+   per-session settings file in `~/.claude-controller/sessions/<id>/`.
+2. **Hooks** — that settings file injects three hooks that run the
+   `claude-controller hook-signal` subcommand, which POSTs back to the server
+   (`POST /api/sessions/{id}/hook-event`):
+   - **SessionStart** reports the real CLI session ID and transcript path
+     (interactive `--resume` forks to a *new* session ID, so this can't be
+     computed up front).
+   - **Stop** signals turn completion — the server synthesizes the
+     `result`/`done` SSE events and flips `activity_state` to `waiting`.
+   - **Notification** relays permission prompts and other notices to the UI.
+3. **Streaming** — the server tails the transcript JSONL and forwards raw
+   lines to the existing SSE pipeline. Transcript entries have the same shape
+   as stream-json events, so frontends are unchanged. Entries older than the
+   process spawn are filtered (no history replay on resume).
+4. **Prompts** — messages are typed into the PTY using bracketed paste
+   (multi-line safe) followed by Enter. `/compact` and other slash commands
+   are typed the same way.
+5. **Enforcement** — turn limits interrupt with ESC and feed the existing
+   auto-continue flow; budget caps compare `SUM(cost)` from transcript usage
+   against the session's `max_budget_usd` and pause the session when exceeded.
+
+## How the print backend works
+
+Each session keeps a warm `claude -p --output-format stream-json
+--input-format stream-json` process. Messages are written to its stdin as
+stream-json user turns; NDJSON events stream from stdout to the SSE pipeline.
+Restrictions travel as CLI flags (`--allowedTools`, `--max-turns`,
+`--max-budget-usd`), and permission prompts route through an MCP bridge to the
+web UI.
+
+## Known gaps in interactive mode
+
+- **Permission prompts**: tools outside the session's allowlist trigger an
+  in-terminal prompt that can't be answered remotely. The Notification hook
+  surfaces the prompt text in the chat; either add the tool to the session's
+  allowed tools or interrupt the turn. (Print mode supports remote
+  approve/deny via the MCP bridge.)
+- **Images** are referenced by file path in the prompt rather than attached
+  inline; Claude reads them with the Read tool.
+- **Model changes** mid-session apply on the next process spawn, not the
+  current one (the long-lived process pins its `--model` at startup).
+- **Windows** always uses print mode until ConPTY support lands.
+
+## Troubleshooting
+
+- **Session stuck in "working"**: the Stop hook may have failed to reach the
+  server. Check that `~/.claude-controller/api.key` exists and the server port
+  matches what the hook command in
+  `~/.claude-controller/sessions/<id>/settings.json` was generated with. A
+  server restart resets stale states.
+- **No streamed output**: the transcript tailer starts when the SessionStart
+  hook reports the transcript path; if hooks never fire, the server falls back
+  to the computed path after 30 seconds. Look for `tailing transcript` lines
+  in the server log.
+- **Need the old behavior back**: `make local MANAGED_MODE=print`.

--- a/docs/superpowers/plans/2026-06-11-interactive-managed-sessions.md
+++ b/docs/superpowers/plans/2026-06-11-interactive-managed-sessions.md
@@ -1,0 +1,570 @@
+# Interactive Managed Sessions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite managed mode to drive a long-lived **interactive** Claude Code process per session (PTY + hooks + transcript tailing) instead of `claude -p`, so usage bills against the Claude Code subscription (issue #174).
+
+**Architecture:** One interactive `claude` process per managed session, spawned under a PTY (`creack/pty`). Prompts are injected via bracketed-paste writes to the PTY. Structured output comes from tailing Claude Code's native transcript JSONL in `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` (same shapes as stream-json assistant events, so the existing SSE pipeline and frontends keep working). Turn lifecycle (working → waiting) is driven by per-session Stop/SessionStart/Notification hooks injected via a generated `--settings` file; the hook command is a new `claude-controller hook-signal` subcommand that POSTs back to the server. The legacy `claude -p` path stays intact behind `MANAGED_MODE=print` for one release (rollback), and is the forced mode on Windows (no ConPTY in v1).
+
+**Tech Stack:** Go 1.26, `github.com/creack/pty`, SQLite, Alpine.js web UI.
+
+---
+
+## Design notes (read first)
+
+### Why hooks, not terminal output
+PTY output is ANSI TUI rendering — unparseable. We **discard** PTY output (small ring buffer kept for error reporting) and use:
+- **SessionStart hook** → tells the server the real `session_id` + `transcript_path` (critical: interactive `--resume` forks to a *new* session ID/file).
+- **Stop hook** → turn completed → synthesize `result` + `done` SSE events, set `activity_state=waiting`.
+- **Notification hook** → e.g. permission prompts → broadcast SSE `notification` event.
+
+### Event-shape preservation
+Transcript JSONL lines are `{"type":"assistant","message":{...},"timestamp":...,"isSidechain":...}` — same shape the web UI/iOS already parse from stream-json. We forward raw lines (tolerant passthrough per issue risk note), filtering:
+- `isSidechain: true` → skip
+- `type:"user"` with plain-text content (echo of our own prompt) → skip; tool_result-bearing user entries forward as-is
+- entries with `timestamp` older than process spawn → skip (avoids replaying history on resume-fork)
+- types other than user/assistant → skip broadcast
+
+At turn end the server synthesizes `{"type":"result","subtype":"success","usage":{...},"cost":...,"model":...}` and `{"type":"done","exit_code":0}` so existing frontend done/cost handling is untouched.
+
+### Feature-parity mapping (issue task 5)
+| `-p` feature | Interactive replacement |
+|---|---|
+| `--allowedTools` | `permissions.allow` in generated per-session settings file |
+| `--max-turns` + auto-continue | Server counts assistant transcript entries per turn; ≥ MaxTurns → write ESC to PTY → treat as `error_max_turns` → existing auto-continue logic |
+| `--max-budget-usd` | Server sums per-turn cost (from transcript `message.usage`) into existing `cost` messages; total > budget → ESC + `budget_exceeded` event + refuse new sends |
+| `--permission-prompt-tool` (MCP bridge) | **GAP (documented):** interactive mode cannot route permission prompts to the web UI. Mitigation: allowlisted tools never prompt; Notification hook surfaces the prompt text in the UI. |
+| stdin stream-json images | **GAP (documented):** images are saved to disk (existing upload flow) and referenced by path in the prompt text ("Read the image at <path>"). |
+| SIGINT interrupt | ESC keystroke to PTY (graceful turn interrupt; process survives) |
+| `/compact` via stdin turn | type `/compact\r` into the PTY; wait for Stop hook or timeout |
+
+### Process/state model
+- `Manager` gets a second map `iprocs map[string]*InteractiveProc`. Existing `procs` map keeps shell one-shots (and legacy print mode). `IsRunning` keeps its current meaning (shell guard unaffected — the long-lived interactive proc must NOT block shell commands).
+- Per-session hook routing lives in the Manager: `SignalSessionStart` (starts transcript tailer), `SignalStop` (forwards to per-session `stopCh`), notifications handled at the API layer.
+- Settings/MCP temp files live under `~/.claude-controller/sessions/<id>/`.
+- Reaper: interactive procs idle > timeout get graceful shutdown (`/exit` typed, then kill).
+
+---
+
+### Task 1: Dependency + transcript tailer
+
+**Files:**
+- Modify: `server/go.mod` (via `go get`)
+- Create: `server/managed/transcript.go`
+- Test: `server/managed/transcript_test.go`
+
+- [ ] **Step 1:** `cd server && go get github.com/creack/pty@v1.1.24`
+- [ ] **Step 2: Write failing tests**
+
+```go
+// transcript_test.go
+package managed
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func collectLines(t *testing.T, path string, offset int64, dur time.Duration) []string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), dur)
+	defer cancel()
+	var mu sync.Mutex
+	var got []string
+	done := make(chan struct{})
+	go func() {
+		TailTranscript(ctx, path, offset, func(line string) {
+			mu.Lock()
+			got = append(got, line)
+			mu.Unlock()
+		})
+		close(done)
+	}()
+	<-done
+	mu.Lock()
+	defer mu.Unlock()
+	return got
+}
+
+func TestTailTranscriptReadsAppendedLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	os.WriteFile(path, []byte("{\"a\":1}\n"), 0644)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+		f.WriteString("{\"b\":2}\n")
+		f.Close()
+	}()
+	got := collectLines(t, path, 0, 700*time.Millisecond)
+	if len(got) != 2 || got[0] != `{"a":1}` || got[1] != `{"b":2}` {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestTailTranscriptWaitsForFileToExist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "later.jsonl")
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		os.WriteFile(path, []byte("{\"x\":1}\n"), 0644)
+	}()
+	got := collectLines(t, path, 0, 700*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 line, got %v", got)
+	}
+}
+
+func TestTailTranscriptRespectsOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	content := "{\"old\":1}\n"
+	os.WriteFile(path, []byte(content), 0644)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+		f.WriteString("{\"new\":2}\n")
+		f.Close()
+	}()
+	got := collectLines(t, path, int64(len(content)), 600*time.Millisecond)
+	if len(got) != 1 || got[0] != `{"new":2}` {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestTailTranscriptHandlesPartialLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	os.WriteFile(path, []byte(`{"par`), 0644)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+		f.WriteString("tial\":1}\n")
+		f.Close()
+	}()
+	got := collectLines(t, path, 0, 700*time.Millisecond)
+	if len(got) != 1 || got[0] != `{"partial":1}` {
+		t.Fatalf("got %v", got)
+	}
+}
+```
+
+- [ ] **Step 3:** Run `go test ./managed/ -run TestTailTranscript -v` — expect FAIL (undefined: TailTranscript)
+- [ ] **Step 4: Implement**
+
+```go
+// transcript.go
+package managed
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"time"
+)
+
+// TranscriptPollInterval controls tail polling frequency. Overridden in tests.
+var TranscriptPollInterval = 200 * time.Millisecond
+
+// TailTranscript polls path for appended JSONL lines starting at offset and
+// calls emit for each complete line (without trailing newline). Tolerates the
+// file not existing yet, and resets to the start if the file shrinks
+// (truncate/recreate). Returns when ctx is done.
+func TailTranscript(ctx context.Context, path string, offset int64, emit func(string)) {
+	var partial bytes.Buffer
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(TranscriptPollInterval):
+		}
+
+		fi, err := os.Stat(path)
+		if err != nil {
+			continue // file doesn't exist yet
+		}
+		if fi.Size() < offset {
+			offset = 0 // truncated/recreated
+			partial.Reset()
+		}
+		if fi.Size() == offset {
+			continue
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			f.Close()
+			continue
+		}
+		data, err := io.ReadAll(f)
+		f.Close()
+		if err != nil {
+			continue
+		}
+		offset += int64(len(data))
+		partial.Write(data)
+
+		for {
+			idx := bytes.IndexByte(partial.Bytes(), '\n')
+			if idx < 0 {
+				break
+			}
+			line := string(partial.Next(idx + 1)[:idx])
+			if line != "" {
+				emit(line)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 5:** Run tests → PASS. (Set `TranscriptPollInterval = 20ms` in tests via TestMain or per-test if flaky.)
+- [ ] **Step 6:** Commit: `feat(managed): transcript JSONL tailer for interactive sessions`
+
+---
+
+### Task 2: Per-session settings file (hooks + permissions parity)
+
+**Files:**
+- Create: `server/managed/settings.go`
+- Test: `server/managed/settings_test.go`
+
+- [ ] **Step 1: Failing tests** — `WriteSessionSettings(dir, binaryPath, sessionID string, port int, allowedToolsJSON string) (string, error)` writes `<dir>/settings.json` containing SessionStart/Stop/Notification hooks invoking `<binaryPath> hook-signal --event <ev> --session-id <id> --port <port>` and `permissions.allow` parsed from the session's allowed_tools JSON array. Assert JSON unmarshals, hook commands contain quoted binary path and event names, allow list matches.
+- [ ] **Step 2: Implement**
+
+```go
+// settings.go
+package managed
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type hookCmd struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+type hookMatcher struct {
+	Hooks []hookCmd `json:"hooks"`
+}
+
+// WriteSessionSettings generates a Claude Code settings file for a managed
+// interactive session: turn-lifecycle hooks pointing back at the controller
+// server, plus permission allow rules mapped from the session's allowed tools.
+func WriteSessionSettings(dir, binaryPath, sessionID string, port int, allowedToolsJSON string) (string, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	mk := func(event string) []hookMatcher {
+		cmd := fmt.Sprintf("%q hook-signal --event %s --session-id %s --port %d", binaryPath, event, sessionID, port)
+		return []hookMatcher{{Hooks: []hookCmd{{Type: "command", Command: cmd}}}}
+	}
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": mk("session_start"),
+			"Stop":         mk("stop"),
+			"Notification": mk("notification"),
+		},
+	}
+	var tools []string
+	if allowedToolsJSON != "" {
+		_ = json.Unmarshal([]byte(allowedToolsJSON), &tools)
+	}
+	if len(tools) > 0 {
+		settings["permissions"] = map[string]any{"allow": tools}
+	}
+	path := filepath.Join(dir, "settings.json")
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// SessionDir returns the per-session scratch directory for generated files.
+func SessionDir(sessionID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "claude-controller", sessionID)
+	}
+	return filepath.Join(home, ".claude-controller", "sessions", sessionID)
+}
+```
+
+- [ ] **Step 3:** Tests pass; commit `feat(managed): per-session settings generator (hooks + permission parity)`
+
+---
+
+### Task 3: Interactive PTY process lifecycle
+
+**Files:**
+- Create: `server/managed/pty_unix.go` (`//go:build !windows`) — `func startPTY(cmd *exec.Cmd) (*os.File, error)` using `pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 200})`
+- Create: `server/managed/pty_windows.go` (`//go:build windows`) — returns `ErrInteractiveUnsupported`
+- Create: `server/managed/interactive.go`
+- Test: `server/managed/interactive_test.go`
+
+**Key API:**
+
+```go
+var ErrInteractiveUnsupported = errors.New("interactive managed mode is not supported on this platform; set MANAGED_MODE=print")
+
+type InteractiveOpts struct {
+	Args             []string // full claude args (no -p)
+	CWD              string
+	OnTranscriptLine func(line string) // called for each raw transcript line
+}
+
+type InteractiveProc struct {
+	Cmd          *exec.Cmd
+	PTY          *os.File
+	Done         chan struct{}
+	ExitCode     int
+	LastActivity time.Time
+	SpawnedAt    time.Time
+
+	mu             sync.Mutex
+	transcriptPath string
+	tailCancel     context.CancelFunc
+	stopCh         chan struct{} // buffered(4); signaled on Stop hook
+	lastOutput     *ringBuffer   // last ~8KB of PTY output for error reporting
+}
+```
+
+Manager additions (all on `*Manager`, `iprocs map[string]*InteractiveProc` guarded by `m.mu`, initialized in `NewManager`):
+- `EnsureInteractive(sessionID string, opts InteractiveOpts) (*InteractiveProc, error)` — returns existing or spawns: `exec.Command(cfg.ClaudeBin, append(cfg.ClaudeArgs, opts.Args...)...)`, `cmd.Dir = opts.CWD`, env = `os.Environ()` + `cfg.ClaudeEnv` + `CLAUDE_CONTROLLER_MANAGED=1` + `TERM=xterm-256color`; `startPTY(cmd)`; goroutine drains PTY into ring buffer; goroutine `cmd.Wait()` → set ExitCode, cancel tailer, remove from `iprocs`, `close(Done)`.
+- `IsInteractiveRunning(sessionID string) bool`
+- `SendPrompt(sessionID, text string) error` — bracketed paste: write `"\x1b[200~" + text + "\x1b[201~"` then `"\r"` (two writes, 50ms apart, so the TUI registers paste before submit). Updates LastActivity.
+- `SendKeys(sessionID, seq string) error` — raw PTY write (ESC = `"\x1b"`).
+- `InterruptInteractive(sessionID string) error` — `SendKeys(sessionID, "\x1b")`.
+- `SetTranscript(sessionID, path string) ` — if no tailer yet and proc alive: record path, `offset = current file size`, start `TailTranscript` goroutine with ctx cancelled on proc death; emit filter: parse `{"timestamp":...}` and drop entries with timestamp < SpawnedAt−5s, then call `opts.OnTranscriptLine`.
+- `SignalStop(sessionID string)` — non-blocking send on `stopCh`.
+- `StopEvents(sessionID string) <-chan struct{}` — returns proc's stopCh (nil-safe).
+- `ShutdownInteractive(sessionID string, timeout time.Duration) error` — type `/exit\r`; wait Done or timeout → `cmd.Process.Kill()`.
+- Wire into `ShutdownAll` and `ReapIdle` (interactive procs idle > maxIdle → `ShutdownInteractive(id, 10*time.Second)`).
+- `Teardown` also tears down interactive procs (used by /clear and /resume).
+
+**Tests** (use `/bin/cat` or a stub shell script as fake claude — PTY echo loopback):
+- `TestEnsureInteractiveSpawnsOnce` — two calls return same proc.
+- `TestSendPromptWritesBracketedPaste` — spawn `cat` under PTY, SendPrompt("hello"), read PTY master, assert output contains `\x1b[200~hello\x1b[201~`.
+- `TestSignalStopDelivers` — SignalStop then receive on StopEvents.
+- `TestSetTranscriptStartsTailer` — temp JSONL file, SetTranscript, append line with current timestamp, assert OnTranscriptLine receives it; append line with old timestamp, assert filtered.
+- `TestShutdownInteractiveKillsAfterTimeout` — spawn `sleep 60` stub, shutdown with 100ms timeout, assert Done closes.
+
+- [ ] Write failing tests → implement → `go test ./managed/ -v` → commit `feat(managed): interactive PTY process lifecycle`
+
+---
+
+### Task 4: `hook-signal` subcommand
+
+**Files:**
+- Create: `server/hooksignal/hooksignal.go`
+- Test: `server/hooksignal/hooksignal_test.go`
+- Modify: `server/main.go` (subcommand dispatch, next to `mcp-bridge`)
+
+Behavior: read hook JSON from stdin (`{"hook_event_name":..., "session_id":..., "transcript_path":..., "message":...}`), POST to `http://localhost:<port>/api/sessions/<managed-id>/hook-event` with body `{"event":<flag>,"claude_session_id":...,"transcript_path":...,"message":...}` and `Authorization: Bearer <key>` where key is read from `~/.claude-controller/api.key` (flag `--key-file` overrides; env `CLAUDE_CONTROLLER_KEY_FILE` also honored). **Always exit 0** and print nothing on stdout errors — a broken hook must never block Claude. 3s HTTP timeout.
+
+```go
+package hooksignal
+
+func Run(event, sessionID string, port int, keyFile string, stdin io.Reader) error
+```
+
+main.go dispatch:
+
+```go
+if len(os.Args) >= 2 && os.Args[1] == "hook-signal" {
+	fs := flag.NewFlagSet("hook-signal", flag.ExitOnError)
+	event := fs.String("event", "", "hook event name")
+	sessionID := fs.String("session-id", "", "managed session ID")
+	port := fs.Int("port", 8080, "server port")
+	keyFile := fs.String("key-file", "", "path to api.key (default ~/.claude-controller/api.key)")
+	fs.Parse(os.Args[2:])
+	hooksignal.Run(*event, *sessionID, *port, *keyFile, os.Stdin) // errors intentionally ignored
+	return
+}
+```
+
+Tests: httptest server asserting method/path/auth-header/body; missing key file → no panic, returns error; malformed stdin → still POSTs with empty fields.
+
+- [ ] TDD cycle → commit `feat: hook-signal subcommand relays Claude hooks to the server`
+
+---
+
+### Task 5: hook-event API endpoint
+
+**Files:**
+- Create: `server/api/hook_event.go`
+- Test: `server/api/hook_event_test.go`
+- Modify: `server/api/router.go` (+1 route), `server/api/interfaces.go`, `server/api/mock_manager_test.go`
+
+Route: `apiMux.HandleFunc("POST /api/sessions/{id}/hook-event", s.handleHookEvent)` (authed — hook-signal sends the bearer key).
+
+```go
+func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	var req struct {
+		Event           string `json:"event"`
+		ClaudeSessionID string `json:"claude_session_id"`
+		TranscriptPath  string `json:"transcript_path"`
+		Message         string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil || sess.Mode != "managed" {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	switch req.Event {
+	case "session_start":
+		if req.ClaudeSessionID != "" && req.ClaudeSessionID != sess.ClaudeSessionID {
+			_ = s.store.UpdateClaudeSessionID(sessionID, req.ClaudeSessionID)
+		}
+		if req.TranscriptPath != "" {
+			s.manager.SetTranscript(sessionID, req.TranscriptPath)
+		}
+	case "stop":
+		s.manager.SignalStop(sessionID)
+	case "notification":
+		evt, _ := json.Marshal(map[string]string{"type": "notification", "message": req.Message})
+		s.manager.GetBroadcaster(sessionID).Send(string(evt))
+		if req.Message != "" {
+			_, _ = s.store.CreateMessage(sessionID, "system", req.Message, 0)
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("{}"))
+}
+```
+
+Interface additions to `SessionManager`: `EnsureInteractive`, `IsInteractiveRunning`, `SendPrompt`, `SendKeys`, `InterruptInteractive`, `SetTranscript`, `SignalStop`, `StopEvents`, `ShutdownInteractive`. Add no-op/recording impls to the mock.
+
+DB: add `UpdateClaudeSessionID(id, claudeID string) error` to `server/db/sessions.go` (simple UPDATE) + test. Also add `SessionCostTotal(sessionID string) (float64, error)` in `server/db/messages.go` (`SELECT COALESCE(SUM(cost),0) FROM messages WHERE session_id = ? AND role = 'cost'`) + test — used by budget enforcement.
+
+- [ ] TDD cycle → commit `feat(api): hook-event endpoint drives interactive turn lifecycle`
+
+---
+
+### Task 6: Interactive send-message orchestrator + mode dispatch
+
+**Files:**
+- Create: `server/api/managed_interactive.go`
+- Test: `server/api/managed_interactive_test.go`
+- Modify: `server/api/managed_sessions.go` (`handleSendMessage` dispatch + `handleInterrupt`)
+
+**Dispatch:** at the top of the existing goroutine setup in `handleSendMessage`, after validation/persistence of the user message:
+
+```go
+if s.manager.Config().Mode == "interactive" {
+	s.sendMessageInteractive(sess, req.Message, req.Model, imagePaths)
+	// (writes the same {"status":"started"} response)
+	return
+}
+// ... existing print-mode flow unchanged ...
+```
+
+(For images: collect `imagePaths` — absolute paths of uploaded files — instead of base64; interactive prompt appends `\n\n[Attached image: <path>] — use the Read tool to view it.` per image.)
+
+**`sendMessageInteractive` flow (async goroutine, mirrors print-mode structure):**
+
+1. Stale-state guard already handled by caller. Set `activity_state=working`, broadcast `model_selected` (model only applied at spawn; same semantics as print mode warm process).
+2. Build args: `--session-id <id>` (new) or `--resume <claude-session-id>` (initialized), `--model`, `--settings <WriteSessionSettings(SessionDir(id), cfg.BinaryPath, id, cfg.ServerPort, sess.AllowedTools)>`.
+3. `OnTranscriptLine` closure (registered once at spawn): tolerant parse; skip sidechain/plain-text-user/non-chat types; forward raw line via broadcaster; persist via existing `extractAssistantText`/`extractToolNames`/`extractSessionFiles`; accumulate per-turn `assistantCount` and `usage` (input/output tokens from `message.usage`) under a mutex; if `assistantCount >= sess.MaxTurns` → `InterruptInteractive` once + set `hitMaxTurns`.
+4. `EnsureInteractive` → on spawn the SessionStart hook will call SetTranscript (tailer starts). Fallback: if no transcript after 30s, compute the path locally from `claudeProjectsDir(sess.CWD)` + resumeID and call SetTranscript ourselves.
+5. `SendPrompt(sessionID, message)`.
+6. `select` on: `StopEvents` (turn done), `proc.Done` (crash → state idle, broadcast stderr ring buffer + done), and — after an ESC interrupt — a 10s fallback timer (Stop hook may not fire on interrupt).
+7. On turn end: increment turn count (existing store call + SSE `turn_count`), compute cost via `calcCost(model, usage)` → persist `cost` message → broadcast synthesized enriched `result` then `done`. Budget check: `SessionCostTotal > sess.MaxBudgetUSD` → broadcast `{"type":"budget_exceeded",...}` + system message + state `waiting` + return.
+8. Auto-continue: same rules as print mode (`hitMaxTurns` required; progress guard `assistantCount >= 2`; `MaxContinuations`; `CompactEveryNContinues` → `SendPrompt("/compact")` + wait stop/5-min timeout + `compacting`/`compact_complete` events). Continuation message identical. Process stays alive between turns; state `waiting` whenever we return without auto-continuing.
+
+**`handleInterrupt`:** if `s.manager.IsInteractiveRunning(id)` → `InterruptInteractive(id)`; else existing `Interrupt(id)`.
+
+**Tests** (mock manager): stop signal → state waiting + result/done broadcast; budget exceeded → budget_exceeded event; max-turns transcript lines → InterruptInteractive called + auto-continue SendPrompt; interrupt endpoint routes to InterruptInteractive when interactive proc running.
+
+- [ ] TDD cycle → commit `feat(api): interactive-mode send orchestrator with hook-driven turns`
+
+---
+
+### Task 7: Config flag, main.go, Windows fallback
+
+**Files:**
+- Modify: `server/managed/manager.go` (`Config.Mode string`)
+- Modify: `server/main.go`
+
+```go
+managedCfg := managed.Config{
+	...,
+	Mode: managedMode(), // helper below
+}
+
+func managedMode() string {
+	mode := envOrDefault("MANAGED_MODE", "interactive")
+	if runtime.GOOS == "windows" && mode == "interactive" {
+		log.Printf("interactive managed mode is not supported on Windows yet; falling back to print mode")
+		return "print"
+	}
+	if mode != "interactive" && mode != "print" {
+		log.Printf("unknown MANAGED_MODE %q, defaulting to interactive", mode)
+		return "interactive"
+	}
+	return mode
+}
+```
+
+- [ ] Build for darwin and windows (`GOOS=windows go build ./...`) → commit `feat: MANAGED_MODE flag (interactive default, print rollback path)`
+
+---
+
+### Task 8: Web UI events
+
+**Files:**
+- Modify: `server/web/static/app.js` (SSE handler, near the `auto_continue_exhausted` block ~line 2106)
+
+```js
+if (data.type === 'notification') {
+  this.appendSystemMessage(data.message || 'Claude sent a notification');
+  return;
+}
+if (data.type === 'budget_exceeded') {
+  this.appendSystemMessage(`Budget limit reached ($${(data.budget || 0).toFixed(2)}). Session paused.`);
+  this.isWorking = false;
+  return;
+}
+```
+
+(Match the file's actual local helper names — use whatever pattern the adjacent `auto_continue_exhausted` handler uses for system messages.)
+
+- [ ] Manual check via `go run .` + browser if feasible; commit `feat(web): surface notification and budget_exceeded events`
+
+---
+
+### Task 9: Docs + finalization
+
+**Files:**
+- Modify: `CLAUDE.md` (Managed Mode section: interactive architecture, MANAGED_MODE flag, parity gaps)
+- Modify: `docs/superpowers/specs/2026-03-19-managed-sessions-design.md` (addendum note pointing at this plan)
+
+- [ ] `cd server && go test ./... ` — all green
+- [ ] `go vet ./...` and `GOOS=windows go build ./...`
+- [ ] Push branch, open **draft** PR: `Closes #174`, summary of architecture, parity-gap table, rollback instructions (`MANAGED_MODE=print`)
+
+---
+
+## Self-review checklist
+- Spec coverage: issue tasks 2 (PTY lifecycle ✓ Task 3), 3 (transcript source ✓ Task 1), 4 (hook lifecycle ✓ Tasks 2/4/5), 5 (parity ✓ design table + Tasks 2/6), 6 (/compact + interrupt ✓ Task 6), 7 (frontend ✓ Task 8, iOS unaffected by shape preservation — verified event shapes), 8 (tests/docs ✓ throughout + Task 9), rollback flag (✓ Task 7). Spike (task 1 of issue) is partially covered: billing cannot be validated programmatically — noted as PR caveat; PTY drivability is validated by Task 3's tests.
+- No placeholders: all code steps include concrete code or exact instructions referencing existing identifiers.
+- Type consistency: `InteractiveProc`, `EnsureInteractive`, `SendPrompt`, `SendKeys`, `InterruptInteractive`, `SetTranscript`, `SignalStop`, `StopEvents`, `ShutdownInteractive`, `Config.Mode` used consistently across Tasks 3, 5, 6, 7.

--- a/docs/superpowers/specs/2026-03-19-managed-sessions-design.md
+++ b/docs/superpowers/specs/2026-03-19-managed-sessions-design.md
@@ -180,3 +180,14 @@ The server splits `CLAUDE_ARGS` on whitespace and prepends them before the per-m
 - Docker/container sandboxing
 - Agent SDK integration (CLI flags are sufficient)
 - Multi-machine / remote Claude Code instances
+
+---
+
+## Addendum (2026-06-11): Interactive backend
+
+The per-message `claude -p` architecture described above was superseded by a
+long-lived interactive Claude Code backend (PTY + hooks + transcript tailing)
+so managed-session usage bills against the Claude Code subscription rather
+than the API. The `-p` path remains available behind `MANAGED_MODE=print` for
+one release as a rollback, and is the forced mode on Windows. See
+`docs/superpowers/plans/2026-06-11-interactive-managed-sessions.md` (issue #174).

--- a/server/api/hook_event.go
+++ b/server/api/hook_event.go
@@ -43,6 +43,11 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 		if req.ClaudeSessionID != "" && req.ClaudeSessionID != sess.ClaudeSessionID {
 			_ = s.store.UpdateClaudeSessionID(sessionID, req.ClaudeSessionID)
 		}
+		// The CLI session is registered from this point — a future spawn must
+		// --resume it; reusing --session-id would fail with "already in use".
+		if !sess.Initialized {
+			_ = s.store.SetInitialized(sessionID)
+		}
 		if req.TranscriptPath != "" {
 			s.manager.SetTranscript(sessionID, req.TranscriptPath)
 		}

--- a/server/api/hook_event.go
+++ b/server/api/hook_event.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// handleHookEvent receives turn-lifecycle signals from the hook-signal
+// subcommand running inside managed interactive Claude Code sessions.
+func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	var req struct {
+		Event           string `json:"event"`
+		ClaudeSessionID string `json:"claude_session_id"`
+		TranscriptPath  string `json:"transcript_path"`
+		Message         string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			http.Error(w, "session not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	if sess.Mode != "managed" {
+		http.Error(w, "not a managed session", http.StatusBadRequest)
+		return
+	}
+
+	switch req.Event {
+	case "session_start":
+		// Interactive --resume forks to a new CLI session ID; track it so the
+		// next spawn resumes the right session and /resume filtering works.
+		if req.ClaudeSessionID != "" && req.ClaudeSessionID != sess.ClaudeSessionID {
+			_ = s.store.UpdateClaudeSessionID(sessionID, req.ClaudeSessionID)
+		}
+		if req.TranscriptPath != "" {
+			s.manager.SetTranscript(sessionID, req.TranscriptPath)
+		}
+	case "stop":
+		s.manager.SignalStop(sessionID)
+	case "notification":
+		evt, _ := json.Marshal(map[string]string{"type": "notification", "message": req.Message})
+		s.manager.GetBroadcaster(sessionID).Send(string(evt))
+		if req.Message != "" {
+			_, _ = s.store.CreateMessage(sessionID, "system", req.Message, 0)
+		}
+	default:
+		http.Error(w, "unknown event", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte("{}"))
+}

--- a/server/api/hook_event_test.go
+++ b/server/api/hook_event_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func postHookEvent(ts *httptest.Server, sessionID, body string) (*http.Response, error) {
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sessionID+"/hook-event", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req)
+}
+
+func TestHookEventStopSignalsManager(t *testing.T) {
+	ts, store, mock := setupMockTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/hook-stop", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.SetInteractiveRunning(sess.ID, true)
+
+	resp, err := postHookEvent(ts, sess.ID, `{"event":"stop"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	select {
+	case <-mock.StopEvents(sess.ID):
+	case <-time.After(time.Second):
+		t.Fatal("stop not signaled to manager")
+	}
+}
+
+func TestHookEventSessionStartUpdatesIDAndTranscript(t *testing.T) {
+	ts, store, mock := setupMockTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/hook-start", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"event":"session_start","claude_session_id":"forked-uuid","transcript_path":"/tmp/forked.jsonl"}`
+	resp, err := postHookEvent(ts, sess.ID, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	updated, _ := store.GetSessionByID(sess.ID)
+	if updated.ClaudeSessionID != "forked-uuid" {
+		t.Errorf("claude_session_id = %s", updated.ClaudeSessionID)
+	}
+	mock.mu.Lock()
+	calls := append([]string{}, mock.SetTranscriptCalls...)
+	mock.mu.Unlock()
+	if len(calls) != 1 || calls[0] != sess.ID+":/tmp/forked.jsonl" {
+		t.Errorf("SetTranscript calls = %v", calls)
+	}
+}
+
+func TestHookEventNotificationBroadcasts(t *testing.T) {
+	ts, store, mock := setupMockTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/hook-notif", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := postHookEvent(ts, sess.ID, `{"event":"notification","message":"Claude needs permission to use WebFetch"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	select {
+	case msg := <-ch:
+		if !strings.Contains(msg, `"notification"`) || !strings.Contains(msg, "WebFetch") {
+			t.Errorf("broadcast = %s", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("notification not broadcast")
+	}
+
+	msgs, _ := store.ListMessages(sess.ID)
+	found := false
+	for _, m := range msgs {
+		if m.Role == "system" && strings.Contains(m.Content, "WebFetch") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("notification not persisted as system message")
+	}
+}
+
+func TestHookEventUnknownSessionReturns404(t *testing.T) {
+	ts, _, _ := setupMockTestServer(t)
+	resp, err := postHookEvent(ts, "missing", `{"event":"stop"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestHookEventUnknownEventReturns400(t *testing.T) {
+	ts, store, _ := setupMockTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/hook-bad", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := postHookEvent(ts, sess.ID, `{"event":"mystery"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/server/api/hook_event_test.go
+++ b/server/api/hook_event_test.go
@@ -136,3 +136,28 @@ func TestHookEventUnknownEventReturns400(t *testing.T) {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
 	}
 }
+
+func TestHookEventSessionStartSetsInitialized(t *testing.T) {
+	ts, store, _ := setupMockTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/hook-init", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.Initialized {
+		t.Fatal("precondition: new session must not be initialized")
+	}
+
+	resp, err := postHookEvent(ts, sess.ID, `{"event":"session_start","claude_session_id":"cid-1","transcript_path":"/tmp/t.jsonl"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	updated, _ := store.GetSessionByID(sess.ID)
+	if !updated.Initialized {
+		t.Fatal("session_start must mark the session initialized (CLI session now exists; next spawn must --resume)")
+	}
+}

--- a/server/api/interfaces.go
+++ b/server/api/interfaces.go
@@ -20,4 +20,15 @@ type SessionManager interface {
 	SpawnShell(sessionID string, opts managed.ShellOpts) (*managed.Process, error)
 	Config() managed.Config
 	UpdateConfig(cfg managed.Config)
+
+	// Interactive mode (long-lived Claude Code under a PTY)
+	EnsureInteractive(sessionID string, opts managed.InteractiveOpts) (*managed.InteractiveProc, error)
+	IsInteractiveRunning(sessionID string) bool
+	SendPrompt(sessionID, text string) error
+	SendKeys(sessionID, seq string) error
+	InterruptInteractive(sessionID string) error
+	SetTranscript(sessionID, path string)
+	SignalStop(sessionID string)
+	StopEvents(sessionID string) <-chan struct{}
+	ShutdownInteractive(sessionID string, timeout time.Duration) error
 }

--- a/server/api/interfaces.go
+++ b/server/api/interfaces.go
@@ -29,6 +29,7 @@ type SessionManager interface {
 	InterruptInteractive(sessionID string) error
 	SetTranscript(sessionID, path string)
 	SignalStop(sessionID string)
+	TouchInteractive(sessionID string)
 	StopEvents(sessionID string) <-chan struct{}
 	ShutdownInteractive(sessionID string, timeout time.Duration) error
 }

--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +26,14 @@ var transcriptDiscoveryFallback = 30 * time.Second
 
 // compactTimeout bounds how long we wait for /compact to finish.
 var compactTimeout = 5 * time.Minute
+
+// promptEchoTimeout is how long we wait for the typed prompt to appear as a
+// user entry in the transcript before re-sending Enter (the paste may land
+// before the TUI is accepting the submit keypress).
+var promptEchoTimeout = 4 * time.Second
+
+// promptEchoRetries is how many extra Enter presses we attempt.
+const promptEchoRetries = 2
 
 // buildInteractiveArgs builds CLI args for a long-lived interactive process.
 // Tool restrictions and lifecycle hooks travel via the generated settings
@@ -57,6 +66,7 @@ type interactiveTurnState struct {
 	inputTokens    int
 	outputTokens   int
 	interruptedFor string // "" | "max_turns" | "budget"
+	promptEchoed   bool   // the typed prompt appeared in the transcript
 }
 
 func (t *interactiveTurnState) reset() {
@@ -66,6 +76,21 @@ func (t *interactiveTurnState) reset() {
 	t.inputTokens = 0
 	t.outputTokens = 0
 	t.interruptedFor = ""
+	t.promptEchoed = false
+}
+
+func (t *interactiveTurnState) markPromptEchoed() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.promptEchoed = true
+}
+
+// submitted reports whether there is transcript evidence the prompt reached
+// Claude: either the user-entry echo or any assistant activity.
+func (t *interactiveTurnState) submitted() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.promptEchoed || t.assistantCount > 0
 }
 
 func (t *interactiveTurnState) snapshot() (count, in, out int, interrupted string) {
@@ -112,7 +137,7 @@ func hasOnlyTextContent(content json.RawMessage) bool {
 // managedSessionSettings writes the per-session settings file (lifecycle
 // hooks + permission allowlist) and returns its path.
 func managedSessionSettings(cfg managed.Config, sess *db.Session) (string, error) {
-	return managed.WriteSessionSettings(managed.SessionDir(sess.ID), cfg.BinaryPath, sess.ID, cfg.ServerPort, sess.AllowedTools)
+	return managed.WriteSessionSettings(managed.SessionDir(sess.ID), cfg.BinaryPath, sess.ID, cfg.ServerPort, sess.AllowedTools, cfg.KeyFilePath)
 }
 
 func interactiveOpts(sess *db.Session, settingsPath string, onLine func(string)) managed.InteractiveOpts {
@@ -182,7 +207,6 @@ func (s *Server) sendMessageInteractive(sess *db.Session, message string, imageP
 	turn := &interactiveTurnState{}
 	s.interactiveTurns.Store(sessionID, turn)
 
-	maxTurns := sess.MaxTurns
 	prompt := message
 	for _, p := range imagePaths {
 		prompt += fmt.Sprintf("\n\n[Attached image: %s] — use the Read tool to view it.", p)
@@ -199,230 +223,330 @@ func (s *Server) sendMessageInteractive(sess *db.Session, message string, imageP
 		modelEvt, _ := json.Marshal(map[string]string{"type": "model_selected", "model": sess.Model, "reason": "session"})
 		broadcaster.Send(string(modelEvt))
 
-		// onTranscriptLine runs on the tailer goroutine for the process
-		// lifetime — across many turns. It forwards chat entries to SSE,
-		// persists them, and enforces the max-turns limit by interrupting
-		// mid-turn. Turn counters are looked up via s.interactiveTurns so
-		// the callback always feeds the turn currently in flight.
-		onTranscriptLine := func(line string) {
-			var entry interactiveTranscriptEntry
-			if err := json.Unmarshal([]byte(line), &entry); err != nil {
-				return // not JSON we understand; skip broadcast, keep tailing
+		s.runInteractiveTurns(sess, prompt, turn, broadcaster, 0)
+	})
+}
+
+// isSessionIDConflict reports whether the process died because the CLI
+// session ID we passed can't be used (registered by a previous spawn whose
+// turn never completed, or a --resume of a session with no transcript).
+func isSessionIDConflict(out string) bool {
+	return strings.Contains(out, "already in use") || strings.Contains(out, "No conversation found")
+}
+
+// retryAfterSessionIDConflict recovers a session wedged on an unusable CLI
+// session ID: rotate to a fresh ID and re-run the turn once. Returns true if
+// the retry was started (the caller must return without further handling).
+func (s *Server) retryAfterSessionIDConflict(sess *db.Session, prompt string, turn *interactiveTurnState, broadcaster *managed.Broadcaster, proc *managed.InteractiveProc, attempt int) bool {
+	if attempt > 0 {
+		return false
+	}
+	select {
+	case <-proc.Done:
+	default:
+		return false
+	}
+	if !isSessionIDConflict(proc.LastOutput()) {
+		return false
+	}
+	newID, err := s.store.RotateClaudeSessionID(sess.ID)
+	if err != nil {
+		log.Printf("session %s: rotate claude_session_id failed: %v", sess.ID, err)
+		return false
+	}
+	sess.ClaudeSessionID = newID
+	sess.Initialized = false
+	log.Printf("session %s: CLI session ID conflict, rotated to %s and retrying", sess.ID, newID)
+	_, _ = s.store.CreateMessage(sess.ID, "system", "Claude session ID conflict detected — retrying with a fresh session.", 0)
+	s.runInteractiveTurns(sess, prompt, turn, broadcaster, 1)
+	return true
+}
+
+// runInteractiveTurns spawns (or reuses) the session's interactive process
+// and drives prompt turns until the conversation goes idle. attempt guards
+// the single session-ID-conflict retry.
+func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *interactiveTurnState, broadcaster *managed.Broadcaster, attempt int) {
+	sessionID := sess.ID
+	maxTurns := sess.MaxTurns
+
+	// onTranscriptLine runs on the tailer goroutine for the process
+	// lifetime — across many turns. It forwards chat entries to SSE,
+	// persists them, and enforces the max-turns limit by interrupting
+	// mid-turn. Turn counters are looked up via s.interactiveTurns so
+	// the callback always feeds the turn currently in flight.
+	onTranscriptLine := func(line string) {
+		var entry interactiveTranscriptEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return // not JSON we understand; skip broadcast, keep tailing
+		}
+		if entry.IsSidechain {
+			return
+		}
+		switch entry.Type {
+		case "assistant":
+			broadcaster.Send(line)
+			if text := extractAssistantText(line); text != "" {
+				_, _ = s.store.CreateMessage(sessionID, "assistant", text, 0)
 			}
-			if entry.IsSidechain {
+			for _, toolName := range extractToolNames(line) {
+				_, _ = s.store.CreateMessage(sessionID, "activity", toolName, 0)
+			}
+			extractSessionFiles(line, sessionID, s.store)
+
+			v, ok := s.interactiveTurns.Load(sessionID)
+			if !ok {
 				return
 			}
-			switch entry.Type {
-			case "assistant":
+			cur := v.(*interactiveTurnState)
+			cur.mu.Lock()
+			cur.assistantCount++
+			cur.inputTokens += entry.Message.Usage.InputTokens
+			cur.outputTokens += entry.Message.Usage.OutputTokens
+			count := cur.assistantCount
+			alreadyInterrupted := cur.interruptedFor != ""
+			if maxTurns > 0 && count >= maxTurns && !alreadyInterrupted {
+				cur.interruptedFor = "max_turns"
+			}
+			shouldInterrupt := cur.interruptedFor == "max_turns" && !alreadyInterrupted
+			cur.mu.Unlock()
+
+			if shouldInterrupt {
+				log.Printf("session %s: hit max turns (%d), interrupting", sessionID, maxTurns)
+				_ = s.manager.InterruptInteractive(sessionID)
+			}
+		case "user":
+			if !hasOnlyTextContent(entry.Message.Content) {
 				broadcaster.Send(line)
-				if text := extractAssistantText(line); text != "" {
-					_, _ = s.store.CreateMessage(sessionID, "assistant", text, 0)
-				}
-				for _, toolName := range extractToolNames(line) {
-					_, _ = s.store.CreateMessage(sessionID, "activity", toolName, 0)
-				}
-				extractSessionFiles(line, sessionID, s.store)
-
-				v, ok := s.interactiveTurns.Load(sessionID)
-				if !ok {
-					return
-				}
-				cur := v.(*interactiveTurnState)
-				cur.mu.Lock()
-				cur.assistantCount++
-				cur.inputTokens += entry.Message.Usage.InputTokens
-				cur.outputTokens += entry.Message.Usage.OutputTokens
-				count := cur.assistantCount
-				alreadyInterrupted := cur.interruptedFor != ""
-				if maxTurns > 0 && count >= maxTurns && !alreadyInterrupted {
-					cur.interruptedFor = "max_turns"
-				}
-				shouldInterrupt := cur.interruptedFor == "max_turns" && !alreadyInterrupted
-				cur.mu.Unlock()
-
-				if shouldInterrupt {
-					log.Printf("session %s: hit max turns (%d), interrupting", sessionID, maxTurns)
-					_ = s.manager.InterruptInteractive(sessionID)
-				}
-			case "user":
-				if !hasOnlyTextContent(entry.Message.Content) {
-					broadcaster.Send(line)
-				}
+			} else if v, ok := s.interactiveTurns.Load(sessionID); ok {
+				v.(*interactiveTurnState).markPromptEchoed()
 			}
 		}
+	}
 
-		settingsPath, err := managedSessionSettings(s.manager.Config(), sess)
-		if err != nil {
-			log.Printf("session %s: settings generation failed: %v", sessionID, err)
+	settingsPath, err := managedSessionSettings(s.manager.Config(), sess)
+	if err != nil {
+		log.Printf("session %s: settings generation failed: %v", sessionID, err)
+	}
+
+	spawned := !s.manager.IsInteractiveRunning(sessionID)
+	proc, err := s.manager.EnsureInteractive(sessionID, interactiveOpts(sess, settingsPath, onTranscriptLine))
+	if err != nil {
+		errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to start interactive session: %s"}`, err.Error())
+		broadcaster.Send(errMsg)
+		_, _ = s.store.CreateMessage(sessionID, "system", "Failed to start interactive session: "+err.Error(), 0)
+		_ = s.store.UpdateActivityState(sessionID, "idle")
+		broadcaster.Send(`{"type":"done","exit_code":1}`)
+		return
+	}
+
+	// Fallback transcript discovery if the SessionStart hook never fires
+	// (e.g. hooks misconfigured): compute the path from the CWD encoding.
+	if spawned {
+		SafeGo("transcript-fallback:"+sessionID, func() {
+			select {
+			case <-time.After(transcriptDiscoveryFallback):
+			case <-proc.Done:
+				return
+			}
+			resumeID := sess.ID
+			if sess.ClaudeSessionID != "" {
+				resumeID = sess.ClaudeSessionID
+			}
+			if dir, err := claudeProjectsDir(sess.CWD); err == nil {
+				s.manager.SetTranscript(sessionID, filepath.Join(dir, resumeID+".jsonl"))
+			}
+		})
+	}
+
+	stopCh := s.manager.StopEvents(sessionID)
+	continuationCount := 0
+	currentPrompt := prompt
+
+	for {
+		turn.reset()
+		// Drain stale stop signals from previous turns
+		for {
+			select {
+			case <-stopCh:
+				continue
+			default:
+			}
+			break
 		}
 
-		spawned := !s.manager.IsInteractiveRunning(sessionID)
-		proc, err := s.manager.EnsureInteractive(sessionID, interactiveOpts(sess, settingsPath, onTranscriptLine))
-		if err != nil {
-			errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to start interactive session: %s"}`, err.Error())
+		if err := s.manager.SendPrompt(sessionID, currentPrompt); err != nil {
+			// The process may have died with a session-ID conflict before
+			// the prompt could be typed (PTY write fails on a dead pty).
+			if s.retryAfterSessionIDConflict(sess, prompt, turn, broadcaster, proc, attempt) {
+				return
+			}
+			errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to send prompt: %s"}`, err.Error())
 			broadcaster.Send(errMsg)
-			_, _ = s.store.CreateMessage(sessionID, "system", "Failed to start interactive session: "+err.Error(), 0)
 			_ = s.store.UpdateActivityState(sessionID, "idle")
 			broadcaster.Send(`{"type":"done","exit_code":1}`)
 			return
 		}
 
-		// Fallback transcript discovery if the SessionStart hook never fires
-		// (e.g. hooks misconfigured): compute the path from the CWD encoding.
-		if spawned {
-			SafeGo("transcript-fallback:"+sessionID, func() {
-				select {
-				case <-time.After(transcriptDiscoveryFallback):
-				case <-proc.Done:
-					return
-				}
-				resumeID := sess.ID
-				if sess.ClaudeSessionID != "" {
-					resumeID = sess.ClaudeSessionID
-				}
-				if dir, err := claudeProjectsDir(sess.CWD); err == nil {
-					s.manager.SetTranscript(sessionID, filepath.Join(dir, resumeID+".jsonl"))
-				}
-			})
+		// Confirm the prompt actually submitted (the Enter keypress can be
+		// lost if the TUI wasn't ready); runs alongside waitForTurnEnd so a
+		// turn that ends quickly isn't delayed by confirmation.
+		turnOver := make(chan struct{})
+		SafeGo("prompt-confirm:"+sessionID, func() {
+			s.confirmPromptSubmission(sessionID, turn, proc.Done, turnOver, broadcaster)
+		})
+
+		procDied := !s.waitForTurnEnd(sessionID, stopCh, proc.Done, turn)
+		close(turnOver)
+
+		count, in, out, interrupted := turn.snapshot()
+
+		if !sess.Initialized {
+			_ = s.store.SetInitialized(sessionID)
+			sess.Initialized = true
 		}
 
-		stopCh := s.manager.StopEvents(sessionID)
-		continuationCount := 0
-		currentPrompt := prompt
+		// Synthesize the result event print mode used to emit.
+		subtype := "success"
+		if interrupted == "max_turns" {
+			subtype = "error_max_turns"
+		}
+		cost := calcCost(sess.Model, in, out)
+		if cost > 0 {
+			_, _ = s.store.CreateMessage(sessionID, "cost", fmt.Sprintf("%.6f", cost), cost)
+		}
+		resultEvt, _ := json.Marshal(map[string]any{
+			"type": "result", "subtype": subtype,
+			"usage": map[string]int{"input_tokens": in, "output_tokens": out},
+			"cost":  cost, "model": sess.Model,
+		})
+		broadcaster.Send(string(resultEvt))
 
-		for {
-			turn.reset()
-			// Drain stale stop signals from previous turns
-			for {
+		if newCount, err := s.store.IncrementTurnCount(sessionID); err == nil {
+			turnMsg, _ := json.Marshal(map[string]any{"type": "turn_count", "turn_count": newCount})
+			broadcaster.Send(string(turnMsg))
+		}
+
+		if procDied {
+			if proc.ExitCode != 0 && s.retryAfterSessionIDConflict(sess, prompt, turn, broadcaster, proc, attempt) {
+				return
+			}
+			state := "waiting"
+			if proc.ExitCode != 0 {
+				state = "idle"
+				errMsg := fmt.Sprintf(`{"type":"system","error":true,"stderr":%q,"exit_code":%d}`, proc.LastOutput(), proc.ExitCode)
+				_, _ = s.store.CreateMessageWithExitCode(sessionID, "system", errMsg, proc.ExitCode, 0)
+				broadcaster.Send(errMsg)
+			}
+			_ = s.store.UpdateActivityState(sessionID, state)
+			broadcaster.Send(fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode))
+			os.RemoveAll(filepath.Dir(settingsPath))
+			return
+		}
+
+		// Budget enforcement from accumulated transcript usage.
+		if sess.MaxBudgetUSD > 0 {
+			if total, err := s.store.SessionCostTotal(sessionID); err == nil && total > sess.MaxBudgetUSD {
+				log.Printf("session %s: budget exceeded ($%.4f > $%.2f)", sessionID, total, sess.MaxBudgetUSD)
+				budgetEvt, _ := json.Marshal(map[string]any{"type": "budget_exceeded", "total": total, "budget": sess.MaxBudgetUSD})
+				broadcaster.Send(string(budgetEvt))
+				_, _ = s.store.CreateMessage(sessionID, "system",
+					fmt.Sprintf("Budget limit reached ($%.2f of $%.2f). Session paused.", total, sess.MaxBudgetUSD), 0)
+				s.finishInteractiveTurn(sessionID, broadcaster)
+				return
+			}
+		}
+
+		if interrupted != "max_turns" {
+			// Claude finished naturally — wait for the next user message.
+			s.finishInteractiveTurn(sessionID, broadcaster)
+			return
+		}
+
+		// --- Auto-continue (same rules as print mode) ---
+		if continuationCount == 0 && sess.MaxContinuations <= 0 {
+			s.finishInteractiveTurn(sessionID, broadcaster)
+			return
+		}
+		if continuationCount > 0 && count < 2 {
+			log.Printf("session %s not making progress (%d events), stopping auto-continue", sessionID, count)
+			_, _ = s.store.CreateMessage(sessionID, "system", "Auto-continue stopped: not making progress", 0)
+			broadcaster.Send(fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d,"reason":"no_progress"}`, continuationCount))
+			s.finishInteractiveTurn(sessionID, broadcaster)
+			return
+		}
+		continuationCount++
+		if continuationCount > sess.MaxContinuations {
+			log.Printf("session %s exhausted auto-continues (%d/%d)", sessionID, continuationCount, sess.MaxContinuations)
+			broadcaster.Send(fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d}`, continuationCount))
+			_, _ = s.store.CreateMessage(sessionID, "system",
+				fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations), 0)
+			s.finishInteractiveTurn(sessionID, broadcaster)
+			return
+		}
+
+		broadcaster.Send(fmt.Sprintf(`{"type":"auto_continuing","continuation_count":%d,"max_continuations":%d}`,
+			continuationCount, sess.MaxContinuations))
+		_, _ = s.store.CreateMessage(sessionID, "system",
+			fmt.Sprintf("Auto-continuing (%d/%d)...", continuationCount, sess.MaxContinuations), 0)
+
+		if sess.CompactEveryNContinues > 0 && continuationCount%sess.CompactEveryNContinues == 0 {
+			broadcaster.Send(fmt.Sprintf(`{"type":"compacting","continuation_count":%d}`, continuationCount))
+			_, _ = s.store.CreateMessage(sessionID, "system", "Running /compact to reduce context size...", 0)
+			if err := s.manager.SendPrompt(sessionID, "/compact"); err != nil {
+				_, _ = s.store.CreateMessage(sessionID, "system", fmt.Sprintf("Compact failed: %v, continuing without it.", err), 0)
+			} else {
 				select {
 				case <-stopCh:
-					continue
-				default:
-				}
-				break
-			}
-
-			if err := s.manager.SendPrompt(sessionID, currentPrompt); err != nil {
-				errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to send prompt: %s"}`, err.Error())
-				broadcaster.Send(errMsg)
-				_ = s.store.UpdateActivityState(sessionID, "idle")
-				broadcaster.Send(`{"type":"done","exit_code":1}`)
-				return
-			}
-
-			procDied := !s.waitForTurnEnd(sessionID, stopCh, proc.Done, turn)
-
-			count, in, out, interrupted := turn.snapshot()
-
-			if !sess.Initialized {
-				_ = s.store.SetInitialized(sessionID)
-				sess.Initialized = true
-			}
-
-			// Synthesize the result event print mode used to emit.
-			subtype := "success"
-			if interrupted == "max_turns" {
-				subtype = "error_max_turns"
-			}
-			cost := calcCost(sess.Model, in, out)
-			if cost > 0 {
-				_, _ = s.store.CreateMessage(sessionID, "cost", fmt.Sprintf("%.6f", cost), cost)
-			}
-			resultEvt, _ := json.Marshal(map[string]any{
-				"type": "result", "subtype": subtype,
-				"usage": map[string]int{"input_tokens": in, "output_tokens": out},
-				"cost":  cost, "model": sess.Model,
-			})
-			broadcaster.Send(string(resultEvt))
-
-			if newCount, err := s.store.IncrementTurnCount(sessionID); err == nil {
-				turnMsg, _ := json.Marshal(map[string]any{"type": "turn_count", "turn_count": newCount})
-				broadcaster.Send(string(turnMsg))
-			}
-
-			if procDied {
-				state := "waiting"
-				if proc.ExitCode != 0 {
-					state = "idle"
-					errMsg := fmt.Sprintf(`{"type":"system","error":true,"stderr":%q,"exit_code":%d}`, proc.LastOutput(), proc.ExitCode)
-					_, _ = s.store.CreateMessageWithExitCode(sessionID, "system", errMsg, proc.ExitCode, 0)
-					broadcaster.Send(errMsg)
-				}
-				_ = s.store.UpdateActivityState(sessionID, state)
-				broadcaster.Send(fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode))
-				os.RemoveAll(filepath.Dir(settingsPath))
-				return
-			}
-
-			// Budget enforcement from accumulated transcript usage.
-			if sess.MaxBudgetUSD > 0 {
-				if total, err := s.store.SessionCostTotal(sessionID); err == nil && total > sess.MaxBudgetUSD {
-					log.Printf("session %s: budget exceeded ($%.4f > $%.2f)", sessionID, total, sess.MaxBudgetUSD)
-					budgetEvt, _ := json.Marshal(map[string]any{"type": "budget_exceeded", "total": total, "budget": sess.MaxBudgetUSD})
-					broadcaster.Send(string(budgetEvt))
-					_, _ = s.store.CreateMessage(sessionID, "system",
-						fmt.Sprintf("Budget limit reached ($%.2f of $%.2f). Session paused.", total, sess.MaxBudgetUSD), 0)
-					s.finishInteractiveTurn(sessionID, broadcaster)
+					_, _ = s.store.CreateMessage(sessionID, "system", "Compact complete.", 0)
+				case <-proc.Done:
+					_ = s.store.UpdateActivityState(sessionID, "idle")
+					broadcaster.Send(fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode))
 					return
+				case <-time.After(compactTimeout):
+					_, _ = s.store.CreateMessage(sessionID, "system", "Compact timed out, continuing.", 0)
 				}
 			}
-
-			if interrupted != "max_turns" {
-				// Claude finished naturally — wait for the next user message.
-				s.finishInteractiveTurn(sessionID, broadcaster)
-				return
-			}
-
-			// --- Auto-continue (same rules as print mode) ---
-			if continuationCount == 0 && sess.MaxContinuations <= 0 {
-				s.finishInteractiveTurn(sessionID, broadcaster)
-				return
-			}
-			if continuationCount > 0 && count < 2 {
-				log.Printf("session %s not making progress (%d events), stopping auto-continue", sessionID, count)
-				_, _ = s.store.CreateMessage(sessionID, "system", "Auto-continue stopped: not making progress", 0)
-				broadcaster.Send(fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d,"reason":"no_progress"}`, continuationCount))
-				s.finishInteractiveTurn(sessionID, broadcaster)
-				return
-			}
-			continuationCount++
-			if continuationCount > sess.MaxContinuations {
-				log.Printf("session %s exhausted auto-continues (%d/%d)", sessionID, continuationCount, sess.MaxContinuations)
-				broadcaster.Send(fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d}`, continuationCount))
-				_, _ = s.store.CreateMessage(sessionID, "system",
-					fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations), 0)
-				s.finishInteractiveTurn(sessionID, broadcaster)
-				return
-			}
-
-			broadcaster.Send(fmt.Sprintf(`{"type":"auto_continuing","continuation_count":%d,"max_continuations":%d}`,
-				continuationCount, sess.MaxContinuations))
-			_, _ = s.store.CreateMessage(sessionID, "system",
-				fmt.Sprintf("Auto-continuing (%d/%d)...", continuationCount, sess.MaxContinuations), 0)
-
-			if sess.CompactEveryNContinues > 0 && continuationCount%sess.CompactEveryNContinues == 0 {
-				broadcaster.Send(fmt.Sprintf(`{"type":"compacting","continuation_count":%d}`, continuationCount))
-				_, _ = s.store.CreateMessage(sessionID, "system", "Running /compact to reduce context size...", 0)
-				if err := s.manager.SendPrompt(sessionID, "/compact"); err != nil {
-					_, _ = s.store.CreateMessage(sessionID, "system", fmt.Sprintf("Compact failed: %v, continuing without it.", err), 0)
-				} else {
-					select {
-					case <-stopCh:
-						_, _ = s.store.CreateMessage(sessionID, "system", "Compact complete.", 0)
-					case <-proc.Done:
-						_ = s.store.UpdateActivityState(sessionID, "idle")
-						broadcaster.Send(fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode))
-						return
-					case <-time.After(compactTimeout):
-						_, _ = s.store.CreateMessage(sessionID, "system", "Compact timed out, continuing.", 0)
-					}
-				}
-				broadcaster.Send(fmt.Sprintf(`{"type":"compact_complete","continuation_count":%d}`, continuationCount))
-			}
-
-			currentPrompt = "You were interrupted due to turn limits. Continue where you left off."
+			broadcaster.Send(fmt.Sprintf(`{"type":"compact_complete","continuation_count":%d}`, continuationCount))
 		}
-	})
+
+		currentPrompt = "You were interrupted due to turn limits. Continue where you left off."
+	}
+}
+
+// confirmPromptSubmission waits for transcript evidence that the typed prompt
+// reached Claude (user-entry echo or assistant activity). If none appears it
+// re-sends Enter — the paste text is still sitting in the input box — and
+// after the retries are exhausted it surfaces a visible warning instead of
+// letting the session hang silently.
+func (s *Server) confirmPromptSubmission(sessionID string, turn *interactiveTurnState, procDone, turnOver <-chan struct{}, broadcaster *managed.Broadcaster) {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for attempt := 0; ; attempt++ {
+		deadline := time.Now().Add(promptEchoTimeout)
+		for time.Now().Before(deadline) {
+			select {
+			case <-procDone:
+				return
+			case <-turnOver:
+				return
+			case <-ticker.C:
+			}
+			if turn.submitted() {
+				return
+			}
+		}
+		if attempt >= promptEchoRetries {
+			break
+		}
+		log.Printf("session %s: prompt not confirmed after %s, re-sending Enter (attempt %d/%d)",
+			sessionID, promptEchoTimeout, attempt+1, promptEchoRetries)
+		_ = s.manager.SendKeys(sessionID, "\r")
+	}
+	warn := "Prompt submission not confirmed — the Claude TUI may be blocked by a dialog. Try Interrupt, or /clear to restart the session."
+	log.Printf("session %s: %s", sessionID, warn)
+	_, _ = s.store.CreateMessage(sessionID, "system", warn, 0)
+	evt, _ := json.Marshal(map[string]any{"type": "system", "error": true, "message": warn})
+	broadcaster.Send(string(evt))
 }
 
 // waitForTurnEnd blocks until the Stop hook fires, the process dies, or — if
@@ -439,6 +563,7 @@ func (s *Server) waitForTurnEnd(sessionID string, stopCh <-chan struct{}, done <
 		case <-done:
 			return false
 		case <-ticker.C:
+			s.manager.TouchInteractive(sessionID)
 			_, _, _, interrupted := turn.snapshot()
 			if interrupted != "" && interruptedAt.IsZero() {
 				interruptedAt = time.Now()

--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -52,11 +52,11 @@ func buildInteractiveArgs(sess *db.Session, settingsPath string) []string {
 // interactiveTurnState tracks per-turn counters shared between the transcript
 // callback (tailer goroutine) and the orchestrator goroutine.
 type interactiveTurnState struct {
-	mu              sync.Mutex
-	assistantCount  int
-	inputTokens     int
-	outputTokens    int
-	interruptedFor  string // "" | "max_turns" | "budget"
+	mu             sync.Mutex
+	assistantCount int
+	inputTokens    int
+	outputTokens   int
+	interruptedFor string // "" | "max_turns" | "budget"
 }
 
 func (t *interactiveTurnState) reset() {
@@ -176,7 +176,11 @@ func (s *Server) handleSendMessageInteractive(w http.ResponseWriter, sess *db.Se
 func (s *Server) sendMessageInteractive(sess *db.Session, message string, imagePaths []string) {
 	sessionID := sess.ID
 	broadcaster := s.manager.GetBroadcaster(sessionID)
+	// Register this message's turn state so the long-lived transcript
+	// callback (registered at spawn, possibly by an earlier message's
+	// goroutine) feeds counters into the current turn.
 	turn := &interactiveTurnState{}
+	s.interactiveTurns.Store(sessionID, turn)
 
 	maxTurns := sess.MaxTurns
 	prompt := message
@@ -196,8 +200,10 @@ func (s *Server) sendMessageInteractive(sess *db.Session, message string, imageP
 		broadcaster.Send(string(modelEvt))
 
 		// onTranscriptLine runs on the tailer goroutine for the process
-		// lifetime. It forwards chat entries to SSE, persists them, and
-		// enforces the max-turns limit by interrupting mid-turn.
+		// lifetime — across many turns. It forwards chat entries to SSE,
+		// persists them, and enforces the max-turns limit by interrupting
+		// mid-turn. Turn counters are looked up via s.interactiveTurns so
+		// the callback always feeds the turn currently in flight.
 		onTranscriptLine := func(line string) {
 			var entry interactiveTranscriptEntry
 			if err := json.Unmarshal([]byte(line), &entry); err != nil {
@@ -217,17 +223,22 @@ func (s *Server) sendMessageInteractive(sess *db.Session, message string, imageP
 				}
 				extractSessionFiles(line, sessionID, s.store)
 
-				turn.mu.Lock()
-				turn.assistantCount++
-				turn.inputTokens += entry.Message.Usage.InputTokens
-				turn.outputTokens += entry.Message.Usage.OutputTokens
-				count := turn.assistantCount
-				alreadyInterrupted := turn.interruptedFor != ""
-				if maxTurns > 0 && count >= maxTurns && !alreadyInterrupted {
-					turn.interruptedFor = "max_turns"
+				v, ok := s.interactiveTurns.Load(sessionID)
+				if !ok {
+					return
 				}
-				shouldInterrupt := turn.interruptedFor == "max_turns" && !alreadyInterrupted
-				turn.mu.Unlock()
+				cur := v.(*interactiveTurnState)
+				cur.mu.Lock()
+				cur.assistantCount++
+				cur.inputTokens += entry.Message.Usage.InputTokens
+				cur.outputTokens += entry.Message.Usage.OutputTokens
+				count := cur.assistantCount
+				alreadyInterrupted := cur.interruptedFor != ""
+				if maxTurns > 0 && count >= maxTurns && !alreadyInterrupted {
+					cur.interruptedFor = "max_turns"
+				}
+				shouldInterrupt := cur.interruptedFor == "max_turns" && !alreadyInterrupted
+				cur.mu.Unlock()
 
 				if shouldInterrupt {
 					log.Printf("session %s: hit max turns (%d), interrupting", sessionID, maxTurns)

--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -1,0 +1,446 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/jaychinthrajah/claude-controller/server/db"
+	"github.com/jaychinthrajah/claude-controller/server/managed"
+)
+
+// escStopFallback is how long we wait for the Stop hook after sending an ESC
+// interrupt before treating the turn as ended anyway (the hook may not fire
+// on interrupts). Variable so tests can shorten it.
+var escStopFallback = 10 * time.Second
+
+// transcriptDiscoveryFallback is how long we wait for the SessionStart hook
+// to report the transcript path before computing it locally.
+var transcriptDiscoveryFallback = 30 * time.Second
+
+// compactTimeout bounds how long we wait for /compact to finish.
+var compactTimeout = 5 * time.Minute
+
+// buildInteractiveArgs builds CLI args for a long-lived interactive process.
+// Tool restrictions and lifecycle hooks travel via the generated settings
+// file rather than -p-only flags.
+func buildInteractiveArgs(sess *db.Session, settingsPath string) []string {
+	var args []string
+	resumeID := sess.ID
+	if sess.ClaudeSessionID != "" {
+		resumeID = sess.ClaudeSessionID
+	}
+	if sess.Initialized {
+		args = append(args, "--resume", resumeID)
+	} else {
+		args = append(args, "--session-id", resumeID)
+	}
+	if sess.Model != "" {
+		args = append(args, "--model", sess.Model)
+	}
+	if settingsPath != "" {
+		args = append(args, "--settings", settingsPath)
+	}
+	return args
+}
+
+// interactiveTurnState tracks per-turn counters shared between the transcript
+// callback (tailer goroutine) and the orchestrator goroutine.
+type interactiveTurnState struct {
+	mu              sync.Mutex
+	assistantCount  int
+	inputTokens     int
+	outputTokens    int
+	interruptedFor  string // "" | "max_turns" | "budget"
+}
+
+func (t *interactiveTurnState) reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.assistantCount = 0
+	t.inputTokens = 0
+	t.outputTokens = 0
+	t.interruptedFor = ""
+}
+
+func (t *interactiveTurnState) snapshot() (count, in, out int, interrupted string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.assistantCount, t.inputTokens, t.outputTokens, t.interruptedFor
+}
+
+// interactiveTranscriptEntry is a tolerant parse of a transcript JSONL line. Unknown
+// fields pass through untouched because we forward the raw line.
+type interactiveTranscriptEntry struct {
+	Type        string `json:"type"`
+	IsSidechain bool   `json:"isSidechain"`
+	Message     struct {
+		Content json.RawMessage `json:"content"`
+		Usage   struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+// hasOnlyTextContent reports whether a user entry's content is plain text
+// (the echo of a prompt we sent) rather than tool results.
+func hasOnlyTextContent(content json.RawMessage) bool {
+	var s string
+	if json.Unmarshal(content, &s) == nil {
+		return true
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+	}
+	if json.Unmarshal(content, &blocks) != nil {
+		return true
+	}
+	for _, b := range blocks {
+		if b.Type == "tool_result" {
+			return false
+		}
+	}
+	return true
+}
+
+// managedSessionSettings writes the per-session settings file (lifecycle
+// hooks + permission allowlist) and returns its path.
+func managedSessionSettings(cfg managed.Config, sess *db.Session) (string, error) {
+	return managed.WriteSessionSettings(managed.SessionDir(sess.ID), cfg.BinaryPath, sess.ID, cfg.ServerPort, sess.AllowedTools)
+}
+
+func interactiveOpts(sess *db.Session, settingsPath string, onLine func(string)) managed.InteractiveOpts {
+	return managed.InteractiveOpts{
+		Args:             buildInteractiveArgs(sess, settingsPath),
+		CWD:              sess.CWD,
+		OnTranscriptLine: onLine,
+	}
+}
+
+// handleSendMessageInteractive is the synchronous half of an interactive
+// send: persist the user message, pick a model, kick off the turn goroutine,
+// and reply {"status":"started"} like print mode does.
+func (s *Server) handleSendMessageInteractive(w http.ResponseWriter, sess *db.Session, message, modelOverride string, imageIDs []string) {
+	sessionID := sess.ID
+
+	var imagePaths []string
+	for _, id := range imageIDs {
+		imgPath, _ := findUploadedImage(sess.CWD, sessionID, id)
+		if imgPath == "" {
+			log.Printf("session %s: uploaded image %s not found", sessionID, id)
+			continue
+		}
+		imagePaths = append(imagePaths, imgPath)
+	}
+
+	displayMsg := message
+	if len(imagePaths) > 0 {
+		label := fmt.Sprintf("%d image", len(imagePaths))
+		if len(imagePaths) > 1 {
+			label += "s"
+		}
+		displayMsg = formatImageUploadMessage(message, label)
+	}
+	_, _ = s.store.CreateMessage(sessionID, "user", displayMsg, 0)
+	_ = s.store.Heartbeat(sessionID)
+	_ = s.store.UpdateActivityState(sessionID, "working")
+
+	// Model is fixed at spawn time for the long-lived process; only apply
+	// overrides/heuristics when no process exists yet.
+	if !s.manager.IsInteractiveRunning(sessionID) {
+		selected := modelOverride
+		if selected == "" {
+			selected = selectModel(message, len(imagePaths) > 0, "")
+		}
+		if selected != "" && sess.Model != selected {
+			sess.Model = selected
+			_ = s.store.UpdateSessionModel(sessionID, selected)
+		}
+	}
+
+	s.sendMessageInteractive(sess, message, imagePaths)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "started"})
+}
+
+// sendMessageInteractive runs one user turn against the session's long-lived
+// interactive Claude Code process. It mirrors the print-mode flow but derives
+// turn boundaries from Stop hooks and message content from the transcript.
+func (s *Server) sendMessageInteractive(sess *db.Session, message string, imagePaths []string) {
+	sessionID := sess.ID
+	broadcaster := s.manager.GetBroadcaster(sessionID)
+	turn := &interactiveTurnState{}
+
+	maxTurns := sess.MaxTurns
+	prompt := message
+	for _, p := range imagePaths {
+		prompt += fmt.Sprintf("\n\n[Attached image: %s] — use the Read tool to view it.", p)
+	}
+
+	SafeGo("interactive:"+sessionID, func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("session %s: interactive goroutine panicked: %v", sessionID, r)
+				_ = s.store.UpdateActivityState(sessionID, "idle")
+			}
+		}()
+
+		modelEvt, _ := json.Marshal(map[string]string{"type": "model_selected", "model": sess.Model, "reason": "session"})
+		broadcaster.Send(string(modelEvt))
+
+		// onTranscriptLine runs on the tailer goroutine for the process
+		// lifetime. It forwards chat entries to SSE, persists them, and
+		// enforces the max-turns limit by interrupting mid-turn.
+		onTranscriptLine := func(line string) {
+			var entry interactiveTranscriptEntry
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				return // not JSON we understand; skip broadcast, keep tailing
+			}
+			if entry.IsSidechain {
+				return
+			}
+			switch entry.Type {
+			case "assistant":
+				broadcaster.Send(line)
+				if text := extractAssistantText(line); text != "" {
+					_, _ = s.store.CreateMessage(sessionID, "assistant", text, 0)
+				}
+				for _, toolName := range extractToolNames(line) {
+					_, _ = s.store.CreateMessage(sessionID, "activity", toolName, 0)
+				}
+				extractSessionFiles(line, sessionID, s.store)
+
+				turn.mu.Lock()
+				turn.assistantCount++
+				turn.inputTokens += entry.Message.Usage.InputTokens
+				turn.outputTokens += entry.Message.Usage.OutputTokens
+				count := turn.assistantCount
+				alreadyInterrupted := turn.interruptedFor != ""
+				if maxTurns > 0 && count >= maxTurns && !alreadyInterrupted {
+					turn.interruptedFor = "max_turns"
+				}
+				shouldInterrupt := turn.interruptedFor == "max_turns" && !alreadyInterrupted
+				turn.mu.Unlock()
+
+				if shouldInterrupt {
+					log.Printf("session %s: hit max turns (%d), interrupting", sessionID, maxTurns)
+					_ = s.manager.InterruptInteractive(sessionID)
+				}
+			case "user":
+				if !hasOnlyTextContent(entry.Message.Content) {
+					broadcaster.Send(line)
+				}
+			}
+		}
+
+		settingsPath, err := managedSessionSettings(s.manager.Config(), sess)
+		if err != nil {
+			log.Printf("session %s: settings generation failed: %v", sessionID, err)
+		}
+
+		spawned := !s.manager.IsInteractiveRunning(sessionID)
+		proc, err := s.manager.EnsureInteractive(sessionID, interactiveOpts(sess, settingsPath, onTranscriptLine))
+		if err != nil {
+			errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to start interactive session: %s"}`, err.Error())
+			broadcaster.Send(errMsg)
+			_, _ = s.store.CreateMessage(sessionID, "system", "Failed to start interactive session: "+err.Error(), 0)
+			_ = s.store.UpdateActivityState(sessionID, "idle")
+			broadcaster.Send(`{"type":"done","exit_code":1}`)
+			return
+		}
+
+		// Fallback transcript discovery if the SessionStart hook never fires
+		// (e.g. hooks misconfigured): compute the path from the CWD encoding.
+		if spawned {
+			SafeGo("transcript-fallback:"+sessionID, func() {
+				select {
+				case <-time.After(transcriptDiscoveryFallback):
+				case <-proc.Done:
+					return
+				}
+				resumeID := sess.ID
+				if sess.ClaudeSessionID != "" {
+					resumeID = sess.ClaudeSessionID
+				}
+				if dir, err := claudeProjectsDir(sess.CWD); err == nil {
+					s.manager.SetTranscript(sessionID, filepath.Join(dir, resumeID+".jsonl"))
+				}
+			})
+		}
+
+		stopCh := s.manager.StopEvents(sessionID)
+		continuationCount := 0
+		currentPrompt := prompt
+
+		for {
+			turn.reset()
+			// Drain stale stop signals from previous turns
+			for {
+				select {
+				case <-stopCh:
+					continue
+				default:
+				}
+				break
+			}
+
+			if err := s.manager.SendPrompt(sessionID, currentPrompt); err != nil {
+				errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to send prompt: %s"}`, err.Error())
+				broadcaster.Send(errMsg)
+				_ = s.store.UpdateActivityState(sessionID, "idle")
+				broadcaster.Send(`{"type":"done","exit_code":1}`)
+				return
+			}
+
+			procDied := !s.waitForTurnEnd(sessionID, stopCh, proc.Done, turn)
+
+			count, in, out, interrupted := turn.snapshot()
+
+			if !sess.Initialized {
+				_ = s.store.SetInitialized(sessionID)
+				sess.Initialized = true
+			}
+
+			// Synthesize the result event print mode used to emit.
+			subtype := "success"
+			if interrupted == "max_turns" {
+				subtype = "error_max_turns"
+			}
+			cost := calcCost(sess.Model, in, out)
+			if cost > 0 {
+				_, _ = s.store.CreateMessage(sessionID, "cost", fmt.Sprintf("%.6f", cost), cost)
+			}
+			resultEvt, _ := json.Marshal(map[string]any{
+				"type": "result", "subtype": subtype,
+				"usage": map[string]int{"input_tokens": in, "output_tokens": out},
+				"cost":  cost, "model": sess.Model,
+			})
+			broadcaster.Send(string(resultEvt))
+
+			if newCount, err := s.store.IncrementTurnCount(sessionID); err == nil {
+				turnMsg, _ := json.Marshal(map[string]any{"type": "turn_count", "turn_count": newCount})
+				broadcaster.Send(string(turnMsg))
+			}
+
+			if procDied {
+				state := "waiting"
+				if proc.ExitCode != 0 {
+					state = "idle"
+					errMsg := fmt.Sprintf(`{"type":"system","error":true,"stderr":%q,"exit_code":%d}`, proc.LastOutput(), proc.ExitCode)
+					_, _ = s.store.CreateMessageWithExitCode(sessionID, "system", errMsg, proc.ExitCode, 0)
+					broadcaster.Send(errMsg)
+				}
+				_ = s.store.UpdateActivityState(sessionID, state)
+				broadcaster.Send(fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode))
+				os.RemoveAll(filepath.Dir(settingsPath))
+				return
+			}
+
+			// Budget enforcement from accumulated transcript usage.
+			if sess.MaxBudgetUSD > 0 {
+				if total, err := s.store.SessionCostTotal(sessionID); err == nil && total > sess.MaxBudgetUSD {
+					log.Printf("session %s: budget exceeded ($%.4f > $%.2f)", sessionID, total, sess.MaxBudgetUSD)
+					budgetEvt, _ := json.Marshal(map[string]any{"type": "budget_exceeded", "total": total, "budget": sess.MaxBudgetUSD})
+					broadcaster.Send(string(budgetEvt))
+					_, _ = s.store.CreateMessage(sessionID, "system",
+						fmt.Sprintf("Budget limit reached ($%.2f of $%.2f). Session paused.", total, sess.MaxBudgetUSD), 0)
+					s.finishInteractiveTurn(sessionID, broadcaster)
+					return
+				}
+			}
+
+			if interrupted != "max_turns" {
+				// Claude finished naturally — wait for the next user message.
+				s.finishInteractiveTurn(sessionID, broadcaster)
+				return
+			}
+
+			// --- Auto-continue (same rules as print mode) ---
+			if continuationCount == 0 && sess.MaxContinuations <= 0 {
+				s.finishInteractiveTurn(sessionID, broadcaster)
+				return
+			}
+			if continuationCount > 0 && count < 2 {
+				log.Printf("session %s not making progress (%d events), stopping auto-continue", sessionID, count)
+				_, _ = s.store.CreateMessage(sessionID, "system", "Auto-continue stopped: not making progress", 0)
+				broadcaster.Send(fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d,"reason":"no_progress"}`, continuationCount))
+				s.finishInteractiveTurn(sessionID, broadcaster)
+				return
+			}
+			continuationCount++
+			if continuationCount > sess.MaxContinuations {
+				log.Printf("session %s exhausted auto-continues (%d/%d)", sessionID, continuationCount, sess.MaxContinuations)
+				broadcaster.Send(fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d}`, continuationCount))
+				_, _ = s.store.CreateMessage(sessionID, "system",
+					fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations), 0)
+				s.finishInteractiveTurn(sessionID, broadcaster)
+				return
+			}
+
+			broadcaster.Send(fmt.Sprintf(`{"type":"auto_continuing","continuation_count":%d,"max_continuations":%d}`,
+				continuationCount, sess.MaxContinuations))
+			_, _ = s.store.CreateMessage(sessionID, "system",
+				fmt.Sprintf("Auto-continuing (%d/%d)...", continuationCount, sess.MaxContinuations), 0)
+
+			if sess.CompactEveryNContinues > 0 && continuationCount%sess.CompactEveryNContinues == 0 {
+				broadcaster.Send(fmt.Sprintf(`{"type":"compacting","continuation_count":%d}`, continuationCount))
+				_, _ = s.store.CreateMessage(sessionID, "system", "Running /compact to reduce context size...", 0)
+				if err := s.manager.SendPrompt(sessionID, "/compact"); err != nil {
+					_, _ = s.store.CreateMessage(sessionID, "system", fmt.Sprintf("Compact failed: %v, continuing without it.", err), 0)
+				} else {
+					select {
+					case <-stopCh:
+						_, _ = s.store.CreateMessage(sessionID, "system", "Compact complete.", 0)
+					case <-proc.Done:
+						_ = s.store.UpdateActivityState(sessionID, "idle")
+						broadcaster.Send(fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode))
+						return
+					case <-time.After(compactTimeout):
+						_, _ = s.store.CreateMessage(sessionID, "system", "Compact timed out, continuing.", 0)
+					}
+				}
+				broadcaster.Send(fmt.Sprintf(`{"type":"compact_complete","continuation_count":%d}`, continuationCount))
+			}
+
+			currentPrompt = "You were interrupted due to turn limits. Continue where you left off."
+		}
+	})
+}
+
+// waitForTurnEnd blocks until the Stop hook fires, the process dies, or — if
+// the turn was interrupted via ESC — a fallback timer expires (the Stop hook
+// may not fire on interrupts). Returns false if the process died.
+func (s *Server) waitForTurnEnd(sessionID string, stopCh <-chan struct{}, done <-chan struct{}, turn *interactiveTurnState) bool {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	var interruptedAt time.Time
+	for {
+		select {
+		case <-stopCh:
+			return true
+		case <-done:
+			return false
+		case <-ticker.C:
+			_, _, _, interrupted := turn.snapshot()
+			if interrupted != "" && interruptedAt.IsZero() {
+				interruptedAt = time.Now()
+			}
+			if !interruptedAt.IsZero() && time.Since(interruptedAt) > escStopFallback {
+				log.Printf("session %s: no Stop hook after interrupt, assuming turn ended", sessionID)
+				return true
+			}
+		}
+	}
+}
+
+func (s *Server) finishInteractiveTurn(sessionID string, broadcaster *managed.Broadcaster) {
+	_ = s.store.UpdateActivityState(sessionID, "waiting")
+	broadcaster.Send(`{"type":"done","exit_code":0}`)
+}

--- a/server/api/managed_interactive_test.go
+++ b/server/api/managed_interactive_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +39,34 @@ func waitForTranscriptFn(t *testing.T, mock *MockManager, sessionID string) {
 
 func assistantTranscriptLine(text string, in, out int) string {
 	return fmt.Sprintf(`{"type":"assistant","timestamp":"2026-06-12T00:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":%q}],"usage":{"input_tokens":%d,"output_tokens":%d}}}`, text, in, out)
+}
+
+func TestInteractiveTurnTouchesActivityWhileWaiting(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-touch", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := sendMessage(ts, sess.ID, "long task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// While the turn is in flight (no Stop hook yet), the orchestrator must
+	// periodically touch the interactive process so the idle reaper doesn't
+	// kill it mid-turn.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mock.TouchInteractiveCount() > 0 {
+			mock.SignalStop(sess.ID)
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	mock.SignalStop(sess.ID)
+	t.Fatal("TouchInteractive never called during in-flight turn")
 }
 
 func TestInteractiveTurnCompletesOnStopHook(t *testing.T) {
@@ -221,6 +251,93 @@ func TestInteractiveBudgetExceededStopsSession(t *testing.T) {
 	pollActivityState(t, store, sess.ID, "waiting", 2*time.Second)
 }
 
+func userEchoTranscriptLine(text string) string {
+	return fmt.Sprintf(`{"type":"user","timestamp":"2026-06-12T00:00:01Z","message":{"role":"user","content":%q}}`, text)
+}
+
+func TestInteractivePromptRetriesEnterWhenNotEchoed(t *testing.T) {
+	old := promptEchoTimeout
+	promptEchoTimeout = 100 * time.Millisecond
+	defer func() { promptEchoTimeout = old }()
+
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-echo-retry", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := sendMessage(ts, sess.ID, "do something")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	waitForTranscriptFn(t, mock, sess.ID)
+
+	// No user-echo transcript entry ever arrives — the orchestrator must
+	// re-send Enter (the prompt text is already in the input box).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(mock.SentKeysCopy()) < 2 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	keys := mock.SentKeysCopy()
+	if len(keys) < 2 {
+		t.Fatalf("expected at least 2 Enter retries, got keys %q", keys)
+	}
+	for _, k := range keys {
+		if k != "\r" {
+			t.Fatalf("unexpected key %q (want \\r)", k)
+		}
+	}
+
+	// After retries are exhausted, a visible warning must be persisted.
+	deadline = time.Now().Add(2 * time.Second)
+	var warned bool
+	for time.Now().Before(deadline) && !warned {
+		msgs, _ := store.ListMessages(sess.ID)
+		for _, m := range msgs {
+			if m.Role == "system" && strings.Contains(m.Content, "not confirmed") {
+				warned = true
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !warned {
+		t.Error("no system warning persisted after Enter retries exhausted")
+	}
+
+	mock.SignalStop(sess.ID)
+	pollActivityState(t, store, sess.ID, "waiting", 2*time.Second)
+}
+
+func TestInteractiveNoEnterRetryWhenPromptEchoed(t *testing.T) {
+	old := promptEchoTimeout
+	promptEchoTimeout = 150 * time.Millisecond
+	defer func() { promptEchoTimeout = old }()
+
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-echo-ok", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := sendMessage(ts, sess.ID, "do something")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	waitForTranscriptFn(t, mock, sess.ID)
+
+	// The prompt echo arrives promptly — no Enter retries expected.
+	mock.EmitTranscriptLine(sess.ID, userEchoTranscriptLine("do something"))
+	time.Sleep(500 * time.Millisecond)
+	if keys := mock.SentKeysCopy(); len(keys) != 0 {
+		t.Fatalf("unexpected Enter retries after prompt echo: %q", keys)
+	}
+
+	mock.SignalStop(sess.ID)
+	pollActivityState(t, store, sess.ID, "waiting", 2*time.Second)
+}
+
 func TestInterruptRoutesToInteractive(t *testing.T) {
 	ts, store, mock := setupInteractiveTestServer(t)
 	sess, err := store.CreateManagedSession("/tmp/int-interrupt", `["Bash"]`, 50, 5.0, 0)
@@ -260,5 +377,66 @@ func TestInteractiveBusySessionReturns409(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	}
+}
+
+func TestInteractiveSessionIDConflictRotatesAndRetries(t *testing.T) {
+	dir := t.TempDir()
+	store, err := db.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	// Fake claude that always dies with the session-ID conflict error, logging
+	// each spawn so the retry is observable.
+	spawnLog := filepath.Join(dir, "spawns.log")
+	script := filepath.Join(dir, "fake-claude.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/bash\necho run >> "+spawnLog+"\necho 'Error: Session ID stale-claude-id is already in use.'\nexit 1\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := managed.Config{ClaudeBin: "/bin/bash", ClaudeArgs: []string{script}, Mode: "interactive", BinaryPath: "/usr/local/bin/claude-controller", ServerPort: 8080}
+	mgr := managed.NewManager(cfg)
+	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil, "test-server-id")
+	ts := httptest.NewServer(router)
+	t.Cleanup(ts.Close)
+
+	sess, err := store.CreateManagedSession(dir, `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateClaudeSessionID(sess.ID, "stale-claude-id"); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := sendMessage(ts, sess.ID, "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	pollActivityState(t, store, sess.ID, "idle", 8*time.Second)
+
+	data, _ := os.ReadFile(spawnLog)
+	if n := strings.Count(string(data), "run"); n != 2 {
+		t.Fatalf("spawn count = %d, want 2 (rotate + one retry)", n)
+	}
+	updated, _ := store.GetSessionByID(sess.ID)
+	if updated.ClaudeSessionID == "stale-claude-id" {
+		t.Fatal("claude_session_id was not rotated after conflict")
+	}
+	msgs, _ := store.ListMessages(sess.ID)
+	var sawConflictMsg bool
+	for _, m := range msgs {
+		if m.Role == "system" && strings.Contains(strings.ToLower(m.Content), "conflict") {
+			sawConflictMsg = true
+		}
+	}
+	if !sawConflictMsg {
+		t.Error("no system message explaining the session-ID conflict")
 	}
 }

--- a/server/api/managed_interactive_test.go
+++ b/server/api/managed_interactive_test.go
@@ -1,0 +1,264 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jaychinthrajah/claude-controller/server/db"
+	"github.com/jaychinthrajah/claude-controller/server/managed"
+)
+
+func setupInteractiveTestServer(t *testing.T) (*httptest.Server, *db.Store, *MockManager) {
+	t.Helper()
+	ts, store, mock := setupMockTestServer(t)
+	mock.ConfigValue = managed.Config{Mode: "interactive", BinaryPath: "/usr/local/bin/claude-controller", ServerPort: 8080}
+	return ts, store, mock
+}
+
+func waitForTranscriptFn(t *testing.T, mock *MockManager, sessionID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mock.mu.Lock()
+		fn := mock.TranscriptLineFns[sessionID]
+		mock.mu.Unlock()
+		if fn != nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("transcript callback never registered (EnsureInteractive not called?)")
+}
+
+func assistantTranscriptLine(text string, in, out int) string {
+	return fmt.Sprintf(`{"type":"assistant","timestamp":"2026-06-12T00:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":%q}],"usage":{"input_tokens":%d,"output_tokens":%d}}}`, text, in, out)
+}
+
+func TestInteractiveTurnCompletesOnStopHook(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-basic", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := sendMessage(ts, sess.ID, "do something")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	waitForTranscriptFn(t, mock, sess.ID)
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLine("working on it", 100, 50))
+
+	// Wait for the prompt to be typed before signaling stop
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(mock.SentPromptsCopy()) == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	prompts := mock.SentPromptsCopy()
+	if len(prompts) != 1 || prompts[0] != "do something" {
+		t.Fatalf("prompts = %v", prompts)
+	}
+
+	mock.SignalStop(sess.ID)
+
+	var sawResult, sawDone bool
+	timeout := time.After(3 * time.Second)
+	for !sawDone {
+		select {
+		case msg := <-ch:
+			var obj map[string]any
+			json.Unmarshal([]byte(msg), &obj)
+			if obj["type"] == "result" {
+				sawResult = true
+				if obj["subtype"] != "success" {
+					t.Errorf("result subtype = %v", obj["subtype"])
+				}
+			}
+			if obj["type"] == "done" {
+				sawDone = true
+			}
+		case <-timeout:
+			t.Fatal("never saw done event")
+		}
+	}
+	if !sawResult {
+		t.Error("no result event before done")
+	}
+
+	pollActivityState(t, store, sess.ID, "waiting", 2*time.Second)
+
+	msgs, _ := store.ListMessages(sess.ID)
+	var sawAssistant bool
+	for _, m := range msgs {
+		if m.Role == "assistant" && strings.Contains(m.Content, "working on it") {
+			sawAssistant = true
+		}
+	}
+	if !sawAssistant {
+		t.Error("assistant transcript text not persisted")
+	}
+}
+
+func TestInteractiveMaxTurnsInterruptsAndAutoContinues(t *testing.T) {
+	old := escStopFallback
+	escStopFallback = 200 * time.Millisecond
+	defer func() { escStopFallback = old }()
+
+	ts, store, mock := setupInteractiveTestServer(t)
+	// max_turns = 2; max_continuations defaults to 5 so auto-continue is allowed
+	sess, err := store.CreateManagedSession("/tmp/int-maxturns", `["Bash"]`, 2, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := sendMessage(ts, sess.ID, "long task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	waitForTranscriptFn(t, mock, sess.ID)
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLine("step 1", 10, 10))
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLine("step 2", 10, 10))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && mock.InterruptInteractiveCount() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if mock.InterruptInteractiveCount() != 1 {
+		t.Fatalf("InterruptInteractive calls = %d, want 1", mock.InterruptInteractiveCount())
+	}
+
+	// No Stop hook arrives (interrupt) — the ESC fallback timer should end
+	// the turn, then auto-continue should type the continuation prompt.
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && len(mock.SentPromptsCopy()) < 2 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	prompts := mock.SentPromptsCopy()
+	if len(prompts) < 2 || !strings.Contains(prompts[1], "Continue where you left off") {
+		t.Fatalf("prompts = %v", prompts)
+	}
+
+	var sawAutoContinuing, sawMaxTurnsResult bool
+	timeout := time.After(2 * time.Second)
+drain:
+	for {
+		select {
+		case msg := <-ch:
+			var obj map[string]any
+			json.Unmarshal([]byte(msg), &obj)
+			if obj["type"] == "auto_continuing" {
+				sawAutoContinuing = true
+				break drain
+			}
+			if obj["type"] == "result" && obj["subtype"] == "error_max_turns" {
+				sawMaxTurnsResult = true
+			}
+		case <-timeout:
+			break drain
+		}
+	}
+	if !sawMaxTurnsResult {
+		t.Error("no error_max_turns result event")
+	}
+	if !sawAutoContinuing {
+		t.Error("no auto_continuing event")
+	}
+}
+
+func TestInteractiveBudgetExceededStopsSession(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-budget", `["Bash"]`, 50, 0.01, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pre-existing spend over the $0.01 budget
+	store.CreateMessage(sess.ID, "cost", "0.50", 0.50)
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := sendMessage(ts, sess.ID, "one more thing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	waitForTranscriptFn(t, mock, sess.ID)
+	mock.SignalStop(sess.ID)
+
+	var sawBudget bool
+	timeout := time.After(3 * time.Second)
+	for !sawBudget {
+		select {
+		case msg := <-ch:
+			if strings.Contains(msg, `"budget_exceeded"`) {
+				sawBudget = true
+			}
+		case <-timeout:
+			t.Fatal("no budget_exceeded event")
+		}
+	}
+	pollActivityState(t, store, sess.ID, "waiting", 2*time.Second)
+}
+
+func TestInterruptRoutesToInteractive(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-interrupt", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.SetInteractiveRunning(sess.ID, true)
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/interrupt", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if mock.InterruptInteractiveCount() != 1 {
+		t.Fatalf("InterruptInteractive calls = %d", mock.InterruptInteractiveCount())
+	}
+}
+
+func TestInteractiveBusySessionReturns409(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-busy", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.SetInteractiveRunning(sess.ID, true)
+	store.UpdateActivityState(sess.ID, "working")
+
+	resp, err := sendMessage(ts, sess.ID, "another message")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	}
+}

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -633,6 +633,12 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request, api
 	// can broadcast events before the SSE subscriber is ready.
 	flusher.Flush()
 
+	// Per-connection heartbeat: the interactive backend can go silent for
+	// minutes mid-turn (long thinking, long tool runs), and the web UI treats
+	// >30s of SSE silence as a dead connection.
+	heartbeat := time.NewTicker(managed.HeartbeatInterval)
+	defer heartbeat.Stop()
+
 	for {
 		select {
 		case msg, ok := <-ch:
@@ -641,10 +647,25 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request, api
 			}
 			fmt.Fprintf(w, "data: %s\n\n", msg)
 			flusher.Flush()
+		case <-heartbeat.C:
+			fmt.Fprintf(w, "data: {\"type\":\"heartbeat\",\"ts\":%d}\n\n", time.Now().UnixMilli())
+			flusher.Flush()
 		case <-r.Context().Done():
 			return
 		}
 	}
+}
+
+// handleGetManagedSession returns a single session by ID. The web UI fetches
+// this when deciding how to recover a dropped SSE connection.
+func (s *Server) handleGetManagedSession(w http.ResponseWriter, r *http.Request) {
+	sess, err := s.store.GetSessionByID(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(sess)
 }
 
 func parseRole(line string) string {
@@ -1008,7 +1029,10 @@ func (s *Server) handleClearSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not a managed session", http.StatusBadRequest)
 		return
 	}
-	if sess.ActivityState == "working" {
+	// Only an active print-mode turn blocks clearing. Interactive processes
+	// are torn down below, and a "working" state with no live process is a
+	// stuck session that clear must be able to recover.
+	if sess.ActivityState == "working" && s.manager.IsRunning(sessionID) {
 		http.Error(w, "cannot clear while session is working", http.StatusConflict)
 		return
 	}

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -107,7 +107,7 @@ func buildPersistentArgs(sess *db.Session, cfg managed.Config) []string {
 			"mcpServers": map[string]interface{}{
 				"controller": map[string]interface{}{
 					"command": cfg.BinaryPath,
-					"args":   []string{"mcp-bridge", "--session-id", sess.ID, "--port", fmt.Sprintf("%d", cfg.ServerPort)},
+					"args":    []string{"mcp-bridge", "--session-id", sess.ID, "--port", fmt.Sprintf("%d", cfg.ServerPort)},
 				},
 			},
 		}
@@ -514,7 +514,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				exhaustedMsg := fmt.Sprintf(`{"type":"auto_continue_exhausted","continuation_count":%d}`, continuationCount)
 				broadcaster.Send(exhaustedMsg)
 				_, _ = s.store.CreateMessage(sessionID, "system",
-				fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations), 0)
+					fmt.Sprintf("Auto-continue limit reached (%d/%d)", continuationCount, sess.MaxContinuations), 0)
 				_ = s.manager.GracefulShutdown(sessionID, 10*time.Second)
 				<-streamDone
 				_ = s.store.UpdateActivityState(sessionID, "waiting")
@@ -576,6 +576,13 @@ func (s *Server) handleInterrupt(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		// The Stop hook may not fire for interrupted turns — nudge the
+		// orchestrator so it doesn't wait forever. Spurious signals are
+		// drained at the start of the next turn.
+		SafeGo("interrupt-fallback:"+sessionID, func() {
+			time.Sleep(escStopFallback)
+			s.manager.SignalStop(sessionID)
+		})
 	} else if err := s.manager.Interrupt(sessionID); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -174,14 +174,24 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	// because activity_state can be stale — the cleanup goroutine updates the
 	// DB after GracefulShutdown (up to 10s), or the goroutine may have exited
 	// without updating state (panic, unexpected error path).
+	interactive := s.manager.Config().Mode == "interactive"
 	if sess.ActivityState == "working" {
-		if s.manager.IsRunning(sessionID) {
+		busy := s.manager.IsRunning(sessionID)
+		if interactive {
+			busy = s.manager.IsInteractiveRunning(sessionID)
+		}
+		if busy {
 			http.Error(w, "session is currently processing (may be auto-continuing — wait for it to finish or interrupt first)", http.StatusConflict)
 			return
 		}
 		// No process running — state is stale. Reset and proceed.
 		log.Printf("session %s: activity_state is 'working' but no process running, resetting to allow new message", sessionID)
 		_ = s.store.UpdateActivityState(sessionID, "waiting")
+	}
+
+	if interactive {
+		s.handleSendMessageInteractive(w, sess, req.Message, req.Model, req.ImageIDs)
+		return
 	}
 
 	var images []imageData
@@ -560,7 +570,13 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleInterrupt(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.PathValue("id")
-	if err := s.manager.Interrupt(sessionID); err != nil {
+	if s.manager.IsInteractiveRunning(sessionID) {
+		// ESC gracefully aborts the current turn; the process stays alive.
+		if err := s.manager.InterruptInteractive(sessionID); err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+	} else if err := s.manager.Interrupt(sessionID); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -116,6 +116,80 @@ func TestListMessagesAPI(t *testing.T) {
 	}
 }
 
+func TestSessionStreamHeartbeat(t *testing.T) {
+	oldInterval := managed.HeartbeatInterval
+	managed.HeartbeatInterval = 50 * time.Millisecond
+	defer func() { managed.HeartbeatInterval = oldInterval }()
+
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/hb-test", `["Read"]`, 50, 5.0, 0)
+
+	// No process running, nothing broadcast — the stream itself must still
+	// emit heartbeats so clients can tell the connection is alive.
+	resp, err := http.Get(ts.URL + "/api/sessions/" + sess.ID + "/stream?token=test-api-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	lines := make(chan string, 16)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			lines <- scanner.Text()
+		}
+		close(lines)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case line, ok := <-lines:
+			if !ok {
+				t.Fatal("stream closed without a heartbeat")
+			}
+			if strings.Contains(line, `"heartbeat"`) {
+				return // got one
+			}
+		case <-deadline:
+			t.Fatal("no heartbeat within 2s on an idle session stream")
+		}
+	}
+}
+
+func TestGetManagedSessionAPI(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/get-test", `["Read"]`, 50, 5.0, 0)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID, nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+
+	var got map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&got)
+	if got["id"] != sess.ID {
+		t.Errorf("id=%v, want %s", got["id"], sess.ID)
+	}
+	if _, ok := got["activity_state"]; !ok {
+		t.Error("response missing activity_state field")
+	}
+}
+
 func TestShellExecuteAPI(t *testing.T) {
 	ts, store := setupTestServer(t)
 	defer ts.Close()
@@ -419,7 +493,9 @@ func TestClearSessionAPI(t *testing.T) {
 	}
 }
 
-func TestClearSessionAPI_RejectsWorking(t *testing.T) {
+func TestClearSessionAPI_AllowsStuckWorkingSession(t *testing.T) {
+	// A session can wedge in "working" with no live process (e.g. a lost
+	// prompt). /clear must recover it, not 409.
 	ts, store := setupTestServer(t)
 	defer ts.Close()
 	defer store.Close()
@@ -436,8 +512,61 @@ func TestClearSessionAPI_RejectsWorking(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200 for stuck working session", resp.StatusCode)
+	}
+	updated, _ := store.GetSessionByID(sess.ID)
+	if updated.ActivityState != "idle" {
+		t.Fatalf("activity_state=%q, want idle after clear", updated.ActivityState)
+	}
+}
+
+func TestClearSessionAPI_TearsDownWorkingInteractiveSession(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+
+	sess, _ := store.CreateManagedSession("/tmp/test-clear-int-working", `["Read"]`, 50, 5.0, 0)
+	mock.SetInteractiveRunning(sess.ID, true)
+	store.UpdateActivityState(sess.ID, "working")
+
+	var tornDown bool
+	mock.OnTeardown = func(sessionID string, timeout time.Duration) error {
+		tornDown = true
+		return nil
+	}
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/clear", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200 (clear must stop the interactive process and proceed)", resp.StatusCode)
+	}
+	if !tornDown {
+		t.Fatal("interactive process was not torn down before clearing")
+	}
+}
+
+func TestClearSessionAPI_StillRejectsRunningPrintTurn(t *testing.T) {
+	ts, store, mock := setupMockTestServer(t)
+
+	sess, _ := store.CreateManagedSession("/tmp/test-clear-print-working", `["Read"]`, 50, 5.0, 0)
+	mock.SetRunning(sess.ID, true) // print-mode one-shot process mid-turn
+	store.UpdateActivityState(sess.ID, "working")
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/clear", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 409 {
-		t.Fatalf("status=%d, want 409 for working session", resp.StatusCode)
+		t.Fatalf("status=%d, want 409 while a print-mode turn is running", resp.StatusCode)
 	}
 }
 

--- a/server/api/mock_manager_test.go
+++ b/server/api/mock_manager_test.go
@@ -34,16 +34,16 @@ type MockManager struct {
 	ConfigValue        managed.Config
 
 	// Interactive mode
-	interactiveRunning   map[string]bool
-	stopChans            map[string]chan struct{}
-	TranscriptLineFns    map[string]func(string) // captured OnTranscriptLine per session
-	SetTranscriptCalls   []string
-	SentPrompts          []string
-	SentKeys             []string
+	interactiveRunning        map[string]bool
+	stopChans                 map[string]chan struct{}
+	TranscriptLineFns         map[string]func(string) // captured OnTranscriptLine per session
+	SetTranscriptCalls        []string
+	SentPrompts               []string
+	SentKeys                  []string
 	InterruptInteractiveCalls int
-	OnEnsureInteractive  func(sessionID string, opts managed.InteractiveOpts) (*managed.InteractiveProc, error)
-	OnSendPrompt         func(sessionID, text string) error
-	OnShutdownInteractive func(sessionID string, timeout time.Duration) error
+	OnEnsureInteractive       func(sessionID string, opts managed.InteractiveOpts) (*managed.InteractiveProc, error)
+	OnSendPrompt              func(sessionID, text string) error
+	OnShutdownInteractive     func(sessionID string, timeout time.Duration) error
 }
 
 func NewMockManager() *MockManager {

--- a/server/api/mock_manager_test.go
+++ b/server/api/mock_manager_test.go
@@ -32,12 +32,27 @@ type MockManager struct {
 	OnTeardown         func(sessionID string, timeout time.Duration) error
 	OnSpawnShell       func(sessionID string, opts managed.ShellOpts) (*managed.Process, error)
 	ConfigValue        managed.Config
+
+	// Interactive mode
+	interactiveRunning   map[string]bool
+	stopChans            map[string]chan struct{}
+	TranscriptLineFns    map[string]func(string) // captured OnTranscriptLine per session
+	SetTranscriptCalls   []string
+	SentPrompts          []string
+	SentKeys             []string
+	InterruptInteractiveCalls int
+	OnEnsureInteractive  func(sessionID string, opts managed.InteractiveOpts) (*managed.InteractiveProc, error)
+	OnSendPrompt         func(sessionID, text string) error
+	OnShutdownInteractive func(sessionID string, timeout time.Duration) error
 }
 
 func NewMockManager() *MockManager {
 	return &MockManager{
-		broadcasters: make(map[string]*managed.Broadcaster),
-		running:      make(map[string]bool),
+		broadcasters:       make(map[string]*managed.Broadcaster),
+		running:            make(map[string]bool),
+		interactiveRunning: make(map[string]bool),
+		stopChans:          make(map[string]chan struct{}),
+		TranscriptLineFns:  make(map[string]func(string)),
 	}
 }
 
@@ -121,6 +136,118 @@ func (m *MockManager) UpdateConfig(cfg managed.Config) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ConfigValue = cfg
+}
+
+// --- Interactive mode ---
+
+func (m *MockManager) EnsureInteractive(sessionID string, opts managed.InteractiveOpts) (*managed.InteractiveProc, error) {
+	m.mu.Lock()
+	m.interactiveRunning[sessionID] = true
+	m.TranscriptLineFns[sessionID] = opts.OnTranscriptLine
+	if _, ok := m.stopChans[sessionID]; !ok {
+		m.stopChans[sessionID] = make(chan struct{}, 4)
+	}
+	m.mu.Unlock()
+	if m.OnEnsureInteractive != nil {
+		return m.OnEnsureInteractive(sessionID, opts)
+	}
+	return &managed.InteractiveProc{Done: make(chan struct{})}, nil
+}
+
+func (m *MockManager) IsInteractiveRunning(sessionID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.interactiveRunning[sessionID]
+}
+
+func (m *MockManager) SetInteractiveRunning(sessionID string, running bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.interactiveRunning[sessionID] = running
+	if _, ok := m.stopChans[sessionID]; !ok {
+		m.stopChans[sessionID] = make(chan struct{}, 4)
+	}
+}
+
+func (m *MockManager) SendPrompt(sessionID, text string) error {
+	m.mu.Lock()
+	m.SentPrompts = append(m.SentPrompts, text)
+	m.mu.Unlock()
+	if m.OnSendPrompt != nil {
+		return m.OnSendPrompt(sessionID, text)
+	}
+	return nil
+}
+
+func (m *MockManager) SentPromptsCopy() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string{}, m.SentPrompts...)
+}
+
+func (m *MockManager) SendKeys(sessionID, seq string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SentKeys = append(m.SentKeys, seq)
+	return nil
+}
+
+func (m *MockManager) InterruptInteractive(sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.InterruptInteractiveCalls++
+	return nil
+}
+
+func (m *MockManager) InterruptInteractiveCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.InterruptInteractiveCalls
+}
+
+func (m *MockManager) SetTranscript(sessionID, path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SetTranscriptCalls = append(m.SetTranscriptCalls, sessionID+":"+path)
+}
+
+func (m *MockManager) SignalStop(sessionID string) {
+	m.mu.Lock()
+	ch, ok := m.stopChans[sessionID]
+	m.mu.Unlock()
+	if !ok {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+func (m *MockManager) StopEvents(sessionID string) <-chan struct{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.stopChans[sessionID]
+}
+
+func (m *MockManager) ShutdownInteractive(sessionID string, timeout time.Duration) error {
+	m.mu.Lock()
+	m.interactiveRunning[sessionID] = false
+	m.mu.Unlock()
+	if m.OnShutdownInteractive != nil {
+		return m.OnShutdownInteractive(sessionID, timeout)
+	}
+	return nil
+}
+
+// EmitTranscriptLine simulates the transcript tailer delivering a line.
+func (m *MockManager) EmitTranscriptLine(sessionID, line string) {
+	m.mu.Lock()
+	fn := m.TranscriptLineFns[sessionID]
+	m.mu.Unlock()
+	if fn != nil {
+		fn(line)
+	}
 }
 
 // --- Process simulation helpers ---

--- a/server/api/mock_manager_test.go
+++ b/server/api/mock_manager_test.go
@@ -41,6 +41,7 @@ type MockManager struct {
 	SentPrompts               []string
 	SentKeys                  []string
 	InterruptInteractiveCalls int
+	TouchInteractiveCalls     int
 	OnEnsureInteractive       func(sessionID string, opts managed.InteractiveOpts) (*managed.InteractiveProc, error)
 	OnSendPrompt              func(sessionID, text string) error
 	OnShutdownInteractive     func(sessionID string, timeout time.Duration) error
@@ -192,6 +193,12 @@ func (m *MockManager) SendKeys(sessionID, seq string) error {
 	return nil
 }
 
+func (m *MockManager) SentKeysCopy() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string{}, m.SentKeys...)
+}
+
 func (m *MockManager) InterruptInteractive(sessionID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -203,6 +210,18 @@ func (m *MockManager) InterruptInteractiveCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.InterruptInteractiveCalls
+}
+
+func (m *MockManager) TouchInteractive(sessionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.TouchInteractiveCalls++
+}
+
+func (m *MockManager) TouchInteractiveCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.TouchInteractiveCalls
 }
 
 func (m *MockManager) SetTranscript(sessionID, path string) {

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -74,6 +74,7 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 	apiMux.HandleFunc("POST /api/sessions/{id}/shell", s.handleShellExecute)
 	apiMux.HandleFunc("POST /api/sessions/{id}/upload", s.handleUploadImage)
 	apiMux.HandleFunc("POST /api/sessions/{id}/clear", s.handleClearSession)
+	apiMux.HandleFunc("POST /api/sessions/{id}/hook-event", s.handleHookEvent)
 	apiMux.HandleFunc("POST /api/sessions/{id}/permission-request", s.handlePermissionRequest)
 	apiMux.HandleFunc("POST /api/sessions/{id}/permission-respond", s.handlePermissionRespond)
 	apiMux.HandleFunc("GET /api/sessions/{id}/pending-permission", s.handlePendingPermission)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -42,6 +42,7 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 	apiMux.HandleFunc("POST /api/sessions/register", s.handleRegisterSession)
 	apiMux.HandleFunc("POST /api/sessions/{id}/heartbeat", s.handleHeartbeat)
 	apiMux.HandleFunc("GET /api/sessions", s.handleListSessions)
+	apiMux.HandleFunc("GET /api/sessions/{id}", s.handleGetManagedSession)
 	apiMux.HandleFunc("PUT /api/sessions/{id}/archive", s.handleSetArchived)
 	apiMux.HandleFunc("DELETE /api/sessions/{id}", s.handleDeleteSession)
 	apiMux.HandleFunc("PUT /api/sessions/{id}/name", s.handleUpdateSessionName)

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -25,6 +25,11 @@ type Server struct {
 	skipKeychain      bool   // skip macOS keychain lookup in tests
 	usageCache        *UsageCache
 	usageCacheMu      sync.RWMutex
+	// interactiveTurns maps sessionID -> *interactiveTurnState for the turn
+	// currently in flight. The transcript callback is registered once at
+	// process spawn and outlives individual turns, so it must look up the
+	// live turn state here instead of capturing it.
+	interactiveTurns sync.Map
 }
 
 func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath string, shutdownFunc func(), serverID string) http.Handler {

--- a/server/db/messages.go
+++ b/server/db/messages.go
@@ -52,6 +52,14 @@ func (s *Store) CreateMessageWithExitCode(sessionID, role, content string, exitC
 	return &msg, nil
 }
 
+// SessionCostTotal sums the cost of all cost messages for a session,
+// including cleared ones (budget enforcement must survive /clear).
+func (s *Store) SessionCostTotal(sessionID string) (float64, error) {
+	var total float64
+	err := s.db.QueryRow(`SELECT COALESCE(SUM(cost), 0) FROM messages WHERE session_id = ? AND role = 'cost'`, sessionID).Scan(&total)
+	return total, err
+}
+
 func (s *Store) ListMessages(sessionID string) ([]Message, error) {
 	rows, err := s.db.Query(`SELECT id, session_id, seq, role, content, exit_code, created_at, cost FROM messages WHERE session_id = ? AND cleared_at IS NULL ORDER BY seq`, sessionID)
 	if err != nil {

--- a/server/db/messages_test.go
+++ b/server/db/messages_test.go
@@ -100,3 +100,61 @@ func TestCreateMessage_WithCost(t *testing.T) {
 		t.Errorf("expected cost 0.05, got %v", msg.Cost)
 	}
 }
+
+func TestSessionCostTotal(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	sess, err := store.CreateManagedSession("/tmp/cost-project", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	total, err := store.SessionCostTotal(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 {
+		t.Errorf("empty session total = %f, want 0", total)
+	}
+
+	store.CreateMessage(sess.ID, "cost", "0.5", 0.5)
+	store.CreateMessage(sess.ID, "cost", "0.25", 0.25)
+	store.CreateMessage(sess.ID, "assistant", "not a cost", 99) // wrong role, excluded
+
+	total, err = store.SessionCostTotal(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0.75 {
+		t.Errorf("total = %f, want 0.75", total)
+	}
+}
+
+func TestUpdateClaudeSessionID(t *testing.T) {
+	dir := t.TempDir()
+	store, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	sess, err := store.CreateManagedSession("/tmp/csid-project", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateClaudeSessionID(sess.ID, "new-cli-uuid"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.GetSessionByID(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ClaudeSessionID != "new-cli-uuid" {
+		t.Errorf("claude_session_id = %s, want new-cli-uuid", got.ClaudeSessionID)
+	}
+}

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -142,6 +142,18 @@ func (s *Store) SetInitialized(id string) error {
 	return err
 }
 
+// RotateClaudeSessionID assigns a fresh CLI session ID and clears the
+// initialized flag so the next spawn starts a brand-new Claude session.
+// Used to recover from "session ID already in use" / unresumable sessions.
+func (s *Store) RotateClaudeSessionID(id string) (string, error) {
+	newID := uuid.New().String()
+	_, err := s.db.Exec(`UPDATE sessions SET claude_session_id = ?, initialized = 0 WHERE id = ?`, newID, id)
+	if err != nil {
+		return "", fmt.Errorf("rotate claude_session_id: %w", err)
+	}
+	return newID, nil
+}
+
 func (s *Store) ResumeSession(id, claudeSessionID string) error {
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -227,6 +227,11 @@ func (s *Store) UpdateActivityState(id, state string) error {
 	return err
 }
 
+func (s *Store) UpdateClaudeSessionID(id, claudeSessionID string) error {
+	_, err := s.db.Exec("UPDATE sessions SET claude_session_id = ? WHERE id = ? AND deleted_at IS NULL", claudeSessionID, id)
+	return err
+}
+
 func (s *Store) UpdateSessionModel(id, model string) error {
 	_, err := s.db.Exec("UPDATE sessions SET model = ? WHERE id = ?", model, id)
 	return err

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -11,27 +11,27 @@ import (
 )
 
 type Session struct {
-	ID             string    `json:"id"`
-	ComputerName   string    `json:"computer_name"`
-	ProjectPath    string    `json:"project_path"`
-	TranscriptPath string    `json:"transcript_path,omitempty"`
-	Status         string    `json:"status"`
-	CreatedAt      time.Time `json:"created_at"`
-	LastSeenAt     time.Time `json:"last_seen_at"`
-	Archived       bool      `json:"archived"`
-	Mode           string    `json:"mode"`
-	CWD            string    `json:"cwd,omitempty"`
-	AllowedTools   string    `json:"allowed_tools,omitempty"`
-	MaxTurns       int       `json:"max_turns"`
-	MaxBudgetUSD   float64   `json:"max_budget_usd"`
-	Initialized     bool   `json:"initialized"`
-	ClaudeSessionID       string  `json:"claude_session_id,omitempty"`
-	MaxContinuations      int     `json:"max_continuations"`
-	ActivityState         string  `json:"activity_state"`
-	TurnCount             int     `json:"turn_count"`
-	Name                  string  `json:"name"`
-	CompactEveryNContinues int    `json:"compact_every_n_continues"`
-	Model                  string `json:"-"`
+	ID                     string    `json:"id"`
+	ComputerName           string    `json:"computer_name"`
+	ProjectPath            string    `json:"project_path"`
+	TranscriptPath         string    `json:"transcript_path,omitempty"`
+	Status                 string    `json:"status"`
+	CreatedAt              time.Time `json:"created_at"`
+	LastSeenAt             time.Time `json:"last_seen_at"`
+	Archived               bool      `json:"archived"`
+	Mode                   string    `json:"mode"`
+	CWD                    string    `json:"cwd,omitempty"`
+	AllowedTools           string    `json:"allowed_tools,omitempty"`
+	MaxTurns               int       `json:"max_turns"`
+	MaxBudgetUSD           float64   `json:"max_budget_usd"`
+	Initialized            bool      `json:"initialized"`
+	ClaudeSessionID        string    `json:"claude_session_id,omitempty"`
+	MaxContinuations       int       `json:"max_continuations"`
+	ActivityState          string    `json:"activity_state"`
+	TurnCount              int       `json:"turn_count"`
+	Name                   string    `json:"name"`
+	CompactEveryNContinues int       `json:"compact_every_n_continues"`
+	Model                  string    `json:"-"`
 }
 
 const sessionColumns = `id, computer_name, project_path, COALESCE(transcript_path,''), status, created_at, last_seen_at, archived, mode, COALESCE(cwd,''), COALESCE(allowed_tools,''), max_turns, max_budget_usd, initialized, COALESCE(claude_session_id,''), max_continuations, COALESCE(activity_state,'idle'), turn_count, COALESCE(name,''), compact_every_n_continues, COALESCE(model,'')`
@@ -292,7 +292,6 @@ func (s *Store) SetWorkingToWaiting() error {
 	_, err := s.db.Exec("UPDATE sessions SET activity_state = 'waiting' WHERE activity_state = 'working' AND deleted_at IS NULL")
 	return err
 }
-
 
 func (s *Store) DeleteSession(id string) error {
 	tx, err := s.db.Begin()

--- a/server/db/sessions_test.go
+++ b/server/db/sessions_test.go
@@ -438,3 +438,36 @@ func TestGetManagedSessionNamesByCliIDs(t *testing.T) {
 		}
 	})
 }
+
+func TestRotateClaudeSessionID(t *testing.T) {
+	store := newTestStore(t)
+	sess, err := store.CreateManagedSession("/tmp/rotate", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateClaudeSessionID(sess.ID, "old-claude-id"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetInitialized(sess.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	newID, err := store.RotateClaudeSessionID(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newID == "" || newID == "old-claude-id" {
+		t.Fatalf("newID = %q, want fresh UUID", newID)
+	}
+
+	updated, err := store.GetSessionByID(sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.ClaudeSessionID != newID {
+		t.Fatalf("claude_session_id = %q, want %q", updated.ClaudeSessionID, newID)
+	}
+	if updated.Initialized {
+		t.Fatal("initialized should be reset by rotation")
+	}
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,5 @@
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/server/hooksignal/hooksignal.go
+++ b/server/hooksignal/hooksignal.go
@@ -1,0 +1,76 @@
+// Package hooksignal implements the `claude-controller hook-signal`
+// subcommand. It runs as a Claude Code hook inside managed interactive
+// sessions and relays hook events (SessionStart, Stop, Notification) to the
+// local controller server so it can drive the turn lifecycle.
+package hooksignal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Run reads the Claude Code hook payload from stdin and POSTs a hook-event to
+// the local server. Callers must treat errors as non-fatal: a broken relay
+// must never block Claude (main.go ignores the returned error and exits 0).
+func Run(event, sessionID string, port int, keyFile string, stdin io.Reader) error {
+	if keyFile == "" {
+		keyFile = os.Getenv("CLAUDE_CONTROLLER_KEY_FILE")
+	}
+	if keyFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		keyFile = filepath.Join(home, ".claude-controller", "api.key")
+	}
+	keyData, err := os.ReadFile(keyFile)
+	if err != nil {
+		return fmt.Errorf("read api key: %w", err)
+	}
+	apiKey := strings.TrimSpace(string(keyData))
+
+	var input struct {
+		SessionID      string `json:"session_id"`
+		TranscriptPath string `json:"transcript_path"`
+		Message        string `json:"message"`
+	}
+	raw, _ := io.ReadAll(io.LimitReader(stdin, 1<<20))
+	_ = json.Unmarshal(raw, &input) // tolerate malformed input
+
+	body, err := json.Marshal(map[string]string{
+		"event":             event,
+		"claude_session_id": input.SessionID,
+		"transcript_path":   input.TranscriptPath,
+		"message":           input.Message,
+	})
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("http://localhost:%d/api/sessions/%s/hook-event", port, sessionID)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/server/hooksignal/hooksignal_test.go
+++ b/server/hooksignal/hooksignal_test.go
@@ -1,0 +1,76 @@
+package hooksignal
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestRunPostsHookEvent(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	keyFile := filepath.Join(t.TempDir(), "api.key")
+	os.WriteFile(keyFile, []byte("sk-test-key"), 0600)
+
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+
+	stdin := strings.NewReader(`{"hook_event_name":"Stop","session_id":"cli-uuid","transcript_path":"/tmp/t.jsonl","message":"hello"}`)
+	if err := Run("stop", "managed-1", port, keyFile, stdin); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotPath != "/api/sessions/managed-1/hook-event" {
+		t.Errorf("path = %s", gotPath)
+	}
+	if gotAuth != "Bearer sk-test-key" {
+		t.Errorf("auth = %s", gotAuth)
+	}
+	if gotBody["event"] != "stop" || gotBody["claude_session_id"] != "cli-uuid" ||
+		gotBody["transcript_path"] != "/tmp/t.jsonl" || gotBody["message"] != "hello" {
+		t.Errorf("body = %v", gotBody)
+	}
+}
+
+func TestRunToleratesMalformedStdin(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	keyFile := filepath.Join(t.TempDir(), "api.key")
+	os.WriteFile(keyFile, []byte("k"), 0600)
+
+	u, _ := url.Parse(srv.URL)
+	port, _ := strconv.Atoi(u.Port())
+
+	if err := Run("notification", "m1", port, keyFile, strings.NewReader("not json")); err != nil {
+		t.Fatal(err)
+	}
+	if gotBody["event"] != "notification" {
+		t.Errorf("body = %v", gotBody)
+	}
+}
+
+func TestRunMissingKeyFileReturnsError(t *testing.T) {
+	err := Run("stop", "m1", 1, filepath.Join(t.TempDir(), "nope.key"), strings.NewReader("{}"))
+	if err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -104,12 +104,13 @@ func main() {
 	envPath, _ := filepath.Abs(".env")
 	binaryPath, _ := os.Executable()
 	managedCfg := managed.Config{
-		ClaudeBin:  envOrDefault("CLAUDE_BIN", "claude"),
-		ClaudeArgs: strings.Fields(os.Getenv("CLAUDE_ARGS")),
-		ClaudeEnv:  splitEnv(os.Getenv("CLAUDE_ENV")),
-		ServerPort: *port,
-		BinaryPath: binaryPath,
-		Mode:       managedMode(*managedModeFlag),
+		ClaudeBin:   envOrDefault("CLAUDE_BIN", "claude"),
+		ClaudeArgs:  strings.Fields(os.Getenv("CLAUDE_ARGS")),
+		ClaudeEnv:   splitEnv(os.Getenv("CLAUDE_ENV")),
+		ServerPort:  *port,
+		BinaryPath:  binaryPath,
+		KeyFilePath: filepath.Join(filepath.Dir(*dbPath), "api.key"),
+		Mode:        managedMode(*managedModeFlag),
 	}
 	mgr := managed.NewManager(managedCfg)
 	mgr.StartReaper()

--- a/server/main.go
+++ b/server/main.go
@@ -63,6 +63,7 @@ func main() {
 
 	port := flag.Int("port", 0, "port to listen on (default: 8080, auto-detect if occupied)")
 	dbPath := flag.String("db", "", "path to SQLite database (default: ~/.claude-controller/data.db)")
+	managedModeFlag := flag.String("managed-mode", "", "managed session backend: interactive or print (default: MANAGED_MODE env, then interactive)")
 	flag.Parse()
 
 	if *port == 0 {
@@ -108,7 +109,7 @@ func main() {
 		ClaudeEnv:  splitEnv(os.Getenv("CLAUDE_ENV")),
 		ServerPort: *port,
 		BinaryPath: binaryPath,
-		Mode:       managedMode(),
+		Mode:       managedMode(*managedModeFlag),
 	}
 	mgr := managed.NewManager(managedCfg)
 	mgr.StartReaper()
@@ -278,10 +279,14 @@ func loadDotEnv(path string) {
 // managedMode picks the managed-session backend. "interactive" (default)
 // drives a long-lived interactive Claude Code process billed against the
 // subscription; "print" is the legacy claude -p path kept for one release as
-// a rollback (set MANAGED_MODE=print). Windows has no ConPTY support yet, so
-// it always uses print mode.
-func managedMode() string {
-	mode := envOrDefault("MANAGED_MODE", "interactive")
+// a rollback. Precedence: --managed-mode flag > MANAGED_MODE env (incl. .env)
+// > "interactive". Windows has no ConPTY support yet, so it always uses
+// print mode.
+func managedMode(flagValue string) string {
+	mode := flagValue
+	if mode == "" {
+		mode = envOrDefault("MANAGED_MODE", "interactive")
+	}
 	if runtime.GOOS == "windows" && mode == "interactive" {
 		log.Printf("interactive managed mode is not supported on Windows yet; falling back to print mode")
 		return "print"

--- a/server/main.go
+++ b/server/main.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -107,6 +108,7 @@ func main() {
 		ClaudeEnv:  splitEnv(os.Getenv("CLAUDE_ENV")),
 		ServerPort: *port,
 		BinaryPath: binaryPath,
+		Mode:       managedMode(),
 	}
 	mgr := managed.NewManager(managedCfg)
 	mgr.StartReaper()
@@ -271,6 +273,24 @@ func loadDotEnv(path string) {
 			os.Setenv(strings.TrimSpace(k), strings.TrimSpace(v))
 		}
 	}
+}
+
+// managedMode picks the managed-session backend. "interactive" (default)
+// drives a long-lived interactive Claude Code process billed against the
+// subscription; "print" is the legacy claude -p path kept for one release as
+// a rollback (set MANAGED_MODE=print). Windows has no ConPTY support yet, so
+// it always uses print mode.
+func managedMode() string {
+	mode := envOrDefault("MANAGED_MODE", "interactive")
+	if runtime.GOOS == "windows" && mode == "interactive" {
+		log.Printf("interactive managed mode is not supported on Windows yet; falling back to print mode")
+		return "print"
+	}
+	if mode != "interactive" && mode != "print" {
+		log.Printf("unknown MANAGED_MODE %q, defaulting to interactive", mode)
+		return "interactive"
+	}
+	return mode
 }
 
 func envOrDefault(key, fallback string) string {

--- a/server/main.go
+++ b/server/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jaychinthrajah/claude-controller/server/api"
 	"github.com/jaychinthrajah/claude-controller/server/db"
+	"github.com/jaychinthrajah/claude-controller/server/hooksignal"
 	"github.com/jaychinthrajah/claude-controller/server/managed"
 	"github.com/jaychinthrajah/claude-controller/server/mcp"
 	"github.com/jaychinthrajah/claude-controller/server/scheduler"
@@ -40,6 +41,21 @@ func main() {
 		}
 		if err := mcp.Run(*sessionID, *port); err != nil {
 			log.Fatalf("mcp-bridge error: %v", err)
+		}
+		return
+	}
+
+	if len(os.Args) >= 2 && os.Args[1] == "hook-signal" {
+		fs := flag.NewFlagSet("hook-signal", flag.ExitOnError)
+		event := fs.String("event", "", "hook event name (session_start|stop|notification)")
+		sessionID := fs.String("session-id", "", "managed session ID")
+		hookPort := fs.Int("port", 8080, "server port")
+		keyFile := fs.String("key-file", "", "path to api.key (default ~/.claude-controller/api.key)")
+		fs.Parse(os.Args[2:])
+		// Errors are intentionally swallowed: a broken relay must never
+		// block Claude from finishing its turn.
+		if err := hooksignal.Run(*event, *sessionID, *hookPort, *keyFile, os.Stdin); err != nil {
+			log.Printf("hook-signal: %v", err)
 		}
 		return
 	}

--- a/server/managed/interactive.go
+++ b/server/managed/interactive.go
@@ -1,0 +1,268 @@
+package managed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+var ErrInteractiveUnsupported = errors.New("interactive managed mode is not supported on this platform; set MANAGED_MODE=print")
+
+// InteractiveOpts configures a long-lived interactive Claude Code process.
+type InteractiveOpts struct {
+	Args []string // claude CLI args (no -p)
+	CWD  string
+	// OnTranscriptLine is called for each raw transcript JSONL line appended
+	// after the process spawned (older entries are filtered by timestamp).
+	OnTranscriptLine func(line string)
+}
+
+// InteractiveProc is a persistent interactive Claude Code process driven via PTY.
+type InteractiveProc struct {
+	Cmd          *exec.Cmd
+	PTY          *os.File
+	Done         chan struct{}
+	ExitCode     int
+	SpawnedAt    time.Time
+	LastActivity time.Time
+
+	opts InteractiveOpts
+
+	mu          sync.Mutex
+	tailStarted bool
+	tailCancel  context.CancelFunc
+	stopCh      chan struct{}
+	lastOutput  []byte
+}
+
+const ptyRingSize = 8 * 1024
+
+// LastOutput returns the most recent raw PTY output (up to 8KB), useful for
+// error reporting when the process dies unexpectedly.
+func (p *InteractiveProc) LastOutput() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return string(p.lastOutput)
+}
+
+func (p *InteractiveProc) appendOutput(data []byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastOutput = append(p.lastOutput, data...)
+	if len(p.lastOutput) > ptyRingSize {
+		p.lastOutput = p.lastOutput[len(p.lastOutput)-ptyRingSize:]
+	}
+}
+
+// EnsureInteractive returns the session's running interactive process, or
+// spawns a new one under a PTY.
+func (m *Manager) EnsureInteractive(sessionID string, opts InteractiveOpts) (*InteractiveProc, error) {
+	mu := m.sessionMutex(sessionID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	m.mu.Lock()
+	if proc, ok := m.iprocs[sessionID]; ok {
+		proc.LastActivity = time.Now()
+		m.mu.Unlock()
+		return proc, nil
+	}
+	cfg := m.cfg
+	m.mu.Unlock()
+
+	args := append(append([]string{}, cfg.ClaudeArgs...), opts.Args...)
+	cmd := exec.Command(cfg.ClaudeBin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Env = append(os.Environ(), cfg.ClaudeEnv...)
+	cmd.Env = append(cmd.Env, "CLAUDE_CONTROLLER_MANAGED=1", "TERM=xterm-256color")
+
+	ptmx, err := startPTY(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("start pty: %w", err)
+	}
+
+	now := time.Now()
+	proc := &InteractiveProc{
+		Cmd:          cmd,
+		PTY:          ptmx,
+		Done:         make(chan struct{}),
+		SpawnedAt:    now,
+		LastActivity: now,
+		opts:         opts,
+		stopCh:       make(chan struct{}, 4),
+	}
+
+	m.mu.Lock()
+	m.iprocs[sessionID] = proc
+	m.mu.Unlock()
+
+	// Drain PTY output continuously — the child blocks if the master fills up.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := ptmx.Read(buf)
+			if n > 0 {
+				proc.appendOutput(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		cmd.Wait()
+		if cmd.ProcessState != nil {
+			proc.ExitCode = cmd.ProcessState.ExitCode()
+		}
+		proc.mu.Lock()
+		if proc.tailCancel != nil {
+			proc.tailCancel()
+		}
+		proc.mu.Unlock()
+		ptmx.Close()
+		m.mu.Lock()
+		if m.iprocs[sessionID] == proc {
+			delete(m.iprocs, sessionID)
+		}
+		m.mu.Unlock()
+		close(proc.Done)
+	}()
+
+	return proc, nil
+}
+
+func (m *Manager) getInteractive(sessionID string) *InteractiveProc {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.iprocs[sessionID]
+}
+
+func (m *Manager) IsInteractiveRunning(sessionID string) bool {
+	return m.getInteractive(sessionID) != nil
+}
+
+// SendPrompt types a prompt into the interactive session using bracketed
+// paste (so multi-line text isn't interpreted as separate submissions),
+// followed by Enter.
+func (m *Manager) SendPrompt(sessionID, text string) error {
+	proc := m.getInteractive(sessionID)
+	if proc == nil {
+		return fmt.Errorf("no interactive process for session %s", sessionID)
+	}
+	proc.LastActivity = time.Now()
+	if _, err := proc.PTY.Write([]byte("\x1b[200~" + text + "\x1b[201~")); err != nil {
+		return err
+	}
+	// Small delay so the TUI registers the paste before the submit keypress.
+	time.Sleep(50 * time.Millisecond)
+	_, err := proc.PTY.Write([]byte("\r"))
+	return err
+}
+
+// SendKeys writes a raw key sequence to the session's PTY.
+func (m *Manager) SendKeys(sessionID, seq string) error {
+	proc := m.getInteractive(sessionID)
+	if proc == nil {
+		return fmt.Errorf("no interactive process for session %s", sessionID)
+	}
+	_, err := proc.PTY.Write([]byte(seq))
+	return err
+}
+
+// InterruptInteractive sends ESC, which gracefully interrupts the current
+// turn in interactive Claude Code without killing the process.
+func (m *Manager) InterruptInteractive(sessionID string) error {
+	return m.SendKeys(sessionID, "\x1b")
+}
+
+// SignalStop records a Stop-hook event for the session (non-blocking).
+func (m *Manager) SignalStop(sessionID string) {
+	proc := m.getInteractive(sessionID)
+	if proc == nil {
+		return
+	}
+	select {
+	case proc.stopCh <- struct{}{}:
+	default:
+	}
+}
+
+// StopEvents returns the channel signaled on each Stop hook, or nil if the
+// session has no interactive process.
+func (m *Manager) StopEvents(sessionID string) <-chan struct{} {
+	proc := m.getInteractive(sessionID)
+	if proc == nil {
+		return nil
+	}
+	return proc.stopCh
+}
+
+// SetTranscript starts tailing the given transcript JSONL (idempotent —
+// subsequent calls are no-ops). Called when the SessionStart hook reports the
+// real transcript path. Entries timestamped before the process spawned are
+// filtered so resumed sessions don't replay history.
+func (m *Manager) SetTranscript(sessionID, path string) {
+	proc := m.getInteractive(sessionID)
+	if proc == nil {
+		return
+	}
+	proc.mu.Lock()
+	if proc.tailStarted {
+		proc.mu.Unlock()
+		return
+	}
+	proc.tailStarted = true
+	ctx, cancel := context.WithCancel(context.Background())
+	proc.tailCancel = cancel
+	proc.mu.Unlock()
+
+	var offset int64
+	if fi, err := os.Stat(path); err == nil {
+		offset = fi.Size()
+	}
+	cutoff := proc.SpawnedAt.Add(-5 * time.Second)
+	emit := func(line string) {
+		var meta struct {
+			Timestamp string `json:"timestamp"`
+		}
+		if json.Unmarshal([]byte(line), &meta) == nil && meta.Timestamp != "" {
+			if ts, err := time.Parse(time.RFC3339, meta.Timestamp); err == nil && ts.Before(cutoff) {
+				return
+			}
+		}
+		if proc.opts.OnTranscriptLine != nil {
+			proc.opts.OnTranscriptLine(line)
+		}
+	}
+	go TailTranscript(ctx, path, offset, emit)
+	log.Printf("session %s: tailing transcript %s from offset %d", sessionID, path, offset)
+}
+
+// ShutdownInteractive ends the interactive session gracefully by typing
+// /exit, then kills the process if it doesn't exit within timeout.
+// No-op if no interactive process is running.
+func (m *Manager) ShutdownInteractive(sessionID string, timeout time.Duration) error {
+	proc := m.getInteractive(sessionID)
+	if proc == nil {
+		return nil
+	}
+	proc.PTY.Write([]byte("\x1b")) // clear any in-progress turn or input
+	time.Sleep(50 * time.Millisecond)
+	proc.PTY.Write([]byte("/exit\r"))
+
+	select {
+	case <-proc.Done:
+		return nil
+	case <-time.After(timeout):
+		proc.Cmd.Process.Kill()
+		<-proc.Done
+		return nil
+	}
+}

--- a/server/managed/interactive.go
+++ b/server/managed/interactive.go
@@ -8,8 +8,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 var ErrInteractiveUnsupported = errors.New("interactive managed mode is not supported on this platform; set MANAGED_MODE=print")
@@ -34,14 +37,27 @@ type InteractiveProc struct {
 
 	opts InteractiveOpts
 
-	mu          sync.Mutex
-	tailStarted bool
-	tailCancel  context.CancelFunc
-	stopCh      chan struct{}
-	lastOutput  []byte
+	mu            sync.Mutex
+	tailStarted   bool
+	tailCancel    context.CancelFunc
+	stopCh        chan struct{}
+	lastOutput    []byte
+	outTotal      int64
+	lastOutputAt  time.Time
+	readyDone     bool
+	trustAnswered bool
 }
 
 const ptyRingSize = 8 * 1024
+
+// Readiness tuning for the first prompt after spawn. The TUI takes a few
+// seconds to boot; typing into it earlier loses the prompt. Variables so
+// tests can shorten them.
+var (
+	interactiveReadyQuiescence = 600 * time.Millisecond
+	interactiveReadyTimeout    = 15 * time.Second
+	interactiveReadyPoll       = 25 * time.Millisecond
+)
 
 // LastOutput returns the most recent raw PTY output (up to 8KB), useful for
 // error reporting when the process dies unexpectedly.
@@ -58,6 +74,78 @@ func (p *InteractiveProc) appendOutput(data []byte) {
 	if len(p.lastOutput) > ptyRingSize {
 		p.lastOutput = p.lastOutput[len(p.lastOutput)-ptyRingSize:]
 	}
+	p.outTotal += int64(len(data))
+	p.lastOutputAt = time.Now()
+}
+
+var ansiSeq = regexp.MustCompile(`\x1b\[[0-9;?>]*[a-zA-Z]|\x1b\][^\x07\x1b]*(\x07|\x1b\\)|\x1b[()][0-9A-Z]|\x1b.`)
+
+// compactTerminalText strips ANSI escape sequences and all whitespace so
+// dialog text can be matched even when the TUI interleaves styling or cursor
+// movement mid-phrase.
+func compactTerminalText(s string) string {
+	s = ansiSeq.ReplaceAllString(s, "")
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+func containsTrustDialog(out string) bool {
+	c := compactTerminalText(out)
+	return strings.Contains(c, "trustthisfolder") || strings.Contains(c, "Doyoutrustthefiles")
+}
+
+// waitReady blocks until the TUI looks ready for input: the process has
+// produced output and then gone quiet. Auto-accepts the folder trust dialog
+// (option 1 is preselected, Enter confirms). Gives up at
+// interactiveReadyTimeout and proceeds best-effort. Sticky per process —
+// only the first prompt after spawn pays this wait.
+func (p *InteractiveProc) waitReady(sessionID string) {
+	p.mu.Lock()
+	if p.readyDone {
+		p.mu.Unlock()
+		return
+	}
+	p.mu.Unlock()
+
+	deadline := time.Now().Add(interactiveReadyTimeout)
+	for {
+		select {
+		case <-p.Done:
+			return
+		default:
+		}
+
+		p.mu.Lock()
+		total, last := p.outTotal, p.lastOutputAt
+		ring := string(p.lastOutput)
+		answered := p.trustAnswered
+		p.mu.Unlock()
+
+		if !answered && containsTrustDialog(ring) {
+			log.Printf("session %s: trust dialog detected, auto-accepting", sessionID)
+			p.PTY.Write([]byte("\r"))
+			p.mu.Lock()
+			p.trustAnswered = true
+			p.mu.Unlock()
+			time.Sleep(interactiveReadyPoll)
+			continue
+		}
+		if total > 0 && time.Since(last) >= interactiveReadyQuiescence {
+			break
+		}
+		if time.Now().After(deadline) {
+			log.Printf("session %s: TUI not quiescent after %s, sending prompt anyway", sessionID, interactiveReadyTimeout)
+			break
+		}
+		time.Sleep(interactiveReadyPoll)
+	}
+	p.mu.Lock()
+	p.readyDone = true
+	p.mu.Unlock()
 }
 
 // EnsureInteractive returns the session's running interactive process, or
@@ -138,6 +226,16 @@ func (m *Manager) EnsureInteractive(sessionID string, opts InteractiveOpts) (*In
 	return proc, nil
 }
 
+// TouchInteractive marks the session's interactive process as recently active
+// so the idle reaper doesn't kill it while a turn is in flight.
+func (m *Manager) TouchInteractive(sessionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if proc, ok := m.iprocs[sessionID]; ok {
+		proc.LastActivity = time.Now()
+	}
+}
+
 func (m *Manager) getInteractive(sessionID string) *InteractiveProc {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -157,6 +255,7 @@ func (m *Manager) SendPrompt(sessionID, text string) error {
 		return fmt.Errorf("no interactive process for session %s", sessionID)
 	}
 	proc.LastActivity = time.Now()
+	proc.waitReady(sessionID)
 	if _, err := proc.PTY.Write([]byte("\x1b[200~" + text + "\x1b[201~")); err != nil {
 		return err
 	}

--- a/server/managed/interactive_test.go
+++ b/server/managed/interactive_test.go
@@ -1,0 +1,193 @@
+//go:build !windows
+
+package managed
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestManager(bin string, args ...string) *Manager {
+	return NewManager(Config{ClaudeBin: bin, ClaudeArgs: args, Mode: "interactive"})
+}
+
+func waitFor(t *testing.T, dur time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(dur)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met in time")
+}
+
+func TestEnsureInteractiveSpawnsOnce(t *testing.T) {
+	m := newTestManager("cat")
+	p1, err := m.EnsureInteractive("s1", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("s1", time.Second)
+	p2, err := m.EnsureInteractive("s1", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 != p2 {
+		t.Fatal("expected same process on second EnsureInteractive")
+	}
+	if !m.IsInteractiveRunning("s1") {
+		t.Fatal("expected IsInteractiveRunning true")
+	}
+}
+
+func TestSendPromptWritesBracketedPaste(t *testing.T) {
+	m := newTestManager("cat")
+	proc, err := m.EnsureInteractive("s2", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("s2", time.Second)
+
+	if err := m.SendPrompt("s2", "hello world"); err != nil {
+		t.Fatal(err)
+	}
+	// cat echoes PTY input back to the master; ring buffer captures it.
+	waitFor(t, 2*time.Second, func() bool {
+		out := proc.LastOutput()
+		return strings.Contains(out, "\x1b[200~hello world\x1b[201~")
+	})
+}
+
+func TestSendKeysWritesRaw(t *testing.T) {
+	m := newTestManager("cat")
+	proc, err := m.EnsureInteractive("s3", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("s3", time.Second)
+
+	if err := m.SendKeys("s3", "xyz"); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		return strings.Contains(proc.LastOutput(), "xyz")
+	})
+	// InterruptInteractive sends ESC; the TTY echoes it as caret notation
+	// ("^[") so just verify it writes without error against a live PTY.
+	if err := m.InterruptInteractive("s3"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSignalStopDelivers(t *testing.T) {
+	m := newTestManager("cat")
+	_, err := m.EnsureInteractive("s4", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("s4", time.Second)
+
+	m.SignalStop("s4")
+	select {
+	case <-m.StopEvents("s4"):
+	case <-time.After(time.Second):
+		t.Fatal("stop signal not delivered")
+	}
+}
+
+func TestSignalStopNoProcessIsNoop(t *testing.T) {
+	m := newTestManager("cat")
+	m.SignalStop("nope") // must not panic
+	if ch := m.StopEvents("nope"); ch != nil {
+		t.Fatal("expected nil StopEvents for unknown session")
+	}
+}
+
+func TestSetTranscriptStartsTailerAndFiltersOldEntries(t *testing.T) {
+	old := TranscriptPollInterval
+	TranscriptPollInterval = 20 * time.Millisecond
+	defer func() { TranscriptPollInterval = old }()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.jsonl")
+
+	var mu sync.Mutex
+	var lines []string
+	m := newTestManager("cat")
+	_, err := m.EnsureInteractive("s5", InteractiveOpts{
+		CWD: dir,
+		OnTranscriptLine: func(line string) {
+			mu.Lock()
+			lines = append(lines, line)
+			mu.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("s5", time.Second)
+
+	m.SetTranscript("s5", path)
+	// Second SetTranscript must not start a second tailer (no duplicate lines).
+	m.SetTranscript("s5", path)
+
+	oldEntry, _ := json.Marshal(map[string]any{"type": "assistant", "timestamp": time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)})
+	newEntry, _ := json.Marshal(map[string]any{"type": "assistant", "timestamp": time.Now().UTC().Format(time.RFC3339)})
+	noTS, _ := json.Marshal(map[string]any{"type": "assistant"})
+	os.WriteFile(path, []byte(fmt.Sprintf("%s\n%s\n%s\n", oldEntry, newEntry, noTS)), 0644)
+
+	waitFor(t, 2*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(lines) >= 2
+	})
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (old entry filtered, no-timestamp kept), got %d: %v", len(lines), lines)
+	}
+}
+
+func TestShutdownInteractiveKillsAfterTimeout(t *testing.T) {
+	m := newTestManager("sleep", "60")
+	proc, err := m.EnsureInteractive("s6", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := time.Now()
+	if err := m.ShutdownInteractive("s6", 200*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-proc.Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("process did not die")
+	}
+	if time.Since(start) > 3*time.Second {
+		t.Fatal("shutdown took too long")
+	}
+	if m.IsInteractiveRunning("s6") {
+		t.Fatal("still marked running")
+	}
+}
+
+func TestInteractiveDoesNotBlockShellGuard(t *testing.T) {
+	m := newTestManager("cat")
+	_, err := m.EnsureInteractive("s7", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("s7", time.Second)
+	if m.IsRunning("s7") {
+		t.Fatal("interactive proc must not count as a one-shot process (shell guard)")
+	}
+}

--- a/server/managed/interactive_test.go
+++ b/server/managed/interactive_test.go
@@ -48,7 +48,156 @@ func TestEnsureInteractiveSpawnsOnce(t *testing.T) {
 	}
 }
 
+// fastReady shortens readiness tuning so tests with silent fake binaries
+// (cat) don't block on the ready gate.
+func fastReady(t *testing.T) {
+	t.Helper()
+	oldQ, oldT := interactiveReadyQuiescence, interactiveReadyTimeout
+	interactiveReadyQuiescence = 30 * time.Millisecond
+	interactiveReadyTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		interactiveReadyQuiescence = oldQ
+		interactiveReadyTimeout = oldT
+	})
+}
+
+func writeScript(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-claude.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/bash\n"+body), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSendPromptWaitsForBootQuiescence(t *testing.T) {
+	oldQ, oldT := interactiveReadyQuiescence, interactiveReadyTimeout
+	interactiveReadyQuiescence = 250 * time.Millisecond
+	interactiveReadyTimeout = 5 * time.Second
+	t.Cleanup(func() {
+		interactiveReadyQuiescence = oldQ
+		interactiveReadyTimeout = oldT
+	})
+
+	// Fake TUI: streams boot output for ~800ms, then goes quiet and echoes stdin.
+	script := writeScript(t, `for i in $(seq 1 8); do echo "boot $i"; sleep 0.1; done
+exec cat`)
+	m := newTestManager("/bin/bash", script)
+	proc, err := m.EnsureInteractive("rq1", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("rq1", time.Second)
+
+	start := time.Now()
+	if err := m.SendPrompt("rq1", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 850*time.Millisecond {
+		t.Fatalf("SendPrompt returned after %v; expected it to wait for boot output to go quiet (~1s)", elapsed)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		return strings.Contains(proc.LastOutput(), "\x1b[200~hello\x1b[201~")
+	})
+}
+
+func TestSendPromptAutoAcceptsTrustDialog(t *testing.T) {
+	oldQ, oldT := interactiveReadyQuiescence, interactiveReadyTimeout
+	interactiveReadyQuiescence = 150 * time.Millisecond
+	interactiveReadyTimeout = 5 * time.Second
+	t.Cleanup(func() {
+		interactiveReadyQuiescence = oldQ
+		interactiveReadyTimeout = oldT
+	})
+
+	// Fake trust dialog with ANSI styling interleaved mid-phrase, waiting for
+	// Enter before showing the input screen.
+	script := writeScript(t, `printf 'Is this a project you created or one you \x1b[1mtrust\x1b[0m?\n'
+printf '> 1. Yes, I \x1b[32mtrust this folder\x1b[0m\n  2. No, exit\n'
+read -r _
+echo "TRUSTED"
+exec cat`)
+	m := newTestManager("/bin/bash", script)
+	proc, err := m.EnsureInteractive("rq2", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("rq2", time.Second)
+
+	if err := m.SendPrompt("rq2", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	out := proc.LastOutput()
+	if !strings.Contains(out, "TRUSTED") {
+		t.Fatalf("trust dialog was not auto-accepted; output: %q", out)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		out := proc.LastOutput()
+		return strings.Index(out, "TRUSTED") < strings.Index(out, "\x1b[200~hello\x1b[201~")
+	})
+}
+
+func TestSendPromptProceedsAfterReadyTimeout(t *testing.T) {
+	oldQ, oldT := interactiveReadyQuiescence, interactiveReadyTimeout
+	interactiveReadyQuiescence = 100 * time.Millisecond
+	interactiveReadyTimeout = 300 * time.Millisecond
+	t.Cleanup(func() {
+		interactiveReadyQuiescence = oldQ
+		interactiveReadyTimeout = oldT
+	})
+
+	// Fake TUI that never goes quiet: readiness must give up at the timeout
+	// rather than block forever.
+	script := writeScript(t, `while true; do echo busy; sleep 0.05; done`)
+	m := newTestManager("/bin/bash", script)
+	if _, err := m.EnsureInteractive("rq3", InteractiveOpts{CWD: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("rq3", time.Second)
+
+	start := time.Now()
+	if err := m.SendPrompt("rq3", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("SendPrompt blocked %v; expected it to proceed at the ready timeout", elapsed)
+	}
+}
+
+func TestSendPromptReadyGateIsStickyPerProcess(t *testing.T) {
+	oldQ, oldT := interactiveReadyQuiescence, interactiveReadyTimeout
+	interactiveReadyQuiescence = 300 * time.Millisecond
+	interactiveReadyTimeout = 5 * time.Second
+	t.Cleanup(func() {
+		interactiveReadyQuiescence = oldQ
+		interactiveReadyTimeout = oldT
+	})
+
+	script := writeScript(t, `echo ready
+exec cat`)
+	m := newTestManager("/bin/bash", script)
+	if _, err := m.EnsureInteractive("rq4", InteractiveOpts{CWD: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("rq4", time.Second)
+
+	if err := m.SendPrompt("rq4", "first"); err != nil {
+		t.Fatal(err)
+	}
+	// Second prompt must not pay the quiescence wait again (echo of the first
+	// prompt counts as fresh output, so a non-sticky gate would re-block).
+	start := time.Now()
+	if err := m.SendPrompt("rq4", "second"); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("second SendPrompt waited %v; readiness must be sticky", elapsed)
+	}
+}
+
 func TestSendPromptWritesBracketedPaste(t *testing.T) {
+	fastReady(t)
 	m := newTestManager("cat")
 	proc, err := m.EnsureInteractive("s2", InteractiveOpts{CWD: t.TempDir()})
 	if err != nil {
@@ -101,6 +250,34 @@ func TestSignalStopDelivers(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("stop signal not delivered")
 	}
+}
+
+func TestTouchInteractiveUpdatesLastActivity(t *testing.T) {
+	m := newTestManager("cat")
+	_, err := m.EnsureInteractive("s-touch", InteractiveOpts{CWD: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.ShutdownInteractive("s-touch", time.Second)
+
+	old := time.Now().Add(-time.Hour)
+	m.mu.Lock()
+	m.iprocs["s-touch"].LastActivity = old
+	m.mu.Unlock()
+
+	m.TouchInteractive("s-touch")
+
+	m.mu.Lock()
+	got := m.iprocs["s-touch"].LastActivity
+	m.mu.Unlock()
+	if !got.After(old) {
+		t.Fatalf("LastActivity not updated: %v", got)
+	}
+}
+
+func TestTouchInteractiveNoProcessIsNoop(t *testing.T) {
+	m := newTestManager("cat")
+	m.TouchInteractive("nope") // must not panic
 }
 
 func TestSignalStopNoProcessIsNoop(t *testing.T) {

--- a/server/managed/manager.go
+++ b/server/managed/manager.go
@@ -17,6 +17,10 @@ type Config struct {
 	ServerPort         int
 	BinaryPath         string
 	IdleTimeoutMinutes int
+	// Mode selects the managed-session backend: "interactive" (long-lived
+	// interactive Claude Code under a PTY, billed via subscription) or
+	// "print" (legacy per-message claude -p, billed via API).
+	Mode string
 }
 
 type SpawnOpts struct {
@@ -39,6 +43,7 @@ type Manager struct {
 	cfg          Config
 	mu           sync.Mutex
 	procs        map[string]*Process
+	iprocs       map[string]*InteractiveProc
 	broadcasters map[string]*Broadcaster
 	mutexes      map[string]*sync.Mutex
 }
@@ -47,6 +52,7 @@ func NewManager(cfg Config) *Manager {
 	return &Manager{
 		cfg:          cfg,
 		procs:        make(map[string]*Process),
+		iprocs:       make(map[string]*InteractiveProc),
 		broadcasters: make(map[string]*Broadcaster),
 		mutexes:      make(map[string]*sync.Mutex),
 	}
@@ -194,10 +200,16 @@ func (m *Manager) Interrupt(sessionID string) error {
 func (m *Manager) ReapIdle(maxIdle time.Duration) {
 	m.mu.Lock()
 	var toReap []string
+	var toReapInteractive []string
 	now := time.Now()
 	for id, proc := range m.procs {
 		if now.Sub(proc.LastActivity) > maxIdle {
 			toReap = append(toReap, id)
+		}
+	}
+	for id, proc := range m.iprocs {
+		if now.Sub(proc.LastActivity) > maxIdle {
+			toReapInteractive = append(toReapInteractive, id)
 		}
 	}
 	m.mu.Unlock()
@@ -210,6 +222,11 @@ func (m *Manager) ReapIdle(maxIdle time.Duration) {
 			log.Printf("reaping idle process for session %s", id)
 			proc.Stdin.Close()
 		}
+	}
+
+	for _, id := range toReapInteractive {
+		log.Printf("reaping idle interactive process for session %s", id)
+		m.ShutdownInteractive(id, 10*time.Second)
 	}
 }
 
@@ -305,6 +322,11 @@ func (m *Manager) SpawnShell(sessionID string, opts ShellOpts) (*Process, error)
 }
 
 func (m *Manager) Teardown(sessionID string, timeout time.Duration) error {
+	if m.IsInteractiveRunning(sessionID) {
+		if err := m.ShutdownInteractive(sessionID, timeout); err != nil {
+			return err
+		}
+	}
 	if !m.IsRunning(sessionID) {
 		return nil
 	}
@@ -388,11 +410,19 @@ func (m *Manager) ShutdownAll(timeout time.Duration) {
 	for id := range m.procs {
 		ids = append(ids, id)
 	}
+	iids := make([]string, 0, len(m.iprocs))
+	for id := range m.iprocs {
+		iids = append(iids, id)
+	}
 	m.mu.Unlock()
 
 	for _, id := range ids {
 		log.Printf("shutting down process for session %s", id)
 		m.GracefulShutdown(id, timeout)
+	}
+	for _, id := range iids {
+		log.Printf("shutting down interactive process for session %s", id)
+		m.ShutdownInteractive(id, timeout)
 	}
 }
 

--- a/server/managed/manager.go
+++ b/server/managed/manager.go
@@ -16,6 +16,9 @@ type Config struct {
 	ClaudeEnv          []string
 	ServerPort         int
 	BinaryPath         string
+	// KeyFilePath is the api.key location hook-signal subprocesses must read
+	// (follows the --db directory rather than the default home location).
+	KeyFilePath string
 	IdleTimeoutMinutes int
 	// Mode selects the managed-session backend: "interactive" (long-lived
 	// interactive Claude Code under a PTY, billed via subscription) or

--- a/server/managed/pty_unix.go
+++ b/server/managed/pty_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package managed
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/creack/pty"
+)
+
+// startPTY launches cmd attached to a new pseudo-terminal and returns the
+// master side. Wide window avoids the TUI wrapping long prompts.
+func startPTY(cmd *exec.Cmd) (*os.File, error) {
+	return pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 200})
+}

--- a/server/managed/pty_windows.go
+++ b/server/managed/pty_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package managed
+
+import (
+	"os"
+	"os/exec"
+)
+
+// startPTY is unsupported on Windows (no ConPTY support yet). Managed mode
+// falls back to print mode there — see managedMode in main.go.
+func startPTY(cmd *exec.Cmd) (*os.File, error) {
+	return nil, ErrInteractiveUnsupported
+}

--- a/server/managed/settings.go
+++ b/server/managed/settings.go
@@ -1,0 +1,65 @@
+package managed
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type hookCmd struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+type hookMatcher struct {
+	Hooks []hookCmd `json:"hooks"`
+}
+
+// WriteSessionSettings generates a Claude Code settings file for a managed
+// interactive session: turn-lifecycle hooks pointing back at the controller
+// server, plus permission allow rules mapped from the session's allowed tools
+// (parity with the legacy --allowedTools flag).
+func WriteSessionSettings(dir, binaryPath, sessionID string, port int, allowedToolsJSON string) (string, error) {
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	mk := func(event string) []hookMatcher {
+		cmd := fmt.Sprintf("%q hook-signal --event %s --session-id %s --port %d", binaryPath, event, sessionID, port)
+		return []hookMatcher{{Hooks: []hookCmd{{Type: "command", Command: cmd}}}}
+	}
+	settings := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": mk("session_start"),
+			"Stop":         mk("stop"),
+			"Notification": mk("notification"),
+		},
+	}
+	var tools []string
+	if allowedToolsJSON != "" {
+		_ = json.Unmarshal([]byte(allowedToolsJSON), &tools)
+	}
+	if len(tools) > 0 {
+		settings["permissions"] = map[string]any{"allow": tools}
+	}
+	path := filepath.Join(dir, "settings.json")
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// SessionDir returns the per-session scratch directory for generated files
+// (settings, MCP config). Lives under the user's home so it isn't
+// world-readable like /tmp.
+func SessionDir(sessionID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "claude-controller", "sessions", sessionID)
+	}
+	return filepath.Join(home, ".claude-controller", "sessions", sessionID)
+}

--- a/server/managed/settings.go
+++ b/server/managed/settings.go
@@ -20,12 +20,15 @@ type hookMatcher struct {
 // interactive session: turn-lifecycle hooks pointing back at the controller
 // server, plus permission allow rules mapped from the session's allowed tools
 // (parity with the legacy --allowedTools flag).
-func WriteSessionSettings(dir, binaryPath, sessionID string, port int, allowedToolsJSON string) (string, error) {
+func WriteSessionSettings(dir, binaryPath, sessionID string, port int, allowedToolsJSON, keyFilePath string) (string, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
 	}
 	mk := func(event string) []hookMatcher {
 		cmd := fmt.Sprintf("%q hook-signal --event %s --session-id %s --port %d", binaryPath, event, sessionID, port)
+		if keyFilePath != "" {
+			cmd += fmt.Sprintf(" --key-file %q", keyFilePath)
+		}
 		return []hookMatcher{{Hooks: []hookCmd{{Type: "command", Command: cmd}}}}
 	}
 	settings := map[string]any{

--- a/server/managed/settings_test.go
+++ b/server/managed/settings_test.go
@@ -22,7 +22,7 @@ type settingsFile struct {
 
 func TestWriteSessionSettings(t *testing.T) {
 	dir := t.TempDir()
-	path, err := WriteSessionSettings(dir, "/usr/local/bin/claude controller", "sess-1", 8080, `["Bash","Read"]`)
+	path, err := WriteSessionSettings(dir, "/usr/local/bin/claude controller", "sess-1", 8080, `["Bash","Read"]`, "/home/u/.claude controller/api.key")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,6 +50,11 @@ func TestWriteSessionSettings(t *testing.T) {
 		if !strings.Contains(cmd, "hook-signal") || !strings.Contains(cmd, "--session-id sess-1") || !strings.Contains(cmd, "--port 8080") {
 			t.Errorf("%s hook command malformed: %s", event, cmd)
 		}
+		// hook-signal must read the same api.key the server generated, even
+		// when the server runs with a non-default --db directory.
+		if !strings.Contains(cmd, `--key-file "/home/u/.claude controller/api.key"`) {
+			t.Errorf("%s hook command missing quoted --key-file: %s", event, cmd)
+		}
 		if matchers[0].Hooks[0].Type != "command" {
 			t.Errorf("%s hook type = %s", event, matchers[0].Hooks[0].Type)
 		}
@@ -68,7 +73,7 @@ func TestWriteSessionSettings(t *testing.T) {
 
 func TestWriteSessionSettingsNoTools(t *testing.T) {
 	dir := t.TempDir()
-	path, err := WriteSessionSettings(dir, "/bin/cc", "sess-2", 9090, "")
+	path, err := WriteSessionSettings(dir, "/bin/cc", "sess-2", 9090, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,6 +82,9 @@ func TestWriteSessionSettingsNoTools(t *testing.T) {
 	json.Unmarshal(data, &raw)
 	if _, ok := raw["permissions"]; ok {
 		t.Errorf("permissions should be omitted when no tools: %s", data)
+	}
+	if strings.Contains(string(data), "--key-file") {
+		t.Errorf("--key-file should be omitted when no key path is configured: %s", data)
 	}
 }
 

--- a/server/managed/settings_test.go
+++ b/server/managed/settings_test.go
@@ -1,0 +1,89 @@
+package managed
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type settingsFile struct {
+	Hooks map[string][]struct {
+		Hooks []struct {
+			Type    string `json:"type"`
+			Command string `json:"command"`
+		} `json:"hooks"`
+	} `json:"hooks"`
+	Permissions struct {
+		Allow []string `json:"allow"`
+	} `json:"permissions"`
+}
+
+func TestWriteSessionSettings(t *testing.T) {
+	dir := t.TempDir()
+	path, err := WriteSessionSettings(dir, "/usr/local/bin/claude controller", "sess-1", 8080, `["Bash","Read"]`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join(dir, "settings.json") {
+		t.Fatalf("unexpected path %s", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sf settingsFile
+	if err := json.Unmarshal(data, &sf); err != nil {
+		t.Fatalf("settings not valid JSON: %v", err)
+	}
+
+	for _, event := range []string{"SessionStart", "Stop", "Notification"} {
+		matchers, ok := sf.Hooks[event]
+		if !ok || len(matchers) != 1 || len(matchers[0].Hooks) != 1 {
+			t.Fatalf("missing hook for %s: %s", event, data)
+		}
+		cmd := matchers[0].Hooks[0].Command
+		if !strings.Contains(cmd, `"/usr/local/bin/claude controller"`) {
+			t.Errorf("%s hook command does not quote binary path: %s", event, cmd)
+		}
+		if !strings.Contains(cmd, "hook-signal") || !strings.Contains(cmd, "--session-id sess-1") || !strings.Contains(cmd, "--port 8080") {
+			t.Errorf("%s hook command malformed: %s", event, cmd)
+		}
+		if matchers[0].Hooks[0].Type != "command" {
+			t.Errorf("%s hook type = %s", event, matchers[0].Hooks[0].Type)
+		}
+	}
+	if !strings.Contains(sf.Hooks["Stop"][0].Hooks[0].Command, "--event stop") {
+		t.Errorf("stop hook missing event flag: %s", sf.Hooks["Stop"][0].Hooks[0].Command)
+	}
+	if !strings.Contains(sf.Hooks["SessionStart"][0].Hooks[0].Command, "--event session_start") {
+		t.Errorf("session_start hook missing event flag")
+	}
+
+	if len(sf.Permissions.Allow) != 2 || sf.Permissions.Allow[0] != "Bash" || sf.Permissions.Allow[1] != "Read" {
+		t.Errorf("permissions.allow = %v", sf.Permissions.Allow)
+	}
+}
+
+func TestWriteSessionSettingsNoTools(t *testing.T) {
+	dir := t.TempDir()
+	path, err := WriteSessionSettings(dir, "/bin/cc", "sess-2", 9090, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	var raw map[string]json.RawMessage
+	json.Unmarshal(data, &raw)
+	if _, ok := raw["permissions"]; ok {
+		t.Errorf("permissions should be omitted when no tools: %s", data)
+	}
+}
+
+func TestSessionDirIsPerSession(t *testing.T) {
+	a := SessionDir("aaa")
+	b := SessionDir("bbb")
+	if a == b || !strings.Contains(a, "aaa") {
+		t.Fatalf("SessionDir not per-session: %s vs %s", a, b)
+	}
+}

--- a/server/managed/transcript.go
+++ b/server/managed/transcript.go
@@ -1,0 +1,66 @@
+package managed
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"time"
+)
+
+// TranscriptPollInterval controls tail polling frequency. Overridden in tests.
+var TranscriptPollInterval = 200 * time.Millisecond
+
+// TailTranscript polls path for appended JSONL lines starting at offset and
+// calls emit for each complete line (without trailing newline). Tolerates the
+// file not existing yet, and resets to the start if the file shrinks
+// (truncate/recreate). Returns when ctx is done.
+func TailTranscript(ctx context.Context, path string, offset int64, emit func(string)) {
+	var partial bytes.Buffer
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(TranscriptPollInterval):
+		}
+
+		fi, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if fi.Size() < offset {
+			offset = 0
+			partial.Reset()
+		}
+		if fi.Size() == offset {
+			continue
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			f.Close()
+			continue
+		}
+		data, err := io.ReadAll(f)
+		f.Close()
+		if err != nil {
+			continue
+		}
+		offset += int64(len(data))
+		partial.Write(data)
+
+		for {
+			idx := bytes.IndexByte(partial.Bytes(), '\n')
+			if idx < 0 {
+				break
+			}
+			line := string(partial.Next(idx + 1)[:idx])
+			if line != "" {
+				emit(line)
+			}
+		}
+	}
+}

--- a/server/managed/transcript_test.go
+++ b/server/managed/transcript_test.go
@@ -1,0 +1,117 @@
+package managed
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func collectLines(t *testing.T, path string, offset int64, dur time.Duration) []string {
+	t.Helper()
+	old := TranscriptPollInterval
+	TranscriptPollInterval = 20 * time.Millisecond
+	defer func() { TranscriptPollInterval = old }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), dur)
+	defer cancel()
+	var mu sync.Mutex
+	var got []string
+	done := make(chan struct{})
+	go func() {
+		TailTranscript(ctx, path, offset, func(line string) {
+			mu.Lock()
+			got = append(got, line)
+			mu.Unlock()
+		})
+		close(done)
+	}()
+	<-done
+	mu.Lock()
+	defer mu.Unlock()
+	return got
+}
+
+func TestTailTranscriptReadsAppendedLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	os.WriteFile(path, []byte("{\"a\":1}\n"), 0644)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+		f.WriteString("{\"b\":2}\n")
+		f.Close()
+	}()
+	got := collectLines(t, path, 0, 500*time.Millisecond)
+	if len(got) != 2 || got[0] != `{"a":1}` || got[1] != `{"b":2}` {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestTailTranscriptWaitsForFileToExist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "later.jsonl")
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		os.WriteFile(path, []byte("{\"x\":1}\n"), 0644)
+	}()
+	got := collectLines(t, path, 0, 500*time.Millisecond)
+	if len(got) != 1 || got[0] != `{"x":1}` {
+		t.Fatalf("expected 1 line, got %v", got)
+	}
+}
+
+func TestTailTranscriptRespectsOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	content := "{\"old\":1}\n"
+	os.WriteFile(path, []byte(content), 0644)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+		f.WriteString("{\"new\":2}\n")
+		f.Close()
+	}()
+	got := collectLines(t, path, int64(len(content)), 500*time.Millisecond)
+	if len(got) != 1 || got[0] != `{"new":2}` {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestTailTranscriptHandlesPartialLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	os.WriteFile(path, []byte(`{"par`), 0644)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+		f.WriteString("tial\":1}\n")
+		f.Close()
+	}()
+	got := collectLines(t, path, 0, 500*time.Millisecond)
+	if len(got) != 1 || got[0] != `{"partial":1}` {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestTailTranscriptResetsOnTruncation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	os.WriteFile(path, []byte("{\"a\":1}\n{\"b\":2}\n"), 0644)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		os.WriteFile(path, []byte("{\"c\":3}\n"), 0644)
+	}()
+	got := collectLines(t, path, 0, 500*time.Millisecond)
+	want := []string{`{"a":1}`, `{"b":2}`, `{"c":3}`}
+	if len(got) != 3 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2121,6 +2121,26 @@ document.addEventListener('alpine:init', () => {
             return;
           }
 
+          if (data.type === 'notification') {
+            this.chatMessages.push({
+              id: 'notification-' + Date.now(),
+              role: 'system',
+              content: data.message || 'Claude sent a notification'
+            });
+            this.$nextTick(() => this.scrollToBottom(true));
+            return;
+          }
+
+          if (data.type === 'budget_exceeded') {
+            this.chatMessages.push({
+              id: 'budget-' + Date.now(),
+              role: 'system',
+              content: `Budget limit reached ($${(data.total || 0).toFixed(2)} of $${(data.budget || 0).toFixed(2)}). Session paused.`
+            });
+            this.$nextTick(() => this.scrollToBottom(true));
+            return;
+          }
+
           if (data.type === 'done' || data.type === 'result') {
             // Track cost from result events — always, including compact turns
             if (data.type === 'result' && data.cost != null) {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2054,7 +2054,8 @@ document.addEventListener('alpine:init', () => {
               outputMsg.complete = true;
             }
             this.activeShellId = null;
-            this.stopSessionSSE();
+            // Keep SSE open — the stream is shared with chat events and a
+            // turn may still be in flight. Heartbeats keep it alive when idle.
             return;
           }
 
@@ -2162,7 +2163,10 @@ document.addEventListener('alpine:init', () => {
           if (data.type === 'done') {
             this.pendingPermission = null;
             this.finalizeAgentInvocations();
-            this.stopSessionSSE();
+            // Keep the SSE connection open: in interactive mode the Claude
+            // process outlives the turn and can produce more output (e.g.
+            // resuming after a background task completes). Server heartbeats
+            // keep the idle connection alive.
             return;
           }
 
@@ -2287,28 +2291,21 @@ document.addEventListener('alpine:init', () => {
       this.sseReconnectAttempts++;
 
       this.sseReconnectTimer = setTimeout(async () => {
-        // Check session state to decide reconnect strategy
+        if (sessionId !== this.selectedSessionId) return;
+        // Reachability probe — never give up silently on a bad response;
+        // retry with backoff until the attempt cap handles it.
         try {
           const resp = await fetch(`/api/sessions/${sessionId}`, {
             headers: { 'Authorization': `Bearer ${this.apiKey}` }
           });
-          if (!resp.ok) return;
-          const session = await resp.json();
-          if (session.activity_state !== 'working') {
-            // Session not currently working — reload messages to catch anything missed
-            await this.fetchManagedMessages(sessionId);
-            // Still reconnect SSE so we're listening if the session resumes
-            // (e.g., after compact finishes and new process starts)
-            this.startSessionSSE(sessionId);
-            return;
-          }
+          if (!resp.ok) throw new Error(`session fetch ${resp.status}`);
         } catch (e) {
-          // Server unreachable, try again later
           this.attemptSSEReconnect(sessionId);
           return;
         }
-
-        // Session still working — reconnect SSE
+        // Reload messages to catch anything broadcast while disconnected —
+        // events are not replayed on reconnect, only persisted to the DB.
+        await this.fetchManagedMessages(sessionId);
         this.startSessionSSE(sessionId);
       }, delay);
     },


### PR DESCRIPTION
Closes #174

## Summary

Managed mode now drives one **long-lived interactive Claude Code process per session** (PTY + hooks + transcript tailing) instead of per-message `claude -p`, so usage bills against the Claude Code subscription rather than the API after the upcoming pricing change.

**Architecture (issue tasks 2-6):**
- **PTY lifecycle** (`server/managed/interactive.go`, `pty_unix.go`): spawned via `creack/pty`; prompts injected with bracketed paste + Enter; interrupts via ESC keystroke (process survives); graceful shutdown types `/exit`. Idle reaper / `ShutdownAll` / `Teardown` cover interactive procs.
- **Structured output** (`server/managed/transcript.go`): tails the native transcript JSONL in `~/.claude/projects/` and forwards **raw lines** to the existing SSE pipeline. Transcript shapes match stream-json assistant events, so web UI and iOS parsing are unchanged. Tolerant parsing: unknown fields/types pass through or are skipped, never fatal. Entries older than process spawn are filtered (resume-fork replay protection).
- **Turn lifecycle via hooks**: a generated per-session `--settings` file injects SessionStart/Stop/Notification hooks running the new `claude-controller hook-signal` subcommand, which POSTs to `POST /api/sessions/{id}/hook-event`. SessionStart reports the real CLI session ID + transcript path (interactive `--resume` forks to a new ID); Stop ends the turn (server synthesizes the `result`/`done` events print mode used to emit and sets `activity_state=waiting`); Notification broadcasts to the UI.
- **Feature parity** (issue task 5): `--allowedTools` maps to `permissions.allow` in the settings file; turn limits are enforced by counting assistant transcript entries and ESC-interrupting, feeding the existing auto-continue flow; `--max-budget-usd` becomes server-side cost accumulation from transcript usage (`SessionCostTotal`).
- **`/compact` + interrupts** (issue task 6): compact-every-N types `/compact` into the live session; the interrupt endpoint sends ESC with a fallback stop signal in case the Stop hook does not fire for interrupted turns.
- **Rollback**: legacy `-p` path is fully intact behind `MANAGED_MODE=print`; Windows is forced to print mode (no ConPTY in v1, per issue risk note).

**Documented parity gaps:**
- Permission prompts for non-allowlisted tools surface as notifications only - no remote approve/deny (the `--permission-prompt-tool` MCP bridge is print-mode-only).
- Image uploads are referenced by file path in the prompt ("use the Read tool to view it") instead of inline base64.
- Model is fixed at process spawn; mid-session model changes apply on next spawn.

**Spike caveat (issue task 1):** PTY drivability is validated by the `managed` package tests (real PTY with stub processes). Subscription billing of interactive usage cannot be verified programmatically - needs manual confirmation post-pricing-change before removing the print path.

## Test plan
- [x] `go test ./...` green (new coverage: transcript tailer, settings generator, PTY lifecycle, hook-signal, hook-event endpoint, interactive orchestrator incl. max-turns/budget/auto-continue)
- [x] `GOOS=windows go build ./...` (print-mode fallback compiles)
- [ ] Manual: create a managed session in the web UI with `MANAGED_MODE=interactive`, send a message, verify streaming, stop-hook turn completion, interrupt, `/compact`
- [ ] Manual: verify `MANAGED_MODE=print` still behaves exactly as before (rollback path)
- [ ] Manual: confirm interactive usage bills against subscription after pricing change

Plan: `docs/superpowers/plans/2026-06-11-interactive-managed-sessions.md`
