### PR TITLE
fix: suppress "No response requested" CLI noise in web UI

### DIFF
--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -113,6 +113,14 @@ type interactiveTranscriptEntry struct {
 	} `json:"message"`
 }
 
+// isCliNoiseMessage returns true for known CLI-internal messages that should
+// not surface in the web UI (e.g. "No response requested." when input arrives
+// in an unexpected state).
+func isCliNoiseMessage(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	return trimmed == "No response requested." || trimmed == "No response requested"
+}
+
 // hasOnlyTextContent reports whether a user entry's content is plain text
 // (the echo of a prompt we sent) rather than tool results.
 func hasOnlyTextContent(content json.RawMessage) bool {
@@ -284,6 +292,10 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 		}
 		switch entry.Type {
 		case "assistant":
+			if text := extractAssistantText(line); isCliNoiseMessage(text) {
+				log.Printf("session %s: suppressed CLI noise message: %q", sessionID, text)
+				return
+			}
 			broadcaster.Send(line)
 			if text := extractAssistantText(line); text != "" {
 				_, _ = s.store.CreateMessage(sessionID, "assistant", text, 0)
@@ -372,6 +384,28 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 			default:
 			}
 			break
+		}
+
+		// Guard: verify the process is still alive before injecting the
+		// prompt. The process may have died between EnsureInteractive and
+		// now, and writing to a stale PTY can produce CLI noise like
+		// "No response requested." instead of a clear error.
+		select {
+		case <-proc.Done:
+			if s.retryAfterSessionIDConflict(sess, prompt, turn, broadcaster, proc, attempt) {
+				return
+			}
+			state := "waiting"
+			if proc.ExitCode != 0 {
+				state = "idle"
+			}
+			errMsg := `{"type":"system","error":true,"message":"Session process exited unexpectedly. Please send your message again."}`
+			broadcaster.Send(errMsg)
+			_, _ = s.store.CreateMessage(sessionID, "system", "Session process exited unexpectedly. Please send your message again.", 0)
+			_ = s.store.UpdateActivityState(sessionID, state)
+			broadcaster.Send(fmt.Sprintf(`{"type":"done","exit_code":%d}`, proc.ExitCode))
+			return
+		default:
 		}
 
 		if err := s.manager.SendPrompt(sessionID, currentPrompt); err != nil {

--- a/server/api/managed_interactive_test.go
+++ b/server/api/managed_interactive_test.go
@@ -440,3 +440,97 @@ func TestInteractiveSessionIDConflictRotatesAndRetries(t *testing.T) {
 		t.Error("no system message explaining the session-ID conflict")
 	}
 }
+
+func TestIsCliNoiseMessage(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"No response requested.", true},
+		{"No response requested", true},
+		{"  No response requested.  ", true},
+		{"\nNo response requested.\n", true},
+		{"Hello, how can I help?", false},
+		{"No response requested. But here's something.", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isCliNoiseMessage(tt.input)
+		if got != tt.want {
+			t.Errorf("isCliNoiseMessage(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestInteractiveNoResponseRequestedSuppressed(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-noise", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := sendMessage(ts, sess.ID, "continue")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	waitForTranscriptFn(t, mock, sess.ID)
+
+	// Emit the CLI noise message via transcript
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLine("No response requested.", 0, 0))
+	// Then emit a real assistant message and stop
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLine("Here is the real response", 100, 50))
+	mock.SignalStop(sess.ID)
+
+	// Collect all broadcast messages
+	var assistantTexts []string
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case msg := <-ch:
+			var obj map[string]any
+			json.Unmarshal([]byte(msg), &obj)
+			if obj["type"] == "assistant" {
+				if text := extractAssistantText(msg); text != "" {
+					assistantTexts = append(assistantTexts, text)
+				}
+			}
+			if obj["type"] == "done" {
+				goto done
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for done event")
+		}
+	}
+done:
+
+	// "No response requested." must NOT appear in broadcast messages
+	for _, text := range assistantTexts {
+		if isCliNoiseMessage(text) {
+			t.Errorf("CLI noise message was broadcast: %q", text)
+		}
+	}
+	// The real response must appear
+	found := false
+	for _, text := range assistantTexts {
+		if strings.Contains(text, "real response") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("real assistant message was not broadcast")
+	}
+
+	// Verify the noise message was not persisted to DB
+	msgs, _ := store.ListMessages(sess.ID)
+	for _, m := range msgs {
+		if m.Role == "assistant" && isCliNoiseMessage(m.Content) {
+			t.Errorf("CLI noise message was persisted to DB: %q", m.Content)
+		}
+	}
+}

