### PR TITLE
Fix workflow progress panel to display step names instead of UUIDs

### DIFF
--- a/server/db/workflows.go
+++ b/server/db/workflows.go
@@ -235,6 +235,7 @@ type WorkflowRunStep struct {
 	ID         string     `json:"id"`
 	RunID      string     `json:"run_id"`
 	StepID     string     `json:"step_id"`
+	StepName   string     `json:"step_name"`
 	Status     string     `json:"status"`
 	Attempt    int        `json:"attempt"`
 	StartedAt  *time.Time `json:"started_at"`
@@ -334,7 +335,7 @@ func (s *Store) CreateWorkflowRunSteps(runID string, stepIDs []string) error {
 // GetWorkflowRunSteps returns run steps ordered by their parent step's step_order.
 func (s *Store) GetWorkflowRunSteps(runID string) ([]WorkflowRunStep, error) {
 	rows, err := s.db.Query(`
-		SELECT rs.id, rs.run_id, rs.step_id, rs.status, rs.attempt, rs.started_at, rs.finished_at, rs.error
+		SELECT rs.id, rs.run_id, rs.step_id, ws.name, rs.status, rs.attempt, rs.started_at, rs.finished_at, rs.error
 		FROM workflow_run_steps rs
 		JOIN workflow_steps ws ON rs.step_id = ws.id
 		WHERE rs.run_id = ?
@@ -347,7 +348,7 @@ func (s *Store) GetWorkflowRunSteps(runID string) ([]WorkflowRunStep, error) {
 	var steps []WorkflowRunStep
 	for rows.Next() {
 		var rs WorkflowRunStep
-		if err := rows.Scan(&rs.ID, &rs.RunID, &rs.StepID, &rs.Status, &rs.Attempt, &rs.StartedAt, &rs.FinishedAt, &rs.Error); err != nil {
+		if err := rows.Scan(&rs.ID, &rs.RunID, &rs.StepID, &rs.StepName, &rs.Status, &rs.Attempt, &rs.StartedAt, &rs.FinishedAt, &rs.Error); err != nil {
 			return nil, fmt.Errorf("scan run step: %w", err)
 		}
 		steps = append(steps, rs)

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -416,7 +416,7 @@
                     <span style="width:14px;text-align:center;font-size:11px;"
                           :style="rs.status === 'completed' ? 'color:#22c55e;' : rs.status === 'running' ? 'color:#f59e0b;' : rs.status === 'failed' ? 'color:#ef4444;' : 'color:#6b7280;'"
                           x-text="rs.status === 'completed' ? '✓' : rs.status === 'running' ? '▶' : rs.status === 'failed' ? '✕' : '●'"></span>
-                    <span style="flex:1;color:var(--text);" x-text="rs.step_id"></span>
+                    <span style="flex:1;color:var(--text);" x-text="rs.step_name"></span>
                     <span x-show="rs.attempt > 1" style="color:var(--text-muted);font-size:10px;" x-text="'attempt ' + rs.attempt"></span>
                     <span x-show="rs.error" style="color:#ef4444;font-size:10px;" x-text="rs.error"></span>
                   </div>


### PR DESCRIPTION
## Summary
- Add `StepName` field to `WorkflowRunStep` struct
- Join `workflow_steps.name` in `GetWorkflowRunSteps` query (the JOIN already existed for ordering)
- Render `rs.step_name` instead of `rs.step_id` in the progress panel UI

Fixes #192

## Test plan
- [x] `go build ./...` passes
- [x] All workflow DB tests pass (`go test ./db/ -v -run Workflow`)
- [ ] Manual: create a workflow with named steps, start a run, verify the progress panel shows step names