### PR TITLE
fix: correct Fable model ID and add backend pricing constant

### DIFF
--- a/server/api/pricing.go
+++ b/server/api/pricing.go
@@ -6,6 +6,7 @@ const (
 	ModelHaiku  = "claude-haiku-4-5-20251001"
 	ModelSonnet = "claude-sonnet-4-6"
 	ModelOpus   = "claude-opus-4-6"
+	ModelFable  = "claude-fable-5[1m]"
 
 	// EscalateAfterChars is the message length threshold (in Unicode code points)
 	// above which selectModel auto-escalates to Sonnet 4.6.
@@ -19,6 +20,7 @@ var modelPrices = map[string]struct{ InputPer1M, OutputPer1M float64 }{
 	ModelHaiku:  {0.80, 4.00},
 	ModelSonnet: {3.00, 15.00},
 	ModelOpus:   {15.00, 75.00},
+	ModelFable:  {1.00, 5.00},
 }
 
 // selectModel picks the model for a managed session turn.

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -541,7 +541,7 @@
                   <option value="">Auto</option>
                   <option value="claude-opus-4-6">Opus</option>
                   <option value="claude-sonnet-4-6">Sonnet</option>
-                  <option value="claude-fable-4-5">Fable</option>
+                  <option value="claude-fable-5[1m]">Fable</option>
                   <option value="claude-haiku-4-5-20251001">Haiku</option>
                 </select>
                 <span class="input-hint">⌘↵ to send</span>
@@ -1751,7 +1751,7 @@
               <option value="">Default</option>
               <option value="claude-opus-4-6">Opus</option>
               <option value="claude-sonnet-4-6">Sonnet</option>
-              <option value="claude-fable-4-5">Fable</option>
+              <option value="claude-fable-5[1m]">Fable</option>
               <option value="claude-haiku-4-5-20251001">Haiku</option>
             </select>
           </div>


### PR DESCRIPTION
Closes #194

## Summary
- Fixed frontend model ID from `claude-fable-4-5` to `claude-fable-5[1m]` in both chat UI and scheduled tasks dropdowns
- Added `ModelFable` constant and per-token pricing to the backend `modelPrices` map in `pricing.go`

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [ ] Verify `claude --model "claude-fable-5[1m]"` works with the CLI (brackets may need quoting)
- [ ] Select Fable in the web UI chat model picker and confirm the correct model ID is sent
- [ ] Select Fable in the scheduled tasks modal and confirm the correct model ID is sent