### PR TITLE
fix: wire DEFAULT_SESSION_BUDGET setting into per-session budget cap

### DIFF
--- a/server/api/cost.go
+++ b/server/api/cost.go
@@ -14,7 +14,15 @@ import (
 const (
 	DefaultFiveHourLimitUSD  = 5.0
 	DefaultSevenDayLimitUSD  = 50.0
+	DefaultSessionBudgetUSD  = 5.0
 )
+
+func (s *Server) defaultSessionBudget() float64 {
+	if v, err := strconv.ParseFloat(readEnvFile(s.envPath)["DEFAULT_SESSION_BUDGET"], 64); err == nil && v > 0 {
+		return v
+	}
+	return DefaultSessionBudgetUSD
+}
 
 func (s *Server) usageLimits() (fiveHr, sevenDay float64) {
 	fiveHr = DefaultFiveHourLimitUSD

--- a/server/api/create_project.go
+++ b/server/api/create_project.go
@@ -124,7 +124,7 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		fullPath,
 		`["Bash","Read","Edit","Write","Glob","Grep"]`,
 		50,
-		5.0,
+		s.defaultSessionBudget(),
 		0,
 	)
 	if err != nil {

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -42,7 +42,7 @@ func (s *Server) handleCreateManagedSession(w http.ResponseWriter, r *http.Reque
 		req.MaxTurns = 50
 	}
 	if req.MaxBudgetUSD == 0 {
-		req.MaxBudgetUSD = 5.0
+		req.MaxBudgetUSD = s.defaultSessionBudget()
 	}
 	if req.CompactEveryNContinues == 0 {
 		if v, err := strconv.Atoi(readEnvFile(s.envPath)["COMPACT_EVERY_N_CONTINUES"]); err == nil && v > 0 {

--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -25,6 +25,7 @@ type settingsPayload struct {
 	CompactEveryNContinues string     `json:"compact_every_n_continues"`
 	UsageLimit5hr          string     `json:"usage_limit_5hr"`
 	UsageLimit7day         string     `json:"usage_limit_7day"`
+	DefaultSessionBudget   string     `json:"default_session_budget"`
 	GithubToken            string     `json:"github_token"`
 	JiraURL                string     `json:"jira_url"`
 	JiraToken              string     `json:"jira_token"`
@@ -88,6 +89,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		CompactEveryNContinues: vals["COMPACT_EVERY_N_CONTINUES"],
 		UsageLimit5hr:          vals["USAGE_LIMIT_5HR"],
 		UsageLimit7day:         vals["USAGE_LIMIT_7DAY"],
+		DefaultSessionBudget:   vals["DEFAULT_SESSION_BUDGET"],
 		GithubToken:            vals["GITHUB_TOKEN"],
 		JiraURL:                vals["JIRA_URL"],
 		JiraToken:              vals["JIRA_TOKEN"],
@@ -223,6 +225,9 @@ func formatEnvFile(p settingsPayload) string {
 	}
 	if p.UsageLimit7day != "" {
 		b.WriteString("USAGE_LIMIT_7DAY=" + p.UsageLimit7day + "\n")
+	}
+	if p.DefaultSessionBudget != "" && p.DefaultSessionBudget != "0" {
+		b.WriteString("DEFAULT_SESSION_BUDGET=" + p.DefaultSessionBudget + "\n")
 	}
 	b.WriteString("\n# GitHub\n")
 	if p.GithubToken != "" {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -160,7 +160,7 @@ document.addEventListener('alpine:init', () => {
     // Settings state
     showSettingsModal: false,
     settingsFirstRun: false,
-    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', usage_limit_5hr: '', usage_limit_7day: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] },
+    settingsForm: { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', usage_limit_5hr: '', usage_limit_7day: '', default_session_budget: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] },
     settingsError: '',
     settingsSaving: false,
     settingsRestartRequired: false,
@@ -576,6 +576,7 @@ document.addEventListener('alpine:init', () => {
           compact_every_n_continues: data.compact_every_n_continues || '',
           usage_limit_5hr: data.usage_limit_5hr || '',
           usage_limit_7day: data.usage_limit_7day || '',
+          default_session_budget: data.default_session_budget || '',
           github_token: data.github_token || '',
           jira_url: data.jira_url || '',
           jira_token: data.jira_token || '',
@@ -586,7 +587,7 @@ document.addEventListener('alpine:init', () => {
         };
         this.settingsOriginal = JSON.parse(JSON.stringify(this.settingsForm));
       } catch (e) {
-        this.settingsForm = { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] };
+        this.settingsForm = { port: '', ngrok_authtoken: '', claude_bin: '', claude_args: '', claude_env: '', compact_every_n_continues: '', usage_limit_5hr: '', usage_limit_7day: '', default_session_budget: '', github_token: '', jira_url: '', jira_token: '', jira_email: '', asana_token: '', google_tasks_token: '', shortcuts: [] };
       }
       this.showSettingsModal = true;
     },

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1900,6 +1900,15 @@
               </div>
             </div>
             <div class="modal-hint">Anthropic usage limits for utilization bars. Defaults: $5 / 5hr, $50 / 7day.</div>
+
+            <div class="settings-field" style="margin-top:16px;">
+              <label class="modal-label">
+                Default Session Budget ($)
+                <span x-show="isFieldChanged('default_session_budget')" class="settings-change-badge">changed</span>
+              </label>
+              <input x-model="settingsForm.default_session_budget" type="number" min="0" step="0.5" placeholder="5" class="modal-input" :style="isFieldChanged('default_session_budget') ? 'border-color:var(--yellow)' : ''">
+              <div class="modal-hint">Max budget per managed session. New sessions use this cap unless overridden. Default: $5.</div>
+            </div>
           </div>
 
           <!-- Integrations tab -->


### PR DESCRIPTION
## Summary

Closes #201

- Add `DEFAULT_SESSION_BUDGET` setting to Settings UI and `.env` file
- Replace hardcoded `$5.0` fallback in `managed_sessions.go` and `create_project.go` with `s.defaultSessionBudget()` which reads the configured value
- Sessions created with an explicit `max_budget_usd` still use that value

## Test plan

- [ ] Set `DEFAULT_SESSION_BUDGET=10` in Settings, create a new managed session without specifying a budget — verify `max_budget_usd` is `$10`
- [ ] Create a session with an explicit budget via API — verify it uses the explicit value, not the default
- [ ] Leave `DEFAULT_SESSION_BUDGET` unset — verify new sessions fall back to `$5`
- [ ] Verify existing sessions retain their original `max_budget_usd`
- [ ] `go test ./...` passes