### PR TITLE
fix: match Claude Code current project dir encoding for resume

### DIFF
--- a/server/api/resume.go
+++ b/server/api/resume.go
@@ -14,16 +14,14 @@ import (
 )
 
 // claudeProjectDir encodes a CWD to match Claude Code's project directory naming.
-// Replaces / with -; preserves _ and . (Claude Code 2.1.x preserves them).
-// Handles Windows paths (backslashes, drive letter colon).
+// Replaces /, _, and . with -. Handles Windows paths (backslashes, drive letter colon).
 func claudeProjectDir(cwd string) string {
-	// Normalize Windows backslashes to forward slashes
 	cwd = filepath.ToSlash(cwd)
-	// Strip drive letter colon (e.g. "C:/Users/..." -> "C/Users/...")
 	if len(cwd) >= 2 && cwd[1] == ':' {
 		cwd = cwd[:1] + cwd[2:]
 	}
-	return strings.ReplaceAll(cwd, "/", "-")
+	r := strings.NewReplacer("/", "-", "_", "-", ".", "-")
+	return r.Replace(cwd)
 }
 
 func claudeConfigDir() (string, error) {

--- a/server/api/resume_test.go
+++ b/server/api/resume_test.go
@@ -9,14 +9,14 @@ func TestClaudeProjectDir(t *testing.T) {
 		want string
 	}{
 		{
-			name: "preserves underscores",
+			name: "replaces underscores",
 			cwd:  "/Users/jay/workspaces/_personal_/claude-control",
-			want: "-Users-jay-workspaces-_personal_-claude-control",
+			want: "-Users-jay-workspaces--personal--claude-control",
 		},
 		{
-			name: "preserves dots",
+			name: "replaces dots",
 			cwd:  "/Users/jay/workspaces/_personal_/jay-day/.claude-worktrees/inspiring-panini",
-			want: "-Users-jay-workspaces-_personal_-jay-day-.claude-worktrees-inspiring-panini",
+			want: "-Users-jay-workspaces--personal--jay-day--claude-worktrees-inspiring-panini",
 		},
 		{
 			name: "plain path",


### PR DESCRIPTION
## Summary
- Claude Code changed its project directory encoding to replace `_` and `.` with `-`, but the controller's `claudeProjectDir` still preserved them
- This caused `/resume` to look in the wrong directory (e.g. `-_personal_-` instead of `--personal--`) and report no sessions found
- Updated encoding to use `strings.NewReplacer` for `/`, `_`, and `.` → `-`

## Test plan
- [x] `TestClaudeProjectDir` passes with updated expectations
- [ ] Run `/resume` in the web UI for a project under `_personal_/` and verify sessions appear