### PR TITLE
fix(web): pass unrecognized slash commands through to Claude process

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -1288,8 +1288,10 @@ document.addEventListener('alpine:init', () => {
           headers: { 'Authorization': `Bearer ${this.apiKey}` }
         });
         if (!resp.ok) {
-          this.chatMessages.push({ role: 'system', content: `Unknown command: ${cmdName}`, msg_type: 'text', timestamp: new Date().toISOString() });
-          this.$nextTick(() => this.scrollToBottom(true));
+          // Command not found locally — pass through to the Claude process
+          // which handles skills and other slash commands natively.
+          this.inputText = cmdArg ? `${cmdName} ${cmdArg}` : cmdName;
+          await this.sendManagedMessage();
           return;
         }
         const data = await resp.json();


### PR DESCRIPTION
## Summary
- Skills like `/git-main` and `/git-issue-create` were showing "Unknown command" in the managed session web UI because it intercepted slash commands and only searched `.claude/commands/`
- Now unrecognized commands fall through to the interactive Claude Code process, which handles skills natively via the PTY

## Test plan
- [ ] Type a known custom command (from `.claude/commands/`) — still resolves locally
- [ ] Type a skill command like `/git-main` — passes through to Claude process instead of "Unknown command"
- [ ] Type `/compact` or other built-in commands — still handled client-side as before