### PR TITLE
fix(web): prevent skill click from sending duplicate commands

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2494,7 +2494,12 @@ document.addEventListener('alpine:init', () => {
     sendSkill(skillName) {
       if (!this.selectedSessionId || !skillName) return;
       this.inputText = '/' + skillName;
-      this.$nextTick(() => this.handleInput());
+      const sess = this.currentSession;
+      if (sess && sess.mode === 'managed') {
+        this.$nextTick(() => this.sendManagedMessage());
+      } else {
+        this.$nextTick(() => this.handleInput());
+      }
     },
 
     // GitHub Issues methods


### PR DESCRIPTION
Fixes #179

## Summary
- Clicking a skill in the sidebar sent the command twice because `sendSkill()` routed through `handleInput()` → `executeSlashCommand()` → `executeCustomCommand()` → `sendManagedMessage()`, which pushed the user message to `chatMessages` in two places (line 1127 in `executeSlashCommand` and line 1765 in `sendManagedMessage`)
- For managed sessions, `sendSkill()` now calls `sendManagedMessage()` directly, bypassing the slash command pipeline since skills are always pass-through commands to the Claude process
- Hook mode sessions still route through `handleInput()` → `sendInstruction()`, which has no duplicate push

## Test plan
- [ ] Click a skill in the desktop sidebar — verify only one message appears in chat
- [ ] Click a skill in the mobile sidebar — verify only one message appears in chat
- [ ] Verify the skill command is sent to and processed by the Claude session
- [ ] Verify built-in slash commands (`/clear`, `/help`, `/status`) still work correctly