### PR TITLE
feat(web): add linked PR/branch indicators and comment threads to issues view

### DIFF
--- a/server/api/github.go
+++ b/server/api/github.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 func jsonError(w http.ResponseWriter, msg string, status int) {
@@ -32,6 +33,22 @@ type issueResponse struct {
 	Author    string       `json:"author"`
 	Labels    []issueLabel `json:"labels"`
 	Body      string       `json:"body"`
+	Comments  int          `json:"comments"`
+}
+
+type linkedPR struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	State   string `json:"state"`
+	IsDraft bool   `json:"is_draft"`
+	Branch  string `json:"branch"`
+}
+
+type issueComment struct {
+	ID        int    `json:"id"`
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }
 
 type issueListResponse struct {
@@ -52,14 +69,15 @@ type ghAPILabel struct {
 }
 
 type ghAPIIssue struct {
-	Number       int              `json:"number"`
-	Title        string           `json:"title"`
-	State        string           `json:"state"`
-	CreatedAt    string           `json:"created_at"`
-	User         ghAPIUser        `json:"user"`
-	Labels       []ghAPILabel     `json:"labels"`
-	Body         string           `json:"body"`
-	PullRequest  *json.RawMessage `json:"pull_request,omitempty"`
+	Number      int              `json:"number"`
+	Title       string           `json:"title"`
+	State       string           `json:"state"`
+	CreatedAt   string           `json:"created_at"`
+	User        ghAPIUser        `json:"user"`
+	Labels      []ghAPILabel     `json:"labels"`
+	Body        string           `json:"body"`
+	Comments    int              `json:"comments"`
+	PullRequest *json.RawMessage `json:"pull_request,omitempty"`
 }
 
 func reshapeAPIIssue(g ghAPIIssue) issueResponse {
@@ -75,6 +93,7 @@ func reshapeAPIIssue(g ghAPIIssue) issueResponse {
 		Author:    g.User.Login,
 		Labels:    labels,
 		Body:      g.Body,
+		Comments:  g.Comments,
 	}
 }
 
@@ -539,4 +558,280 @@ func (s *Server) handleGetGithubPull(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(reshapeAPIPull(raw))
+}
+
+// Issue comments endpoint
+
+type ghAPIComment struct {
+	ID        int       `json:"id"`
+	User      ghAPIUser `json:"user"`
+	Body      string    `json:"body"`
+	CreatedAt string    `json:"created_at"`
+}
+
+func (s *Server) handleListIssueComments(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		jsonError(w, "Session not found", http.StatusNotFound)
+		return
+	}
+	if sess.Mode != "managed" {
+		jsonError(w, "Comments are only available for managed sessions", http.StatusBadRequest)
+		return
+	}
+	cwd := sess.CWD
+	if cwd == "" {
+		jsonError(w, "Session has no working directory", http.StatusBadRequest)
+		return
+	}
+
+	numberStr := r.PathValue("number")
+	number, err := strconv.Atoi(numberStr)
+	if err != nil || number < 1 {
+		jsonError(w, "Invalid issue number", http.StatusBadRequest)
+		return
+	}
+
+	token := s.githubToken()
+	if token == "" {
+		jsonError(w, "GitHub token not configured — add it in Settings", http.StatusBadRequest)
+		return
+	}
+
+	repo, err := repoFromRemote(cwd)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/issues/%d/comments?per_page=100", repo, number)
+	body, status, err := githubAPIGet(token, apiURL)
+	if err != nil {
+		jsonError(w, "Failed to reach GitHub API", http.StatusInternalServerError)
+		return
+	}
+	if status == 401 || status == 403 {
+		jsonError(w, "GitHub token is invalid or lacks permissions — update it in Settings", http.StatusUnauthorized)
+		return
+	}
+	if status != 200 {
+		jsonError(w, fmt.Sprintf("GitHub API error (HTTP %d)", status), http.StatusInternalServerError)
+		return
+	}
+
+	var raw []ghAPIComment
+	if err := json.Unmarshal(body, &raw); err != nil {
+		jsonError(w, "Unexpected response from GitHub API", http.StatusInternalServerError)
+		return
+	}
+
+	comments := make([]issueComment, 0, len(raw))
+	for _, c := range raw {
+		comments = append(comments, issueComment{
+			ID:        c.ID,
+			Author:    c.User.Login,
+			Body:      c.Body,
+			CreatedAt: c.CreatedAt,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(comments)
+}
+
+// Linked PRs via timeline endpoint
+
+type ghTimelineEvent struct {
+	Event  string `json:"event"`
+	Source *struct {
+		Type  string `json:"type"`
+		Issue *struct {
+			Number      int              `json:"number"`
+			Title       string           `json:"title"`
+			State       string           `json:"state"`
+			Draft       bool             `json:"draft"`
+			PullRequest *json.RawMessage `json:"pull_request,omitempty"`
+			Head        *struct {
+				Ref string `json:"ref"`
+			} `json:"head,omitempty"`
+		} `json:"issue,omitempty"`
+	} `json:"source,omitempty"`
+}
+
+func fetchLinkedPRs(token, repo string, issueNumber int) ([]linkedPR, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/issues/%d/timeline?per_page=100", repo, issueNumber)
+	body, status, err := githubAPIGet(token, apiURL)
+	if err != nil {
+		return nil, err
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("GitHub API error (HTTP %d)", status)
+	}
+
+	var events []ghTimelineEvent
+	if err := json.Unmarshal(body, &events); err != nil {
+		return nil, err
+	}
+
+	seen := map[int]bool{}
+	var prs []linkedPR
+	for _, ev := range events {
+		if ev.Event != "cross-referenced" || ev.Source == nil || ev.Source.Issue == nil {
+			continue
+		}
+		issue := ev.Source.Issue
+		if issue.PullRequest == nil {
+			continue
+		}
+		if seen[issue.Number] {
+			continue
+		}
+		seen[issue.Number] = true
+		branch := ""
+		if issue.Head != nil {
+			branch = issue.Head.Ref
+		}
+		prs = append(prs, linkedPR{
+			Number:  issue.Number,
+			Title:   issue.Title,
+			State:   issue.State,
+			IsDraft: issue.Draft,
+			Branch:  branch,
+		})
+	}
+	return prs, nil
+}
+
+func (s *Server) handleListIssueLinkedPRs(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		jsonError(w, "Session not found", http.StatusNotFound)
+		return
+	}
+	if sess.Mode != "managed" {
+		jsonError(w, "Linked PRs are only available for managed sessions", http.StatusBadRequest)
+		return
+	}
+	cwd := sess.CWD
+	if cwd == "" {
+		jsonError(w, "Session has no working directory", http.StatusBadRequest)
+		return
+	}
+
+	numberStr := r.PathValue("number")
+	number, err := strconv.Atoi(numberStr)
+	if err != nil || number < 1 {
+		jsonError(w, "Invalid issue number", http.StatusBadRequest)
+		return
+	}
+
+	token := s.githubToken()
+	if token == "" {
+		jsonError(w, "GitHub token not configured — add it in Settings", http.StatusBadRequest)
+		return
+	}
+
+	repo, err := repoFromRemote(cwd)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	prs, err := fetchLinkedPRs(token, repo, number)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if prs == nil {
+		prs = []linkedPR{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(prs)
+}
+
+// Batch linked PRs — fetches timeline for multiple issues in parallel
+
+type batchLinkedResult struct {
+	IssueNumber int        `json:"issue_number"`
+	LinkedPRs   []linkedPR `json:"linked_prs"`
+}
+
+func (s *Server) handleBatchLinkedPRs(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		jsonError(w, "Session not found", http.StatusNotFound)
+		return
+	}
+	if sess.Mode != "managed" {
+		jsonError(w, "Linked PRs are only available for managed sessions", http.StatusBadRequest)
+		return
+	}
+	cwd := sess.CWD
+	if cwd == "" {
+		jsonError(w, "Session has no working directory", http.StatusBadRequest)
+		return
+	}
+
+	issuesParam := r.URL.Query().Get("issues")
+	if issuesParam == "" {
+		jsonError(w, "Missing 'issues' query parameter", http.StatusBadRequest)
+		return
+	}
+
+	parts := strings.Split(issuesParam, ",")
+	var issueNumbers []int
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil || n < 1 {
+			continue
+		}
+		issueNumbers = append(issueNumbers, n)
+	}
+	if len(issueNumbers) == 0 {
+		jsonError(w, "No valid issue numbers provided", http.StatusBadRequest)
+		return
+	}
+	if len(issueNumbers) > 20 {
+		issueNumbers = issueNumbers[:20]
+	}
+
+	token := s.githubToken()
+	if token == "" {
+		jsonError(w, "GitHub token not configured — add it in Settings", http.StatusBadRequest)
+		return
+	}
+
+	repo, err := repoFromRemote(cwd)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	results := make([]batchLinkedResult, len(issueNumbers))
+	var wg sync.WaitGroup
+	for i, num := range issueNumbers {
+		wg.Add(1)
+		go func(idx, issueNum int) {
+			defer wg.Done()
+			prs, err := fetchLinkedPRs(token, repo, issueNum)
+			if err != nil {
+				prs = []linkedPR{}
+			}
+			if prs == nil {
+				prs = []linkedPR{}
+			}
+			results[idx] = batchLinkedResult{
+				IssueNumber: issueNum,
+				LinkedPRs:   prs,
+			}
+		}(i, num)
+	}
+	wg.Wait()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(results)
 }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -98,7 +98,10 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 
 	// GitHub endpoints
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues", s.handleListGithubIssues)
+	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues/linked", s.handleBatchLinkedPRs)
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues/{number}", s.handleGetGithubIssue)
+	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues/{number}/comments", s.handleListIssueComments)
+	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues/{number}/linked-prs", s.handleListIssueLinkedPRs)
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/pulls", s.handleListGithubPulls)
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/pulls/{number}", s.handleGetGithubPull)
 

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -89,6 +89,10 @@ document.addEventListener('alpine:init', () => {
     selectedIssue: null,
     selectedIssueLoading: false,
     _searchIssuesTimer: null,
+    issueLinkedPRs: {},  // map of issueNumber -> [{number, title, state, is_draft, branch}]
+    issueComments: [],
+    issueCommentsLoading: false,
+    issueCommentsExpanded: true,
 
     // GitHub Pull Requests state
     githubPulls: [],
@@ -2528,6 +2532,7 @@ document.addEventListener('alpine:init', () => {
         this.githubIssues = data.issues || [];
         this.githubIssuesHasMore = data.has_more || false;
         if (data.repo) this.githubRepo = data.repo;
+        this.fetchBatchLinkedPRs(sessionId, this.githubIssues);
       } catch (e) {
         this.githubIssuesError = e.message || 'Failed to load issues';
       } finally {
@@ -2538,6 +2543,8 @@ document.addEventListener('alpine:init', () => {
     async fetchIssueDetail(sessionId, number) {
       if (!sessionId) return;
       this.selectedIssueLoading = true;
+      this.issueComments = [];
+      this.issueCommentsLoading = true;
       // Close any open file/pull viewer and open issue in viewer panel
       this.closeFileViewer();
       this.selectedPull = null;
@@ -2549,6 +2556,8 @@ document.addEventListener('alpine:init', () => {
         if (resp.status === 401) { this.disconnect(); return; }
         if (!resp.ok) return;
         this.selectedIssue = await resp.json();
+        this.fetchIssueComments(sessionId, number);
+        this.fetchIssueLinkedPRs(sessionId, number);
       } catch (e) {
         // Ignore — keep selectedIssue as null
       } finally {
@@ -2559,6 +2568,8 @@ document.addEventListener('alpine:init', () => {
     closeIssueViewer() {
       this.selectedIssue = null;
       this.selectedPull = null;
+      this.issueComments = [];
+      this.issueCommentsLoading = false;
     },
 
     toggleIssueState(state) {
@@ -2617,6 +2628,71 @@ Create a feature branch, implement the solution, and open a draft PR linking to 
       const g = parseInt(hex.substring(2, 4), 16);
       const b = parseInt(hex.substring(4, 6), 16);
       return `background: rgba(${r},${g},${b},0.2); color: rgb(${r},${g},${b}); border-color: rgba(${r},${g},${b},0.4);`;
+    },
+
+    async fetchBatchLinkedPRs(sessionId, issues) {
+      if (!sessionId || !issues || issues.length === 0) return;
+      const numbers = issues.map(i => i.number).join(',');
+      try {
+        const resp = await fetch(`/api/sessions/${sessionId}/github/issues/linked?issues=${numbers}`, {
+          headers: { 'Authorization': 'Bearer ' + this.apiKey }
+        });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        const map = { ...this.issueLinkedPRs };
+        for (const item of data) {
+          map[item.issue_number] = item.linked_prs || [];
+        }
+        this.issueLinkedPRs = map;
+      } catch (e) {
+        // Non-critical — badges just won't show
+      }
+    },
+
+    async fetchIssueComments(sessionId, number) {
+      this.issueCommentsLoading = true;
+      try {
+        const resp = await fetch(`/api/sessions/${sessionId}/github/issues/${number}/comments`, {
+          headers: { 'Authorization': 'Bearer ' + this.apiKey }
+        });
+        if (!resp.ok) return;
+        this.issueComments = await resp.json();
+      } catch (e) {
+        this.issueComments = [];
+      } finally {
+        this.issueCommentsLoading = false;
+      }
+    },
+
+    async fetchIssueLinkedPRs(sessionId, number) {
+      try {
+        const resp = await fetch(`/api/sessions/${sessionId}/github/issues/${number}/linked-prs`, {
+          headers: { 'Authorization': 'Bearer ' + this.apiKey }
+        });
+        if (!resp.ok) return;
+        const prs = await resp.json();
+        this.issueLinkedPRs = { ...this.issueLinkedPRs, [number]: prs };
+      } catch (e) {
+        // Non-critical
+      }
+    },
+
+    linkedPRsForIssue(number) {
+      return this.issueLinkedPRs[number] || [];
+    },
+
+    prStateBadgeStyle(pr) {
+      if (pr.is_draft) return 'background:rgba(110,118,129,0.3);color:#8b949e;';
+      if (pr.state === 'closed') return 'background:rgba(248,81,73,0.2);color:#f85149;';
+      if (pr.state === 'open') return 'background:rgba(35,134,54,0.2);color:#3fb950;';
+      return 'background:rgba(139,92,246,0.2);color:#a78bfa;';
+    },
+
+    prStateLabel(pr) {
+      if (pr.is_draft) return 'Draft';
+      if (pr.state === 'closed') return 'Merged';
+      if (pr.state === 'open') return 'Open';
+      return pr.state;
     },
 
     // GitHub Pull Requests methods

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2621,6 +2621,14 @@ Create a feature branch, implement the solution, and open a draft PR linking to 
       return `${Math.floor(hours / 24)}d ago`;
     },
 
+    renderMarkdown(text) {
+      const fallback = text || '';
+      if (typeof marked === 'undefined') return fallback;
+      const html = marked.parse(fallback);
+      if (typeof DOMPurify !== 'undefined') return DOMPurify.sanitize(html);
+      return html;
+    },
+
     issueLabelStyle(label) {
       if (!label || !label.color) return '';
       const hex = label.color.replace('#', '');

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/png" href="/favicon.png">
   <link rel="stylesheet" href="/style.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.5/dist/purify.min.js" integrity="sha384-qSFej5dZNviyoPgYJ5+Xk4bEbX8AYddxAHPuzs1aSgRiXxJ3qmyWNaPsRkpv/+x5" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" media="(prefers-color-scheme: light)">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
@@ -571,7 +572,7 @@
                       </template>
                     </div>
                     <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
-                         x-html="typeof marked !== 'undefined' ? marked.parse(selectedIssue.body || '*No description*') : (selectedIssue.body || '(No description)')"></div>
+                         x-html="renderMarkdown(selectedIssue.body || '*No description*')"></div>
 
                     <!-- Linked PRs -->
                     <template x-if="linkedPRsForIssue(selectedIssue.number).length > 0">
@@ -609,7 +610,7 @@
                               <span class="issue-comment-time" x-text="issueTimeAgo(comment.created_at)"></span>
                             </div>
                             <div class="issue-comment-body issue-body"
-                                 x-html="typeof marked !== 'undefined' ? marked.parse(comment.body || '') : (comment.body || '')"></div>
+                                 x-html="renderMarkdown(comment.body)"></div>
                           </div>
                         </template>
                       </div>
@@ -646,7 +647,7 @@
                       </template>
                     </div>
                     <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
-                         x-html="typeof marked !== 'undefined' ? marked.parse(selectedPull.body || '*No description*') : (selectedPull.body || '(No description)')"></div>
+                         x-html="renderMarkdown(selectedPull.body || '*No description*')"></div>
                   </div>
                 </div>
               </div>
@@ -1234,7 +1235,7 @@
             </template>
           </div>
           <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
-               x-html="typeof marked !== 'undefined' ? marked.parse(selectedIssue?.body || '*No description*') : (selectedIssue?.body || '(No description)')"></div>
+               x-html="renderMarkdown(selectedIssue?.body || '*No description*')"></div>
 
           <!-- Linked PRs (mobile) -->
           <template x-if="selectedIssue && linkedPRsForIssue(selectedIssue.number).length > 0">
@@ -1271,7 +1272,7 @@
                     <span class="issue-comment-time" x-text="issueTimeAgo(comment.created_at)"></span>
                   </div>
                   <div class="issue-comment-body issue-body"
-                       x-html="typeof marked !== 'undefined' ? marked.parse(comment.body || '') : (comment.body || '')"></div>
+                       x-html="renderMarkdown(comment.body)"></div>
                 </div>
               </template>
             </div>

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -572,6 +572,48 @@
                     </div>
                     <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
                          x-html="typeof marked !== 'undefined' ? marked.parse(selectedIssue.body || '*No description*') : (selectedIssue.body || '(No description)')"></div>
+
+                    <!-- Linked PRs -->
+                    <template x-if="linkedPRsForIssue(selectedIssue.number).length > 0">
+                      <div class="issue-linked-prs">
+                        <div class="issue-section-header">
+                          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+                          Linked Pull Requests
+                        </div>
+                        <template x-for="pr in linkedPRsForIssue(selectedIssue.number)" :key="pr.number">
+                          <div class="linked-pr-item">
+                            <a class="linked-pr-link" :href="'https://github.com/' + githubRepo + '/pull/' + pr.number" target="_blank" rel="noopener">
+                              <span class="linked-pr-number" x-text="'#' + pr.number"></span>
+                              <span class="linked-pr-title" x-text="pr.title"></span>
+                            </a>
+                            <span class="linked-pr-state" :style="prStateBadgeStyle(pr)" x-text="prStateLabel(pr)"></span>
+                            <span class="linked-pr-branch" x-show="pr.branch" x-text="pr.branch"></span>
+                          </div>
+                        </template>
+                      </div>
+                    </template>
+
+                    <!-- Comments thread -->
+                    <div class="issue-comments-section" x-show="selectedIssue.comments > 0 || issueCommentsLoading">
+                      <div class="issue-section-header" style="cursor:pointer" @click="issueCommentsExpanded = !issueCommentsExpanded">
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 01.75.75v2.19l2.72-2.72a.749.749 0 01.53-.22h4.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25H2.75z"/></svg>
+                        <span x-text="'Comments (' + (selectedIssue.comments || 0) + ')'"></span>
+                        <span class="issues-toggle" x-text="issueCommentsExpanded ? '▼' : '▶'" style="margin-left:auto;font-size:9px"></span>
+                      </div>
+                      <div x-show="issueCommentsExpanded" x-collapse>
+                        <div x-show="issueCommentsLoading" class="issues-loading" style="padding:8px 0">Loading comments...</div>
+                        <template x-for="comment in issueComments" :key="comment.id">
+                          <div class="issue-comment">
+                            <div class="issue-comment-header">
+                              <span class="issue-comment-author" x-text="comment.author"></span>
+                              <span class="issue-comment-time" x-text="issueTimeAgo(comment.created_at)"></span>
+                            </div>
+                            <div class="issue-comment-body issue-body"
+                                 x-html="typeof marked !== 'undefined' ? marked.parse(comment.body || '') : (comment.body || '')"></div>
+                          </div>
+                        </template>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -728,7 +770,23 @@
                   <div class="issue-dot" :class="issue.state"></div>
                   <div class="issue-row-content">
                     <div class="issue-row-title" x-text="issue.title"></div>
-                    <div class="issue-row-meta" x-text="'#' + issue.number + ' · ' + issueTimeAgo(issue.updated_at)"></div>
+                    <div class="issue-row-meta">
+                      <span x-text="'#' + issue.number + ' · ' + issueTimeAgo(issue.updated_at)"></span>
+                      <span class="issue-row-badges">
+                        <template x-if="linkedPRsForIssue(issue.number).length > 0">
+                          <span class="issue-badge issue-badge-pr" :title="linkedPRsForIssue(issue.number).map(p => '#' + p.number).join(', ')">
+                            <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+                            <span x-text="linkedPRsForIssue(issue.number).length"></span>
+                          </span>
+                        </template>
+                        <template x-if="issue.comments > 0">
+                          <span class="issue-badge issue-badge-comments">
+                            <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 01.75.75v2.19l2.72-2.72a.749.749 0 01.53-.22h4.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25H2.75z"/></svg>
+                            <span x-text="issue.comments"></span>
+                          </span>
+                        </template>
+                      </span>
+                    </div>
                   </div>
                 </div>
               </template>
@@ -1177,6 +1235,47 @@
           </div>
           <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
                x-html="typeof marked !== 'undefined' ? marked.parse(selectedIssue?.body || '*No description*') : (selectedIssue?.body || '(No description)')"></div>
+
+          <!-- Linked PRs (mobile) -->
+          <template x-if="selectedIssue && linkedPRsForIssue(selectedIssue.number).length > 0">
+            <div class="issue-linked-prs">
+              <div class="issue-section-header">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+                Linked Pull Requests
+              </div>
+              <template x-for="pr in linkedPRsForIssue(selectedIssue.number)" :key="pr.number">
+                <div class="linked-pr-item">
+                  <a class="linked-pr-link" :href="'https://github.com/' + githubRepo + '/pull/' + pr.number" target="_blank" rel="noopener">
+                    <span class="linked-pr-number" x-text="'#' + pr.number"></span>
+                    <span class="linked-pr-title" x-text="pr.title"></span>
+                  </a>
+                  <span class="linked-pr-state" :style="prStateBadgeStyle(pr)" x-text="prStateLabel(pr)"></span>
+                </div>
+              </template>
+            </div>
+          </template>
+
+          <!-- Comments thread (mobile) -->
+          <div class="issue-comments-section" x-show="selectedIssue?.comments > 0 || issueCommentsLoading">
+            <div class="issue-section-header" style="cursor:pointer" @click="issueCommentsExpanded = !issueCommentsExpanded">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 01.75.75v2.19l2.72-2.72a.749.749 0 01.53-.22h4.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25H2.75z"/></svg>
+              <span x-text="'Comments (' + (selectedIssue?.comments || 0) + ')'"></span>
+              <span class="issues-toggle" x-text="issueCommentsExpanded ? '▼' : '▶'" style="margin-left:auto;font-size:9px"></span>
+            </div>
+            <div x-show="issueCommentsExpanded" x-collapse>
+              <div x-show="issueCommentsLoading" class="issues-loading" style="padding:8px 0">Loading comments...</div>
+              <template x-for="comment in issueComments" :key="comment.id">
+                <div class="issue-comment">
+                  <div class="issue-comment-header">
+                    <span class="issue-comment-author" x-text="comment.author"></span>
+                    <span class="issue-comment-time" x-text="issueTimeAgo(comment.created_at)"></span>
+                  </div>
+                  <div class="issue-comment-body issue-body"
+                       x-html="typeof marked !== 'undefined' ? marked.parse(comment.body || '') : (comment.body || '')"></div>
+                </div>
+              </template>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1154,6 +1154,158 @@ body {
   color: var(--text-muted);
 }
 
+/* Issue row badges (PR link count, comment count) */
+.issue-row-badges {
+  display: inline-flex;
+  gap: 6px;
+  margin-left: 4px;
+}
+
+.issue-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.issue-badge svg {
+  opacity: 0.7;
+}
+
+.issue-badge-pr {
+  color: #3fb950;
+}
+
+.issue-badge-comments {
+  color: var(--text-muted);
+}
+
+/* Linked PRs section in issue detail */
+.issue-linked-prs {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.issue-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.linked-pr-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  margin-bottom: 2px;
+  font-size: 12px;
+}
+
+.linked-pr-item:hover {
+  background: var(--bg-secondary);
+}
+
+.linked-pr-link {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text);
+  text-decoration: none;
+  min-width: 0;
+  flex: 1;
+}
+
+.linked-pr-link:hover {
+  color: var(--accent);
+}
+
+.linked-pr-number {
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.linked-pr-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.linked-pr-state {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.linked-pr-branch {
+  font-size: 10px;
+  font-family: monospace;
+  color: var(--text-muted);
+  background: var(--bg-secondary);
+  padding: 1px 5px;
+  border-radius: 3px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Issue comments section */
+.issue-comments-section {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.issue-comment {
+  padding: 10px;
+  margin-bottom: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+}
+
+.issue-comment-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.issue-comment-author {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.issue-comment-time {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.issue-comment-body {
+  max-height: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin-bottom: 0;
+}
+
+.issue-comment-body p { margin: 0.25em 0; }
+.issue-comment-body p:first-child { margin-top: 0; }
+.issue-comment-body p:last-child { margin-bottom: 0; }
+
 /* Main content split */
 .main-content-split { display: flex; flex: 1; overflow: hidden; }
 .chat-column { display: flex; flex-direction: column; flex: 1; min-width: 0; overflow: hidden; }


### PR DESCRIPTION
## Summary

Closes #182

- **Linked PR badges** on issue list rows — shows PR icon with count when an issue has cross-referenced pull requests
- **Comment count badges** on issue list rows — shows comment icon with count
- **Linked PRs section** in issue detail view — displays each linked PR with number, title, state (Open/Draft/Merged), and branch name, linking to GitHub
- **Collapsible comment thread** in issue detail view — renders full comment bodies with author/timestamp using markdown
- **Batch linked PRs endpoint** (`GET /api/sessions/{id}/github/issues/linked?issues=1,2,3`) — fetches GitHub timeline events for multiple issues in parallel using goroutines, extracting cross-referenced PRs
- **Per-issue endpoints** for comments (`GET .../issues/{number}/comments`) and linked PRs (`GET .../issues/{number}/linked-prs`)

## Implementation

**Backend (Go):**
- Added `comments` count to `issueResponse` (free from existing GitHub REST API data)
- New `linkedPR` and `issueComment` response types
- Timeline API integration via `fetchLinkedPRs()` — parses `cross-referenced` events to find PRs
- Batch endpoint caps at 20 issues and uses `sync.WaitGroup` for parallel fetches

**Frontend (Alpine.js):**
- `issueLinkedPRs` map caches linked PR data keyed by issue number
- Batch fetch fires automatically after issue list loads
- Detail view fetches comments and linked PRs on open
- Mobile view includes both sections

## Test plan

- [x] Go server builds cleanly
- [x] All existing tests pass
- [ ] Verify issue list shows PR/comment badges for issues with linked PRs and comments
- [ ] Verify clicking an issue shows linked PRs section with correct state badges
- [ ] Verify comment thread renders with markdown formatting
- [ ] Verify collapsible comments toggle works
- [ ] Verify mobile view shows both sections
- [ ] Verify no badges appear for issues without PRs/comments