### PR TITLE
Add live visibility and skill-trust caching for scheduled task runs

### DIFF
--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -38,7 +38,7 @@ const promptEchoRetries = 2
 // buildInteractiveArgs builds CLI args for a long-lived interactive process.
 // Tool restrictions and lifecycle hooks travel via the generated settings
 // file rather than -p-only flags.
-func buildInteractiveArgs(sess *db.Session, settingsPath string) []string {
+func buildInteractiveArgs(sess *db.Session, settingsPath, trustPrompt string) []string {
 	var args []string
 	resumeID := sess.ID
 	if sess.ClaudeSessionID != "" {
@@ -54,6 +54,9 @@ func buildInteractiveArgs(sess *db.Session, settingsPath string) []string {
 	}
 	if settingsPath != "" {
 		args = append(args, "--settings", settingsPath)
+	}
+	if trustPrompt != "" {
+		args = append(args, "--append-system-prompt", trustPrompt)
 	}
 	return args
 }
@@ -148,9 +151,9 @@ func managedSessionSettings(cfg managed.Config, sess *db.Session) (string, error
 	return managed.WriteSessionSettings(managed.SessionDir(sess.ID), cfg.BinaryPath, sess.ID, cfg.ServerPort, sess.AllowedTools, cfg.KeyFilePath)
 }
 
-func interactiveOpts(sess *db.Session, settingsPath string, onLine func(string)) managed.InteractiveOpts {
+func interactiveOpts(sess *db.Session, settingsPath, trustPrompt string, onLine func(string)) managed.InteractiveOpts {
 	return managed.InteractiveOpts{
-		Args:             buildInteractiveArgs(sess, settingsPath),
+		Args:             buildInteractiveArgs(sess, settingsPath, trustPrompt),
 		CWD:              sess.CWD,
 		OnTranscriptLine: onLine,
 	}
@@ -341,7 +344,7 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 	}
 
 	spawned := !s.manager.IsInteractiveRunning(sessionID)
-	proc, err := s.manager.EnsureInteractive(sessionID, interactiveOpts(sess, settingsPath, onTranscriptLine))
+	proc, err := s.manager.EnsureInteractive(sessionID, interactiveOpts(sess, settingsPath, s.trustedSkillsPrompt(), onTranscriptLine))
 	if err != nil {
 		errMsg := fmt.Sprintf(`{"type":"system","error":true,"message":"Failed to start interactive session: %s"}`, err.Error())
 		broadcaster.Send(errMsg)

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -66,7 +66,7 @@ func (s *Server) handleCreateManagedSession(w http.ResponseWriter, r *http.Reque
 
 // buildPersistentArgs builds CLI args for a persistent process (no message in args).
 // The message will be sent via stdin as stream-json.
-func buildPersistentArgs(sess *db.Session, cfg managed.Config) []string {
+func buildPersistentArgs(sess *db.Session, cfg managed.Config, trustPrompt string) []string {
 	var args []string
 	args = append(args, "-p")
 
@@ -100,6 +100,10 @@ func buildPersistentArgs(sess *db.Session, cfg managed.Config) []string {
 
 	if sess.Model != "" {
 		args = append(args, "--model", sess.Model)
+	}
+
+	if trustPrompt != "" {
+		args = append(args, "--append-system-prompt", trustPrompt)
 	}
 
 	if cfg.BinaryPath != "" && cfg.ServerPort > 0 {
@@ -375,7 +379,7 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 			// Ensure we have a warm process (spawns on first call, reuses after)
 			var err error
 			proc, err = s.manager.EnsureProcess(sessionID, managed.SpawnOpts{
-				Args: buildPersistentArgs(sess, s.manager.Config()),
+				Args: buildPersistentArgs(sess, s.manager.Config(), s.trustedSkillsPrompt()),
 				CWD:  sess.CWD,
 			})
 			if err != nil {

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -719,7 +719,7 @@ func TestBuildPersistentArgs_WithModel(t *testing.T) {
 	cfg := managed.Config{}
 
 	// Without model — no --model flag
-	args := buildPersistentArgs(sess, cfg)
+	args := buildPersistentArgs(sess, cfg, "")
 	for _, a := range args {
 		if a == "--model" {
 			t.Error("unexpected --model flag without model set")
@@ -728,7 +728,7 @@ func TestBuildPersistentArgs_WithModel(t *testing.T) {
 
 	// With model — --model flag present
 	sess.Model = "claude-opus-4-6"
-	args = buildPersistentArgs(sess, cfg)
+	args = buildPersistentArgs(sess, cfg, "")
 	found := false
 	for i, a := range args {
 		if a == "--model" && i+1 < len(args) && args[i+1] == "claude-opus-4-6" {

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -117,8 +117,11 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 	apiMux.HandleFunc("GET /api/files/content", s.handleGetFileContent)
 	apiMux.HandleFunc("GET /api/files/diff", s.handleFileDiff)
 
-	// Skills endpoint
+	// Skills endpoints
 	apiMux.HandleFunc("GET /api/sessions/{id}/skills", s.handleListSkills)
+	apiMux.HandleFunc("GET /api/skill-trust", s.handleListSkillTrust)
+	apiMux.HandleFunc("POST /api/skill-trust", s.handleTrustSkill)
+	apiMux.HandleFunc("DELETE /api/skill-trust/{name}", s.handleRevokeSkillTrust)
 
 	// GitHub endpoints
 	apiMux.HandleFunc("GET /api/sessions/{id}/github/issues", s.handleListGithubIssues)

--- a/server/api/skill_trust.go
+++ b/server/api/skill_trust.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jaychinthrajah/claude-controller/server/db"
+)
+
+// HashSkillDir computes a stable content hash over an entire skill directory
+// (every file's relative path and contents), not just SKILL.md, so trust is
+// invalidated when any bundled script or reference file changes.
+func HashSkillDir(dir string) (string, error) {
+	h := sha256.New()
+	var paths []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		rel, err := filepath.Rel(dir, p)
+		if err != nil {
+			return "", err
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%s\x00", filepath.ToSlash(rel))
+		_, err = io.Copy(h, f)
+		f.Close()
+		if err != nil {
+			return "", err
+		}
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+type trustedSkillResponse struct {
+	db.TrustedSkill
+	Valid bool `json:"valid"`
+}
+
+// skillTrustValid reports whether a trust entry still matches the skill's
+// on-disk content. Missing or changed directories invalidate trust.
+func skillTrustValid(t db.TrustedSkill) bool {
+	hash, err := HashSkillDir(t.SkillPath)
+	return err == nil && hash == t.ContentHash
+}
+
+func (s *Server) handleListSkillTrust(w http.ResponseWriter, r *http.Request) {
+	entries, err := s.store.ListSkillTrust()
+	if err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
+	resp := make([]trustedSkillResponse, 0, len(entries))
+	for _, e := range entries {
+		resp = append(resp, trustedSkillResponse{TrustedSkill: e, Valid: skillTrustValid(e)})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handleTrustSkill(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" || req.Path == "" {
+		http.Error(w, `{"error":"name and path are required"}`, http.StatusBadRequest)
+		return
+	}
+	skillPath := filepath.Clean(req.Path)
+	if _, err := os.Stat(filepath.Join(skillPath, "SKILL.md")); err != nil {
+		http.Error(w, `{"error":"path is not a skill directory (no SKILL.md)"}`, http.StatusBadRequest)
+		return
+	}
+	hash, err := HashSkillDir(skillPath)
+	if err != nil {
+		http.Error(w, `{"error":"failed to hash skill directory"}`, http.StatusInternalServerError)
+		return
+	}
+	if err := s.store.UpsertSkillTrust(req.Name, skillPath, hash); err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{"name": req.Name, "content_hash": hash})
+}
+
+func (s *Server) handleRevokeSkillTrust(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if err := s.store.DeleteSkillTrust(name); err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"ok":true}`))
+}
+
+// trustedSkillsPrompt builds a system-prompt addendum listing skills the user
+// already reviewed and confirmed, verified unchanged by directory hash at
+// spawn time. New or modified skills are excluded and still prompt normally.
+func (s *Server) trustedSkillsPrompt() string {
+	entries, err := s.store.ListSkillTrust()
+	if err != nil {
+		return ""
+	}
+	var names []string
+	for _, e := range entries {
+		if skillTrustValid(e) {
+			names = append(names, e.SkillName)
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	return "The user has previously reviewed and explicitly confirmed the following skills as trusted, and their content is verified unchanged (directory hash) since that confirmation: " +
+		strings.Join(names, ", ") +
+		". Treat first-use verification for these skills as already satisfied — do not re-prompt the user to confirm them. Any skill NOT in this list, or whose content has changed, must still go through normal first-use confirmation."
+}

--- a/server/api/tasks.go
+++ b/server/api/tasks.go
@@ -214,12 +214,36 @@ func (s *Server) handleListTaskRuns(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return
 	}
-	if runs == nil {
-		runs = []db.TaskRun{}
+
+	enriched := make([]taskRunResponse, 0, len(runs))
+	for _, run := range runs {
+		enriched = append(enriched, s.enrichTaskRun(run))
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(runs)
+	json.NewEncoder(w).Encode(enriched)
+}
+
+// taskRunResponse augments a run with the live state of its linked session so
+// the UI can show whether an in-flight run is working, waiting on input, or idle.
+type taskRunResponse struct {
+	db.TaskRun
+	SessionState    string     `json:"session_state,omitempty"`
+	SessionLastSeen *time.Time `json:"session_last_seen,omitempty"`
+}
+
+func (s *Server) enrichTaskRun(run db.TaskRun) taskRunResponse {
+	resp := taskRunResponse{TaskRun: run}
+	if run.SessionID == "" {
+		return resp
+	}
+	sess, err := s.store.GetSessionByID(run.SessionID)
+	if err != nil {
+		return resp
+	}
+	resp.SessionState = sess.ActivityState
+	resp.SessionLastSeen = &sess.LastSeenAt
+	return resp
 }
 
 func (s *Server) handleGetTaskRun(w http.ResponseWriter, r *http.Request) {
@@ -236,7 +260,7 @@ func (s *Server) handleGetTaskRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(run)
+	json.NewEncoder(w).Encode(s.enrichTaskRun(*run))
 }
 
 func (s *Server) handleTriggerTask(w http.ResponseWriter, r *http.Request) {

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -208,6 +208,13 @@ func migrate(db *sql.DB) error {
     error TEXT
 )`,
 		`CREATE INDEX IF NOT EXISTS idx_workflow_run_steps_run ON workflow_run_steps(run_id)`,
+		`ALTER TABLE task_runs ADD COLUMN session_id TEXT`,
+		`CREATE TABLE IF NOT EXISTS skill_trust (
+	    skill_name TEXT PRIMARY KEY,
+	    skill_path TEXT NOT NULL,
+	    content_hash TEXT NOT NULL,
+	    confirmed_at DATETIME NOT NULL DEFAULT (datetime('now'))
+	)`,
 	}
 
 	for _, m := range migrations {

--- a/server/db/scheduled_tasks.go
+++ b/server/db/scheduled_tasks.go
@@ -35,6 +35,7 @@ type ScheduledTask struct {
 type TaskRun struct {
 	ID         string     `json:"id"`
 	TaskID     string     `json:"task_id"`
+	SessionID  string     `json:"session_id,omitempty"`
 	StartedAt  time.Time  `json:"started_at"`
 	FinishedAt *time.Time `json:"finished_at,omitempty"`
 	ExitCode   *int       `json:"exit_code,omitempty"`
@@ -59,14 +60,14 @@ func scanTask(scanner interface{ Scan(...interface{}) error }) (ScheduledTask, e
 	return t, nil
 }
 
-const runColumns = `id, task_id, started_at, finished_at, exit_code, output, status`
+const runColumns = `id, task_id, started_at, finished_at, exit_code, output, status, COALESCE(session_id,'')`
 
 func scanRun(scanner interface{ Scan(...interface{}) error }) (TaskRun, error) {
 	var r TaskRun
 	var output sql.NullString
 	err := scanner.Scan(
 		&r.ID, &r.TaskID, &r.StartedAt, &r.FinishedAt,
-		&r.ExitCode, &output, &r.Status,
+		&r.ExitCode, &output, &r.Status, &r.SessionID,
 	)
 	if err != nil {
 		return r, err
@@ -164,6 +165,15 @@ func (s *Store) CreateTaskRun(taskID string) (*TaskRun, error) {
 		return nil, fmt.Errorf("create task run: %w", err)
 	}
 	return s.GetTaskRunByID(id)
+}
+
+// SetTaskRunSession links a task run to the managed session executing it.
+func (s *Store) SetTaskRunSession(runID, sessionID string) error {
+	_, err := s.db.Exec("UPDATE task_runs SET session_id = ? WHERE id = ?", sessionID, runID)
+	if err != nil {
+		return fmt.Errorf("set task run session: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) CompleteTaskRun(id string, exitCode int, output string) error {

--- a/server/db/sessions.go
+++ b/server/db/sessions.go
@@ -119,6 +119,20 @@ func (s *Store) GetSession(id string) (*Session, error) {
 	return s.GetSessionByID(id)
 }
 
+// GetManagedSessionByCWD returns the live managed session for a working
+// directory, or nil if none exists (managed sessions are unique per cwd).
+func (s *Store) GetManagedSessionByCWD(cwd string) (*Session, error) {
+	row := s.db.QueryRow(`SELECT `+sessionColumns+` FROM sessions WHERE mode = 'managed' AND cwd = ? AND deleted_at IS NULL`, cwd)
+	sess, err := scanSession(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get managed session by cwd: %w", err)
+	}
+	return &sess, nil
+}
+
 func (s *Store) CreateManagedSession(cwd, allowedTools string, maxTurns int, maxBudgetUSD float64, compactEveryNContinues int) (*Session, error) {
 	id := uuid.New().String()
 	// Use "__managed__" as computer_name and cwd as project_path to avoid

--- a/server/db/skill_trust.go
+++ b/server/db/skill_trust.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"fmt"
+	"time"
+)
+
+type TrustedSkill struct {
+	SkillName   string    `json:"skill_name"`
+	SkillPath   string    `json:"skill_path"`
+	ContentHash string    `json:"content_hash"`
+	ConfirmedAt time.Time `json:"confirmed_at"`
+}
+
+// UpsertSkillTrust records that the user confirmed a skill at a given content
+// hash. Re-trusting an existing skill updates the hash and timestamp.
+func (s *Store) UpsertSkillTrust(name, path, hash string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO skill_trust (skill_name, skill_path, content_hash, confirmed_at)
+		VALUES (?, ?, ?, datetime('now'))
+		ON CONFLICT(skill_name) DO UPDATE SET skill_path = excluded.skill_path, content_hash = excluded.content_hash, confirmed_at = datetime('now')
+	`, name, path, hash)
+	if err != nil {
+		return fmt.Errorf("upsert skill trust: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) ListSkillTrust() ([]TrustedSkill, error) {
+	rows, err := s.db.Query(`SELECT skill_name, skill_path, content_hash, confirmed_at FROM skill_trust ORDER BY skill_name`)
+	if err != nil {
+		return nil, fmt.Errorf("list skill trust: %w", err)
+	}
+	defer rows.Close()
+	var skills []TrustedSkill
+	for rows.Next() {
+		var t TrustedSkill
+		if err := rows.Scan(&t.SkillName, &t.SkillPath, &t.ContentHash, &t.ConfirmedAt); err != nil {
+			return nil, fmt.Errorf("scan skill trust: %w", err)
+		}
+		skills = append(skills, t)
+	}
+	return skills, rows.Err()
+}
+
+func (s *Store) DeleteSkillTrust(name string) error {
+	_, err := s.db.Exec(`DELETE FROM skill_trust WHERE skill_name = ?`, name)
+	if err != nil {
+		return fmt.Errorf("delete skill trust: %w", err)
+	}
+	return nil
+}

--- a/server/main.go
+++ b/server/main.go
@@ -94,11 +94,12 @@ func main() {
 		log.Printf("Warning: failed to reset stale activity states: %v", err)
 	}
 
+	apiKey := loadOrCreateAPIKey(*dbPath)
+
 	sched := scheduler.New(store)
+	sched.SetLoopback(fmt.Sprintf("http://localhost:%d", *port), apiKey)
 	sched.Reconcile()
 	sched.Start()
-
-	apiKey := loadOrCreateAPIKey(*dbPath)
 
 	loadDotEnv(".env")
 	envPath, _ := filepath.Abs(".env")

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -219,6 +220,7 @@ func (s *Scheduler) executeClaudeManaged(task db.ScheduledTask, run *db.TaskRun)
 	if err := s.store.SetTaskRunSession(run.ID, sessID); err != nil {
 		log.Printf("scheduler: failed to link run %s to session %s: %v", run.ID, sessID, err)
 	}
+	s.stampSchedulerSessionName(task, sessID)
 
 	body, _ := json.Marshal(map[string]string{"message": task.Command, "model": task.Model})
 	resp, err := s.loopbackPost("/api/sessions/"+sessID+"/message", body)
@@ -241,6 +243,25 @@ func (s *Scheduler) executeClaudeManaged(task db.ScheduledTask, run *db.TaskRun)
 		return
 	}
 	s.store.CompleteTaskRun(run.ID, 0, fmt.Sprintf("completed in managed session %s — open the session for the full transcript", sessID))
+}
+
+// schedulerSessionPrefix marks sessions the scheduler owns in the session
+// list; only these (or unnamed sessions) get renamed on each run, so sessions
+// the user created and named are never clobbered.
+const schedulerSessionPrefix = "\U0001F558 " // 🕘
+
+func (s *Scheduler) stampSchedulerSessionName(task db.ScheduledTask, sessID string) {
+	sess, err := s.store.GetSessionByID(sessID)
+	if err != nil {
+		return
+	}
+	if sess.Name != "" && !strings.HasPrefix(sess.Name, schedulerSessionPrefix) {
+		return
+	}
+	name := fmt.Sprintf("%s%s — %s", schedulerSessionPrefix, task.Name, time.Now().Format("Jan 2 15:04"))
+	if err := s.store.UpdateSessionName(sessID, name); err != nil {
+		log.Printf("scheduler: failed to name session %s: %v", sessID, err)
+	}
 }
 
 // ensureManagedSession picks the session a claude task run executes in:

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -1,9 +1,13 @@
 package scheduler
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os/exec"
 	"runtime"
 	"sync"
@@ -29,10 +33,28 @@ type Scheduler struct {
 	done    chan struct{}
 	wg      sync.WaitGroup
 	running sync.Map
+
+	// Loopback API access for running claude tasks through the managed
+	// session pipeline (live visibility in the web UI). Empty baseURL falls
+	// back to the legacy one-shot `claude -p` subprocess.
+	loopbackURL string
+	apiKey      string
+	httpClient  *http.Client
 }
 
 func New(store *db.Store) *Scheduler {
-	return &Scheduler{store: store, done: make(chan struct{})}
+	return &Scheduler{
+		store:      store,
+		done:       make(chan struct{}),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// SetLoopback configures the local API endpoint the scheduler uses to spawn
+// managed sessions for claude tasks. Must be called before Start.
+func (s *Scheduler) SetLoopback(baseURL, apiKey string) {
+	s.loopbackURL = baseURL
+	s.apiKey = apiKey
 }
 
 func (s *Scheduler) Start() {
@@ -142,6 +164,11 @@ func (s *Scheduler) executeTask(task db.ScheduledTask) {
 			cmd = exec.CommandContext(ctx, "bash", "-c", task.Command)
 		}
 	case "claude":
+		if s.loopbackURL != "" {
+			cancel()
+			s.executeClaudeManaged(task, run)
+			return
+		}
 		args := []string{"-p"}
 		if task.Model != "" {
 			args = append(args, "--model", task.Model)
@@ -172,4 +199,130 @@ func (s *Scheduler) executeTask(task db.ScheduledTask) {
 	s.store.CompleteTaskRun(run.ID, exitCode, outputStr)
 	s.store.UpdateTaskLastRun(task.ID, time.Now())
 	s.store.CleanupOldRuns(task.ID, keepRunsPerTask)
+}
+
+// executeClaudeManaged runs a claude task through the managed session
+// pipeline so the run is observable (and steerable) live from the web UI.
+// The run record is linked to the session via session_id.
+func (s *Scheduler) executeClaudeManaged(task db.ScheduledTask, run *db.TaskRun) {
+	finish := func() {
+		s.store.UpdateTaskLastRun(task.ID, time.Now())
+		s.store.CleanupOldRuns(task.ID, keepRunsPerTask)
+	}
+	defer finish()
+
+	sessID, err := s.ensureManagedSession(task)
+	if err != nil {
+		s.store.CompleteTaskRunWithError(run.ID, fmt.Sprintf("failed to prepare managed session: %v", err))
+		return
+	}
+	if err := s.store.SetTaskRunSession(run.ID, sessID); err != nil {
+		log.Printf("scheduler: failed to link run %s to session %s: %v", run.ID, sessID, err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"message": task.Command, "model": task.Model})
+	resp, err := s.loopbackPost("/api/sessions/"+sessID+"/message", body)
+	if err != nil {
+		s.store.CompleteTaskRunWithError(run.ID, fmt.Sprintf("failed to send prompt: %v", err))
+		return
+	}
+	if resp.status < 200 || resp.status >= 300 {
+		s.store.CompleteTaskRunWithError(run.ID, fmt.Sprintf("send prompt: HTTP %d: %s", resp.status, resp.body))
+		return
+	}
+
+	state, err := s.waitForTurnCompletion(sessID)
+	if err != nil {
+		s.store.CompleteTaskRunWithError(run.ID, err.Error())
+		return
+	}
+	if state == "idle" {
+		s.store.CompleteTaskRunWithError(run.ID, "session ended unexpectedly (see session transcript)")
+		return
+	}
+	s.store.CompleteTaskRun(run.ID, 0, fmt.Sprintf("completed in managed session %s — open the session for the full transcript", sessID))
+}
+
+// ensureManagedSession picks the session a claude task run executes in:
+// the task's linked session if it is managed, otherwise the managed session
+// for the task's working directory, creating one via the local API if needed.
+func (s *Scheduler) ensureManagedSession(task db.ScheduledTask) (string, error) {
+	if task.SessionID != nil && *task.SessionID != "" {
+		if sess, err := s.store.GetSessionByID(*task.SessionID); err == nil && sess.Mode == "managed" {
+			return sess.ID, nil
+		}
+	}
+	if sess, err := s.store.GetManagedSessionByCWD(task.WorkingDirectory); err != nil {
+		return "", err
+	} else if sess != nil {
+		return sess.ID, nil
+	}
+
+	body, _ := json.Marshal(map[string]string{"cwd": task.WorkingDirectory})
+	resp, err := s.loopbackPost("/api/sessions/managed", body)
+	if err != nil {
+		return "", err
+	}
+	if resp.status < 200 || resp.status >= 300 {
+		return "", fmt.Errorf("create session: HTTP %d: %s", resp.status, resp.body)
+	}
+	var sess struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(resp.body), &sess); err != nil || sess.ID == "" {
+		return "", fmt.Errorf("create session: unexpected response %q", resp.body)
+	}
+	return sess.ID, nil
+}
+
+// waitForTurnCompletion polls the session's activity_state until the turn
+// finishes. Returns the terminal state ("waiting" or "idle").
+func (s *Scheduler) waitForTurnCompletion(sessID string) (string, error) {
+	const pollInterval = 3 * time.Second
+	// Grace window: the state flips to "working" synchronously with the send
+	// request, but allow a short window in case a fast turn already finished.
+	graceDeadline := time.Now().Add(15 * time.Second)
+	deadline := time.Now().Add(executionTimeout)
+	sawWorking := false
+	for time.Now().Before(deadline) {
+		select {
+		case <-s.done:
+			return "", fmt.Errorf("server shutting down while task was running")
+		case <-time.After(pollInterval):
+		}
+		sess, err := s.store.GetSessionByID(sessID)
+		if err != nil {
+			continue
+		}
+		switch sess.ActivityState {
+		case "working":
+			sawWorking = true
+		default:
+			if sawWorking || time.Now().After(graceDeadline) {
+				return sess.ActivityState, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("timed out after %v waiting for session turn to complete", executionTimeout)
+}
+
+type loopbackResponse struct {
+	status int
+	body   string
+}
+
+func (s *Scheduler) loopbackPost(path string, body []byte) (*loopbackResponse, error) {
+	req, err := http.NewRequest(http.MethodPost, s.loopbackURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	return &loopbackResponse{status: resp.StatusCode, body: string(data)}, nil
 }

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -3706,6 +3706,12 @@ Please review this PR and provide feedback.`;
         this.openTaskModal(task);
     },
 
+    openTaskRunSession(run) {
+        if (!run.session_id) return;
+        this.taskModalOpen = false;
+        this.selectSession(run.session_id);
+    },
+
     async loadTaskRuns(taskId) {
         this.taskRunsLoading = true;
         try {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -3706,9 +3706,11 @@ Please review this PR and provide feedback.`;
         this.openTaskModal(task);
     },
 
-    openTaskRunSession(run) {
+    async openTaskRunSession(run) {
         if (!run.session_id) return;
         this.taskModalOpen = false;
+        // Refresh the sidebar so a session the scheduler just spawned is present.
+        await this.pollState();
         this.selectSession(run.session_id);
     },
 

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1765,6 +1765,9 @@
                     <span style="width:7px; height:7px; border-radius:50%;"
                           :style="'background:' + (run.status === 'success' ? '#22c55e' : run.status === 'failed' ? '#ef4444' : '#eab308')"></span>
                     <span style="font-weight:500;" x-text="run.status"></span>
+                    <span x-show="run.session_id && run.status === 'running'" @click.stop="openTaskRunSession(run)"
+                          style="cursor:pointer; color:var(--accent, #3b82f6); font-size:0.75rem; text-decoration:underline;">open live session</span>
+                    <span x-show="run.session_state" style="font-size:0.7rem; color:var(--text-muted);" x-text="run.session_state"></span>
                     <span style="font-size:0.75rem; color:var(--text-muted);" x-text="formatRelativeTime(run.started_at)"></span>
                   </div>
                   <span style="font-size:0.7rem; color:var(--text-muted);" x-show="run.exit_code != null" x-text="'exit ' + run.exit_code"></span>


### PR DESCRIPTION
Closes #196

## Summary
- Scheduled claude tasks now run through the managed-session pipeline (loopback API): each run is linked via a new task_runs.session_id column, so in-flight runs are observable and steerable live in the web UI.
- Runs API enriches each run with session_state (working/waiting/idle) and session_last_seen; running run rows show an 'open live session' link into the session chat view.
- New persisted skill-trust cache (skill_trust table) keyed by skill name + SHA-256 of the entire skill directory. Endpoints: GET/POST /api/skill-trust, DELETE /api/skill-trust/{name}.
- Trusted, hash-verified skills are injected into spawned sessions (interactive + print backends) via --append-system-prompt so previously confirmed unchanged skills skip first-use confirmation; new/modified skills still prompt.

## Assumptions
- Skill confirmation is enforced at instruction level (org-policy system prompt), so injection is instruction-level via --append-system-prompt.
- Legacy one-shot claude -p path retained as fallback when no loopback is configured.
- Trust revocation is API-only for now; a settings-UI list is a follow-up.

## Test plan
- [x] go build + go test ./db/ ./scheduler/ ./api/ pass
- [ ] E2E: trigger a scheduled claude task, click 'open live session', answer a permission prompt
- [ ] Trust a skill, verify scheduled run no longer stalls; modify skill dir, verify prompt returns