--- a/server/api/transcript.go
+++ b/server/api/transcript.go
@@ -109,8 +109,7 @@ func (s *Server) handleGetTranscript(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case block.Type == "text" && block.Text != "":
 				text := strings.TrimSpace(block.Text)
-				// Skip noise messages
-				if text == "[Request interrupted by user]" || text == "" {
+				if text == "[Request interrupted by user]" || text == "" || isCliNoiseMessage(text) {
 					continue
 				}
 				messages = append(messages, transcriptMessage{

--- a/server/api/transcript_test.go
+++ b/server/api/transcript_test.go
@@ -63,6 +63,49 @@ func TestGetTranscript(t *testing.T) {
 	}
 }
 
+func TestGetTranscript_FiltersCliNoiseMessages(t *testing.T) {
+	ts, store := newTestServer(t)
+
+	tmpDir := t.TempDir()
+	transcriptFile := filepath.Join(tmpDir, "test-noise.jsonl")
+	lines := []string{
+		`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"continue"}]},"timestamp":"2026-06-14T10:00:00Z"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"No response requested."}]},"timestamp":"2026-06-14T10:00:01Z"}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Here is the real answer."}]},"timestamp":"2026-06-14T10:00:02Z"}`,
+	}
+	var content []byte
+	for _, l := range lines {
+		content = append(content, []byte(l+"\n")...)
+	}
+	os.WriteFile(transcriptFile, content, 0644)
+
+	session, _ := store.UpsertSession("mac1", "/proj", transcriptFile)
+
+	req := authReq("GET", ts.URL+"/api/sessions/"+session.ID+"/transcript", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var messages []struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	json.NewDecoder(resp.Body).Decode(&messages)
+
+	// "No response requested." should be filtered out, leaving 2 messages
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d: %+v", len(messages), messages)
+	}
+	if messages[0].Content != "continue" {
+		t.Errorf("msg 0 content: %q", messages[0].Content)
+	}
+	if messages[1].Content != "Here is the real answer." {
+		t.Errorf("msg 1 content: %q", messages[1].Content)
+	}
+}
+
 func TestGetTranscript_NoPath(t *testing.T) {
 	ts, store := newTestServer(t)
 	session, _ := store.UpsertSession("mac1", "/proj", "")


### PR DESCRIPTION
## Summary

Closes #181

- Filter the CLI-internal "No response requested." message at the transcript callback layer so it never reaches SSE broadcast or DB persistence
- Filter the same message from the transcript REST API so historical fetches don't surface it
- Add a process-alive guard before prompt injection to detect when the Claude process dies between `EnsureInteractive` and `SendPrompt`, surfacing a user-friendly "send again" message instead of cryptic CLI output

## Test plan

- [x] `TestIsCliNoiseMessage` — unit test for the noise detection helper (exact match, whitespace variants, non-matches)
- [x] `TestInteractiveNoResponseRequestedSuppressed` — integration test verifying the message is suppressed from SSE broadcast and DB, while real messages pass through
- [x] `TestGetTranscript_FiltersCliNoiseMessages` — integration test verifying the transcript API endpoint filters the noise message from historical fetches
- [x] Full test suite passes with no regressions