### PR TITLE
fix: preserve _ and . in Claude project dir encoding

### DIFF
--- a/server/api/resume.go
+++ b/server/api/resume.go
@@ -14,7 +14,8 @@ import (
 )
 
 // claudeProjectDir encodes a CWD to match Claude Code's project directory naming.
-// Replaces /, _, and . with -. Handles Windows paths (backslashes, drive letter colon).
+// Replaces / with -; preserves _ and . (Claude Code 2.1.x preserves them).
+// Handles Windows paths (backslashes, drive letter colon).
 func claudeProjectDir(cwd string) string {
 	// Normalize Windows backslashes to forward slashes
 	cwd = filepath.ToSlash(cwd)
@@ -22,8 +23,7 @@ func claudeProjectDir(cwd string) string {
 	if len(cwd) >= 2 && cwd[1] == ':' {
 		cwd = cwd[:1] + cwd[2:]
 	}
-	r := strings.NewReplacer("/", "-", "_", "-", ".", "-")
-	return r.Replace(cwd)
+	return strings.ReplaceAll(cwd, "/", "-")
 }
 
 func claudeConfigDir() (string, error) {

--- a/server/api/resume_test.go
+++ b/server/api/resume_test.go
@@ -1,0 +1,35 @@
+package api
+
+import "testing"
+
+func TestClaudeProjectDir(t *testing.T) {
+	cases := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{
+			name: "preserves underscores",
+			cwd:  "/Users/jay/workspaces/_personal_/claude-control",
+			want: "-Users-jay-workspaces-_personal_-claude-control",
+		},
+		{
+			name: "preserves dots",
+			cwd:  "/Users/jay/workspaces/_personal_/jay-day/.claude-worktrees/inspiring-panini",
+			want: "-Users-jay-workspaces-_personal_-jay-day-.claude-worktrees-inspiring-panini",
+		},
+		{
+			name: "plain path",
+			cwd:  "/Users/jay/workspaces/404-checker",
+			want: "-Users-jay-workspaces-404-checker",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := claudeProjectDir(tc.cwd)
+			if got != tc.want {
+				t.Errorf("claudeProjectDir(%q)\n  got  %q\n  want %q", tc.cwd, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2236,7 +2236,7 @@ document.addEventListener('alpine:init', () => {
             // Show error messages from the server
             this.chatMessages.push({
               role: 'system',
-              content: data.stderr || 'Process error (exit code ' + data.exit_code + ')',
+              content: data.stderr || data.message || 'Process error (exit code ' + data.exit_code + ')',
               msg_type: 'text',
               timestamp: new Date().toISOString()
             });


### PR DESCRIPTION
## Summary

- Claude Code 2.1.x preserves `_` and `.` in `~/.claude/projects/` directory names; only `/` is replaced with `-`. The controller was replacing all three, so the transcript fallback path and `/resume` lookups silently missed sessions for any CWD containing `_` or `.` (e.g. `/workspaces/_personal_/claude-control`).
- When the SessionStart hook fired late, the interactive backend's 30 s fallback tailed a non-existent transcript path, causing the managed session to appear hung in the web UI while Claude was actually still processing in the background.
- Also fixed the chat UI to fall through to `data.message` on system errors. Without this, the actual "Prompt submission not confirmed — the Claude TUI may be blocked by a dialog" warning was being replaced with the unhelpful "Process error (exit code undefined)".
- Added a test pinning the encoding so this doesn't regress.

## Test plan

- [x] `go test ./api/ -run TestClaudeProjectDir -v` — new test passes (preserves underscores, preserves dots, plain path)
- [x] `go test ./...` — full server suite still green
- [ ] Start the managed session interactively against a CWD containing `_` (e.g. `/workspaces/_personal_/claude-control`) and confirm prompts now complete without the "Prompt submission not confirmed" warning
- [ ] Run `/resume` from a managed session in the same CWD and confirm previous sessions appear in the picker