### PR TITLE
feat: add Run Now button for scheduled tasks in mobile web UI

### DIFF
--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1241,6 +1241,9 @@
                   x-text="task.name"></span>
             <span style="font-size:10px;color:var(--text-muted);flex-shrink:0;"
                   x-text="formatCron(task.cron_expression)"></span>
+            <button class="btn btn-sm mobile-run-btn" @click.stop="triggerTask(task.id)"
+                    :disabled="!task.enabled" title="Run now"
+                    style="flex-shrink:0;padding:4px 8px;font-size:12px;min-width:32px;min-height:32px;">&#9654;</button>
           </div>
         </template>
       </div>
@@ -1691,7 +1694,10 @@
             <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
           </svg>
         </button>
-        <span class="mobile-detail-title" x-text="editingTask ? editingTask.name : 'New Scheduled Task'"></span>
+        <span class="mobile-detail-title" x-text="editingTask ? editingTask.name : 'New Scheduled Task'" style="flex:1;"></span>
+        <template x-if="editingTask">
+          <button type="button" class="btn btn-sm" @click="triggerTask(editingTask.id)" style="font-size:0.75rem;flex-shrink:0;">&#9654; Run Now</button>
+        </template>
       </div>
       <div class="modal-header desktop-modal-title">
         <h3 x-text="editingTask ? editingTask.name : 'New Scheduled Task'"></h3>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1941,6 +1941,14 @@ body {
   .desktop-modal-title {
     display: none !important;
   }
+
+  .mobile-run-btn {
+    -webkit-tap-highlight-color: transparent;
+  }
+  .mobile-run-btn:disabled {
+    opacity: 0.3;
+    pointer-events: none;
+  }
 }
 
 /* ===== Smart File Viewer Styles ===== */


### PR DESCRIPTION
## Summary
- Adds a ▶ (play) button to each task row in the mobile tasks tab, wired to `triggerTask()` with `@click.stop` so it triggers the run without opening the edit modal
- Adds a "▶ Run Now" button to the mobile task modal header (previously only in the desktop-only header which is `display:none` on mobile)
- Disabled tasks show the button greyed out (`pointer-events: none`)
- Visual feedback via the existing `toast('Task queued for execution')` in `triggerTask()`

Closes #199

## Test plan
- [ ] Open the web UI at a mobile viewport width (≤768px)
- [ ] Navigate to the Tasks tab — verify each task row shows a ▶ button
- [ ] Tap ▶ on an enabled task — verify toast appears and task runs
- [ ] Verify tapping ▶ does NOT open the edit modal
- [ ] Tap a task name to open the modal — verify "▶ Run Now" appears in the mobile header
- [ ] Tap "▶ Run Now" in the modal header — verify toast appears
- [ ] Verify disabled tasks show the ▶ button greyed out and non-interactive
- [ ] Verify desktop layout is unchanged (no extra button in sidebar task list)