### PR TITLE
fix: execute scheduled tasks on manual trigger and fix session-create route

### DIFF
--- a/server/api/auto_continue_test.go
+++ b/server/api/auto_continue_test.go
@@ -30,7 +30,7 @@ func setupMockTestServer(t *testing.T) (*httptest.Server, *db.Store, *MockManage
 
 	mock := NewMockManager()
 	envPath := filepath.Join(dir, ".env")
-	router := NewRouter(store, "test-api-key", mock, envPath, nil, "test-server-id")
+	router := NewRouter(store, "test-api-key", mock, envPath, nil, "test-server-id", nil)
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, store, mock

--- a/server/api/files_test.go
+++ b/server/api/files_test.go
@@ -20,7 +20,7 @@ func TestHandleGetFileRaw(t *testing.T) {
 	defer store.Close()
 
 	envPath := filepath.Join(dir, ".env")
-	router := NewRouter(store, "test-key", nil, envPath, nil, "test-server-id")
+	router := NewRouter(store, "test-key", nil, envPath, nil, "test-server-id", nil)
 
 	// Create a managed session with CWD set to dir
 	sess, err := store.CreateManagedSession(dir, "", 0, 0, 0)

--- a/server/api/managed_interactive_test.go
+++ b/server/api/managed_interactive_test.go
@@ -398,7 +398,7 @@ func TestInteractiveSessionIDConflictRotatesAndRetries(t *testing.T) {
 
 	cfg := managed.Config{ClaudeBin: "/bin/bash", ClaudeArgs: []string{script}, Mode: "interactive", BinaryPath: "/usr/local/bin/claude-controller", ServerPort: 8080}
 	mgr := managed.NewManager(cfg)
-	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil, "test-server-id")
+	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil, "test-server-id", nil)
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 

--- a/server/api/managed_sessions_test.go
+++ b/server/api/managed_sessions_test.go
@@ -28,7 +28,7 @@ func setupTestServer(t *testing.T) (*httptest.Server, *db.Store) {
 		ClaudeEnv:  []string{},
 	}
 	mgr := managed.NewManager(cfg)
-	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil, "test-server-id")
+	router := NewRouter(store, "test-api-key", mgr, filepath.Join(dir, ".env"), nil, "test-server-id", nil)
 	ts := httptest.NewServer(router)
 	return ts, store
 }

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -14,9 +14,14 @@ import (
 	"github.com/jaychinthrajah/claude-controller/server/web"
 )
 
+// TaskTrigger runs a scheduled task immediately, returning the created run.
+// Wired to scheduler.Trigger in production; nil when no scheduler is available.
+type TaskTrigger func(db.ScheduledTask) (*db.TaskRun, error)
+
 type Server struct {
 	store             *db.Store
 	manager           SessionManager
+	taskTrigger       TaskTrigger
 	workflowEngine    *managed.WorkflowEngine
 	envPath           string
 	permissions       *PermissionManager
@@ -34,8 +39,8 @@ type Server struct {
 	interactiveTurns sync.Map
 }
 
-func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath string, shutdownFunc func(), serverID string) http.Handler {
-	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc, serverID: serverID}
+func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath string, shutdownFunc func(), serverID string, taskTrigger TaskTrigger) http.Handler {
+	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc, serverID: serverID, taskTrigger: taskTrigger}
 
 	// Initialize workflow engine with callbacks wired to the server
 	s.workflowEngine = managed.NewWorkflowEngine(

--- a/server/api/sessions_test.go
+++ b/server/api/sessions_test.go
@@ -19,7 +19,9 @@ func newTestServer(t *testing.T) (*httptest.Server, *db.Store) {
 	}
 	t.Cleanup(func() { store.Close() })
 
-	router := NewRouter(store, "test-key", nil, filepath.Join(t.TempDir(), ".env"), nil, "test-server-id")
+	// Fake trigger mirrors production shape: creates the run record without executing.
+	trigger := func(task db.ScheduledTask) (*db.TaskRun, error) { return store.CreateTaskRun(task.ID) }
+	router := NewRouter(store, "test-key", nil, filepath.Join(t.TempDir(), ".env"), nil, "test-server-id", trigger)
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, store

--- a/server/api/settings_test.go
+++ b/server/api/settings_test.go
@@ -29,7 +29,7 @@ func newTestServerWithManager(t *testing.T) (*httptest.Server, *db.Store, *manag
 
 	mgr := managed.NewManager(managed.Config{ClaudeBin: "claude"})
 	envPath := filepath.Join(tmpDir, ".env")
-	router := NewRouter(store, "test-key", mgr, envPath, nil, "test-server-id")
+	router := NewRouter(store, "test-key", mgr, envPath, nil, "test-server-id", nil)
 	ts := httptest.NewServer(router)
 	t.Cleanup(ts.Close)
 	return ts, store, mgr, envPath

--- a/server/api/tasks.go
+++ b/server/api/tasks.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/jaychinthrajah/claude-controller/server/db"
+	"github.com/jaychinthrajah/claude-controller/server/scheduler"
 	"github.com/robfig/cron/v3"
 )
 
@@ -276,8 +278,16 @@ func (s *Server) handleTriggerTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	run, err := s.store.CreateTaskRun(taskID)
+	if s.taskTrigger == nil {
+		http.Error(w, `{"error":"scheduler unavailable"}`, http.StatusServiceUnavailable)
+		return
+	}
+	run, err := s.taskTrigger(*task)
 	if err != nil {
+		if errors.Is(err, scheduler.ErrAlreadyRunning) {
+			http.Error(w, `{"error":"task is already running"}`, http.StatusConflict)
+			return
+		}
 		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
 		return
 	}

--- a/server/api/tasks_test.go
+++ b/server/api/tasks_test.go
@@ -3,10 +3,108 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/jaychinthrajah/claude-controller/server/db"
+	"github.com/jaychinthrajah/claude-controller/server/scheduler"
 )
