### PR TITLE
feat: add AskUserQuestion handling to managed session chat UI

### DIFF
--- a/server/api/question_respond.go
+++ b/server/api/question_respond.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// handleQuestionRespond sends the user's AskUserQuestion selection to the
+// Claude Code TUI via PTY keystrokes. The TUI presents options as an
+// interactive list; we navigate with arrow-down and confirm with Enter.
+func (s *Server) handleQuestionRespond(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	var req struct {
+		OptionIndex int    `json:"option_index"`
+		OptionCount int    `json:"option_count"`
+		Text        string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			http.Error(w, "session not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	if sess.Mode != "managed" {
+		http.Error(w, "not a managed session", http.StatusBadRequest)
+		return
+	}
+
+	isOther := req.OptionIndex < 0 || req.OptionIndex >= req.OptionCount
+
+	if isOther {
+		// Navigate past all options to "Other", select it, type text, confirm
+		if err := s.sendQuestionKeys(sessionID, req.OptionCount, true, req.Text); err != nil {
+			http.Error(w, fmt.Sprintf("failed to send keystrokes: %v", err), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		if err := s.sendQuestionKeys(sessionID, req.OptionIndex, false, ""); err != nil {
+			http.Error(w, fmt.Sprintf("failed to send keystrokes: %v", err), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// sendQuestionKeys navigates the Claude Code TUI's option selector via PTY
+// keystrokes: arrowCount down-arrows followed by Enter. For "Other" mode,
+// it additionally types the free-text answer and submits.
+func (s *Server) sendQuestionKeys(sessionID string, arrowCount int, isOther bool, text string) error {
+	const keyDelay = 30 * time.Millisecond
+
+	// Navigate down to the target option
+	for i := 0; i < arrowCount; i++ {
+		if err := s.manager.SendKeys(sessionID, "\x1b[B"); err != nil {
+			return err
+		}
+		time.Sleep(keyDelay)
+	}
+
+	// Confirm selection
+	if err := s.manager.SendKeys(sessionID, "\r"); err != nil {
+		return err
+	}
+
+	if isOther && text != "" {
+		// Wait for the text input to appear, then type the answer
+		time.Sleep(100 * time.Millisecond)
+		if err := s.manager.SendKeys(sessionID, text); err != nil {
+			return err
+		}
+		time.Sleep(keyDelay)
+		if err := s.manager.SendKeys(sessionID, "\r"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -113,6 +113,7 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 	apiMux.HandleFunc("POST /api/sessions/{id}/permission-request", s.handlePermissionRequest)
 	apiMux.HandleFunc("POST /api/sessions/{id}/permission-respond", s.handlePermissionRespond)
 	apiMux.HandleFunc("GET /api/sessions/{id}/pending-permission", s.handlePendingPermission)
+	apiMux.HandleFunc("POST /api/sessions/{id}/question-respond", s.handleQuestionRespond)
 	apiMux.HandleFunc("GET /api/sessions/{id}/commands", s.handleListCommands)
 	apiMux.HandleFunc("GET /api/sessions/{id}/commands/content", s.handleCommandContent)
 

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -42,6 +42,8 @@ document.addEventListener('alpine:init', () => {
     // Managed session state
     showNewSessionModal: false,
     pendingPermission: null,
+    pendingQuestion: null,
+    pendingQuestionOtherText: '',
     newSessionCWD: '',
     sessionSSE: null,
     sseReconnectAttempts: 0,
@@ -2189,6 +2191,7 @@ document.addEventListener('alpine:init', () => {
           }
           if (data.type === 'done') {
             this.pendingPermission = null;
+            this.pendingQuestion = null;
             this.finalizeAgentInvocations();
             // Keep the SSE connection open: in interactive mode the Claude
             // process outlives the turn and can produce more output (e.g.
@@ -2204,6 +2207,22 @@ document.addEventListener('alpine:init', () => {
                 const label = this.extractToolContext(block);
                 this.addActivityPill(label, 'active');
                 this.trackAgentInvocation(block, label);
+
+                if (block.name === 'AskUserQuestion' && block.input && block.input.questions) {
+                  this.pendingQuestion = {
+                    toolUseId: block.id,
+                    questions: block.input.questions,
+                    timestamp: new Date().toISOString()
+                  };
+                  this.pendingQuestionOtherText = '';
+                  this.chatMessages.push({
+                    id: 'question-' + Date.now(),
+                    role: 'question',
+                    questions: block.input.questions,
+                    timestamp: new Date().toISOString()
+                  });
+                  this.$nextTick(() => this.scrollToBottom(true));
+                }
               }
             }
           }
@@ -2366,6 +2385,55 @@ document.addEventListener('alpine:init', () => {
         console.error('Failed to respond to permission:', e);
       }
       this.pendingPermission = null;
+    },
+
+    async respondToQuestion(msg, questionIdx, optionIdx, label, optionCount) {
+      if (msg.answered || !this.selectedSessionId) return;
+      msg.answered = true;
+      msg.selectedOption = optionIdx;
+      msg.answerText = label;
+      this.pendingQuestion = null;
+      try {
+        await fetch(`/api/sessions/${this.selectedSessionId}/question-respond`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ option_index: optionIdx, option_count: optionCount, text: '' })
+        });
+      } catch (e) {
+        console.error('Failed to respond to question:', e);
+        this.toast('Failed to send answer: ' + e.message);
+        msg.answered = false;
+        msg.selectedOption = null;
+        msg.answerText = '';
+      }
+    },
+
+    async respondToQuestionOther(msg, questionIdx, text, optionCount) {
+      if (msg.answered || !this.selectedSessionId || !text) return;
+      msg.answered = true;
+      msg.selectedOption = -1;
+      msg.answerText = text;
+      this.pendingQuestion = null;
+      this.pendingQuestionOtherText = '';
+      try {
+        await fetch(`/api/sessions/${this.selectedSessionId}/question-respond`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ option_index: -1, option_count: optionCount, text: text })
+        });
+      } catch (e) {
+        console.error('Failed to respond to question:', e);
+        this.toast('Failed to send answer: ' + e.message);
+        msg.answered = false;
+        msg.selectedOption = null;
+        msg.answerText = '';
+      }
     },
 
     async interruptSession() {
@@ -3260,7 +3328,9 @@ Please review this PR and provide feedback.`;
 
     // Time formatting
     timeAgo(dateStr) {
+      if (!dateStr) return '';
       const date = new Date(dateStr);
+      if (isNaN(date.getTime())) return '';
       const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
       if (seconds < 60) return 'just now';
       const minutes = Math.floor(seconds / 60);

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -381,7 +381,47 @@
                       <span x-text="msg.content"></span>
                     </div>
                   </template>
-                  <template x-if="!msg.isAutoContinue && msg.role !== 'activity' && msg.role !== 'shell' && msg.role !== 'shell_output'">
+                  <template x-if="msg.role === 'question'">
+                    <div class="question-card">
+                      <template x-for="(q, qi) in msg.questions" :key="qi">
+                        <div class="question-block">
+                          <div class="question-header" x-show="q.header">
+                            <span x-text="q.header"></span>
+                          </div>
+                          <div class="question-text" x-text="q.question"></div>
+                          <div class="question-options">
+                            <template x-for="(opt, oi) in q.options" :key="oi">
+                              <button class="question-option-btn"
+                                      :class="{ selected: msg.selectedOption === oi }"
+                                      :disabled="msg.answered"
+                                      @click="respondToQuestion(msg, qi, oi, opt.label, q.options.length)">
+                                <span class="option-label" x-text="opt.label"></span>
+                                <span class="option-desc" x-show="opt.description" x-text="opt.description"></span>
+                              </button>
+                            </template>
+                            <div class="question-other" x-show="!msg.answered">
+                              <div style="display:flex;gap:8px;align-items:center;width:100%;">
+                                <input type="text" class="question-other-input"
+                                       placeholder="Other..."
+                                       x-model="pendingQuestionOtherText"
+                                       @keydown.enter.prevent="if(pendingQuestionOtherText.trim()) respondToQuestionOther(msg, qi, pendingQuestionOtherText.trim(), q.options.length)">
+                                <button class="question-other-btn"
+                                        :disabled="!pendingQuestionOtherText.trim()"
+                                        @click="respondToQuestionOther(msg, qi, pendingQuestionOtherText.trim(), q.options.length)">
+                                  Send
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                          <div class="question-answered" x-show="msg.answered">
+                            <span style="color:var(--green);">&#10003;</span>
+                            <span x-text="'Answered: ' + (msg.answerText || '')"></span>
+                          </div>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                  <template x-if="!msg.isAutoContinue && msg.role !== 'activity' && msg.role !== 'shell' && msg.role !== 'shell_output' && msg.role !== 'question'">
                     <div class="chat-bubble"
                          :class="bubbleClass(msg, idx)"
                          x-html="bubbleHTML(msg)">

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -2816,3 +2816,125 @@ body {
   color: var(--text-muted);
   white-space: nowrap;
 }
+
+/* AskUserQuestion card */
+.question-card {
+  background: var(--card);
+  border: 1px solid var(--yellow);
+  border-radius: 12px;
+  padding: 16px;
+  margin: 8px 0;
+  max-width: 600px;
+}
+.question-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.question-header {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--yellow);
+  padding: 2px 8px;
+  background: rgba(245, 158, 11, 0.1);
+  border-radius: 4px;
+  display: inline-block;
+  width: fit-content;
+}
+.question-text {
+  font-size: 0.9rem;
+  color: var(--text);
+  font-weight: 500;
+  line-height: 1.4;
+}
+.question-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.question-option-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+  width: 100%;
+}
+.question-option-btn:hover:not(:disabled) {
+  border-color: var(--yellow);
+  background: rgba(245, 158, 11, 0.08);
+}
+.question-option-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.question-option-btn.selected {
+  border-color: var(--green);
+  background: rgba(34, 197, 94, 0.1);
+}
+.question-option-btn .option-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+.question-option-btn .option-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.3;
+}
+.question-other {
+  margin-top: 4px;
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+.question-other-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text);
+  font-size: 0.85rem;
+  outline: none;
+}
+.question-other-input:focus {
+  border-color: var(--yellow);
+}
+.question-other-btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--yellow);
+  color: #000;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.question-other-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.question-answered {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  padding: 4px 0;
+}
+
+@media (max-width: 768px) {
+  .question-card {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #203

- Parse `AskUserQuestion` tool_use blocks from the SSE transcript stream and render them as interactive question cards in the chat UI with tappable option buttons
- Add `POST /api/sessions/{id}/question-respond` endpoint that sends arrow-key navigation + Enter keystrokes to the Claude Code TUI interactive selector via PTY
- Support "Other" free-text input alongside predefined options
- Fix "NaNd ago" timestamp bug in `timeAgo()` by guarding against invalid/missing date strings

## Changes

**Frontend (app.js, index.html, style.css):**
- Detect `AskUserQuestion` tool_use blocks in SSE handler and push `role: 'question'` messages to chat
- New question card template renders header chip, question text, option buttons, Other text input, and answered state
- `respondToQuestion()` / `respondToQuestionOther()` methods call the new backend endpoint
- `timeAgo()` now returns empty string for null/undefined/invalid date inputs

**Backend (question_respond.go, router.go):**
- `handleQuestionRespond` validates the request and delegates to `sendQuestionKeys`
- `sendQuestionKeys` sends N arrow-down keystrokes + Enter to navigate the TUI option list, with 30ms delays between keystrokes for TUI reliability
- For "Other": navigates past all options, confirms, types the free text, and submits

## Test plan

- [ ] Start a managed session and trigger an AskUserQuestion
- [ ] Verify the question card renders inline in chat with header, question text, and option buttons
- [ ] Tap an option and verify Claude resumes working with that selection
- [ ] Use "Other" text input and verify free text is delivered and Claude continues
- [ ] Verify normal message sending still works unchanged
- [ ] Verify the waiting badge no longer shows "NaNd ago"
- [ ] Test on mobile viewport width
