### PR TITLE
fix(web): add scrollable containers to sidebar sections

### DIFF
--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -933,6 +933,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  max-height: 30vh;
+  overflow-y: auto;
 }
 
 .issue-row {


### PR DESCRIPTION
## Summary
- Add `max-height: 30vh` and `overflow-y: auto` to `.issue-list` so Skills, Issues, and Pull Requests sidebar sections scroll independently when lists are long
- Headers and search bars remain visible outside the scrollable area

Closes #177

## Test plan
- [ ] Open a managed session with many GitHub issues/PRs — verify each section scrolls independently
- [ ] Verify short lists show no scrollbar
- [ ] Verify all three sections (Skills, Issues, PRs) remain reachable regardless of list length