+
+func newTestServerWithTrigger(t *testing.T, trigger TaskTrigger) (*httptest.Server, *db.Store) {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	router := NewRouter(store, "test-key", nil, filepath.Join(t.TempDir(), ".env"), nil, "test-server-id", trigger)
+	ts := httptest.NewServer(router)
+	t.Cleanup(ts.Close)
+	return ts, store
+}
+
+func TestTriggerTaskExecutesRun(t *testing.T) {
+	var sched *scheduler.Scheduler
+	ts, store := newTestServerWithTrigger(t, func(task db.ScheduledTask) (*db.TaskRun, error) {
+		return sched.Trigger(task)
+	})
+	sched = scheduler.New(store)
+
+	task, err := store.CreateScheduledTask("", "Echo", "shell", "echo hi-from-trigger", "/tmp", "* * * * *", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := authReq("POST", ts.URL+"/api/tasks/"+task.ID+"/trigger", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status=%d, want 201", resp.StatusCode)
+	}
+	var run db.TaskRun
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		t.Fatalf("decode run: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _ := store.GetTaskRunByID(run.ID)
+		if got != nil && got.Status != "running" {
+			if got.Status != "success" {
+				t.Fatalf("run status: got %q (output: %s), want success", got.Status, got.Output)
+			}
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("triggered run never executed — trigger endpoint must actually run the task")
+}
+
+func TestTriggerTaskWithoutSchedulerReturns503(t *testing.T) {
+	ts, store := newTestServerWithTrigger(t, nil)
+
+	task, err := store.CreateScheduledTask("", "Echo", "shell", "echo hi", "/tmp", "* * * * *", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := authReq("POST", ts.URL+"/api/tasks/"+task.ID+"/trigger", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", resp.StatusCode)
+	}
+}
+
+func TestTriggerTaskAlreadyRunningReturns409(t *testing.T) {
+	ts, store := newTestServerWithTrigger(t, func(task db.ScheduledTask) (*db.TaskRun, error) {
+		return nil, scheduler.ErrAlreadyRunning
+	})
+
+	task, err := store.CreateScheduledTask("", "Echo", "shell", "echo hi", "/tmp", "* * * * *", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := authReq("POST", ts.URL+"/api/tasks/"+task.ID+"/trigger", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status=%d, want 409", resp.StatusCode)
+	}
+}
 
 func TestCreateTask_HappyPath(t *testing.T) {
 	ts, _ := newTestServer(t)

--- a/server/main.go
+++ b/server/main.go
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	serverID := fmt.Sprintf("%d", time.Now().UnixNano())
-	router := api.NewRouter(store, apiKey, mgr, envPath, shutdownFunc, serverID)
+	router := api.NewRouter(store, apiKey, mgr, envPath, shutdownFunc, serverID, sched.Trigger)
 
 	// Start local server
 	bindHost := "localhost"

--- a/server/scheduler/scheduler.go
+++ b/server/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -148,12 +149,40 @@ func (s *Scheduler) spawnTask(task db.ScheduledTask) {
 	}()
 }
 
+// ErrAlreadyRunning is returned by Trigger when the task has an execution in flight.
+var ErrAlreadyRunning = errors.New("task is already running")
+
+// Trigger runs a task immediately, outside its cron schedule. The run record
+// is created synchronously so callers can return it; execution happens in the
+// background through the same pipeline as cron-fired runs.
+func (s *Scheduler) Trigger(task db.ScheduledTask) (*db.TaskRun, error) {
+	if _, loaded := s.running.LoadOrStore(task.ID, true); loaded {
+		return nil, ErrAlreadyRunning
+	}
+	run, err := s.store.CreateTaskRun(task.ID)
+	if err != nil {
+		s.running.Delete(task.ID)
+		return nil, fmt.Errorf("create run: %w", err)
+	}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		defer s.running.Delete(task.ID)
+		s.executeRun(task, run)
+	}()
+	return run, nil
+}
+
 func (s *Scheduler) executeTask(task db.ScheduledTask) {
 	run, err := s.store.CreateTaskRun(task.ID)
 	if err != nil {
 		log.Printf("scheduler: failed to create run for task %q: %v", task.Name, err)
 		return
 	}
+	s.executeRun(task, run)
+}
+
+func (s *Scheduler) executeRun(task db.ScheduledTask, run *db.TaskRun) {
 	ctx, cancel := context.WithTimeout(context.Background(), executionTimeout)
 	defer cancel()
 	var cmd *exec.Cmd
@@ -280,7 +309,7 @@ func (s *Scheduler) ensureManagedSession(task db.ScheduledTask) (string, error) 
 	}
 
 	body, _ := json.Marshal(map[string]string{"cwd": task.WorkingDirectory})
-	resp, err := s.loopbackPost("/api/sessions/managed", body)
+	resp, err := s.loopbackPost("/api/sessions/create", body)
 	if err != nil {
 		return "", err
 	}

--- a/server/scheduler/scheduler_test.go
+++ b/server/scheduler/scheduler_test.go
@@ -1,6 +1,9 @@
 package scheduler
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
@@ -60,6 +63,75 @@ func TestSchedulerSkipsConcurrentExecution(t *testing.T) {
 	runs, _ := store.ListTaskRuns(task.ID, 10)
 	if len(runs) != 1 {
 		t.Errorf("expected 1 run (concurrent skipped), got %d", len(runs))
+	}
+}
+
+func TestTriggerExecutesShellTaskImmediately(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.UpsertSession("mac1", "/tmp", "")
+	task, _ := store.CreateScheduledTask(sess.ID, "Manual echo", "shell", "echo triggered", "/tmp", "* * * * *", "")
+
+	s := New(store)
+	run, err := s.Trigger(*task)
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if run == nil || run.ID == "" {
+		t.Fatal("Trigger should return the created run")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _ := store.GetTaskRunByID(run.ID)
+		if got != nil && got.Status != "running" {
+			if got.Status != "success" {
+				t.Fatalf("status: got %q, want success (output: %s)", got.Status, got.Output)
+			}
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("run never completed")
+}
+
+func TestTriggerRejectsConcurrentExecution(t *testing.T) {
+	store := newTestStore(t)
+	sess, _ := store.UpsertSession("mac1", "/tmp", "")
+	task, _ := store.CreateScheduledTask(sess.ID, "Slow manual", "shell", "sleep 3", "/tmp", "* * * * *", "")
+
+	s := New(store)
+	if _, err := s.Trigger(*task); err != nil {
+		t.Fatalf("first Trigger: %v", err)
+	}
+	if _, err := s.Trigger(*task); err != ErrAlreadyRunning {
+		t.Errorf("second Trigger: got %v, want ErrAlreadyRunning", err)
+	}
+}
+
+func TestEnsureManagedSessionPostsToCreateRoute(t *testing.T) {
+	store := newTestStore(t)
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		// Mirror the real router: only /api/sessions/create exists.
+		if r.URL.Path != "/api/sessions/create" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"id": "sess-123"})
+	}))
+	defer srv.Close()
+
+	s := New(store)
+	s.SetLoopback(srv.URL, "test-key")
+	task := db.ScheduledTask{ID: "t1", Name: "T", TaskType: "claude", Command: "hi", WorkingDirectory: filepath.Join(t.TempDir(), "no-session-here")}
+
+	sessID, err := s.ensureManagedSession(task)
+	if err != nil {
+		t.Fatalf("ensureManagedSession: %v (posted to %q)", err, gotPath)
+	}
+	if sessID != "sess-123" {
+		t.Errorf("session id: got %q, want sess-123", sessID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Run Now was a stub**: `POST /api/tasks/{id}/trigger` inserted a `task_runs` row (status `running`) and returned — nothing ever executed it. Runs sat "running" forever until the next restart marked them "failed — Server restarted while task was running". Fixed by wiring the endpoint to `scheduler.Trigger` via a `TaskTrigger` hook on `NewRouter`, so manual runs use the same pipeline as cron-fired runs (409 if already running, 503 if no scheduler).
- **Wrong loopback route**: the scheduler posted session creation to `/api/sessions/managed`, but the real route is `/api/sessions/create` — claude tasks 404ed whenever no managed session existed for the task's cwd (would have broken every cron run introduced in #197).

## Test plan
- [x] TDD: all four new tests observed failing for the right reasons before the fix (`TestTriggerExecutesShellTaskImmediately`, `TestTriggerRejectsConcurrentExecution`, `TestEnsureManagedSessionPostsToCreateRoute`, `TestTriggerTask*` API tests)
- [x] Full suite green: `go test ./...`
- [x] Live E2E: booted the fixed binary on a scratch port/DB, created a claude-type task, hit Run Now via API — managed session auto-created (`🕘 E2E Ping — Jul 14 16:05`), prompt round-tripped (assistant replied `pong`), run completed `success` with `session_id` linked
