### PR TITLE
fix: persist AskUserQuestion state server-side to prevent stuck sessions

### DIFF
--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -306,6 +306,9 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 			for _, toolName := range extractToolNames(line) {
 				_, _ = s.store.CreateMessage(sessionID, "activity", toolName, 0)
 			}
+			if pq := extractAskUserQuestion(line); pq != nil {
+				s.pendingQuestions.Set(sessionID, pq)
+			}
 			extractSessionFiles(line, sessionID, s.store)
 
 			v, ok := s.interactiveTurns.Load(sessionID)
@@ -614,6 +617,7 @@ func (s *Server) waitForTurnEnd(sessionID string, stopCh <-chan struct{}, done <
 }
 
 func (s *Server) finishInteractiveTurn(sessionID string, broadcaster *managed.Broadcaster) {
+	s.pendingQuestions.Delete(sessionID)
 	_ = s.store.UpdateActivityState(sessionID, "waiting")
 	broadcaster.Send(`{"type":"done","exit_code":0}`)
 }

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -436,8 +436,9 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 				sess.Initialized = true
 			}
 
-			// Clean up any pending permission request
+			// Clean up any pending permission/question request
 			s.permissions.Delete(sessionID)
+			s.pendingQuestions.Delete(sessionID)
 
 			// Check if process died
 			select {

--- a/server/api/pending_question.go
+++ b/server/api/pending_question.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type PendingQuestionOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+type PendingQuestionItem struct {
+	Question string                  `json:"question"`
+	Header   string                  `json:"header,omitempty"`
+	Options  []PendingQuestionOption `json:"options"`
+}
+
+type PendingQuestion struct {
+	ToolUseID string                `json:"tool_use_id"`
+	Questions []PendingQuestionItem `json:"questions"`
+	CreatedAt time.Time             `json:"created_at"`
+}
+
+type PendingQuestionManager struct {
+	mu      sync.Mutex
+	pending map[string]*PendingQuestion
+}
+
+func NewPendingQuestionManager() *PendingQuestionManager {
+	return &PendingQuestionManager{
+		pending: make(map[string]*PendingQuestion),
+	}
+}
+
+func (pq *PendingQuestionManager) Set(sessionID string, q *PendingQuestion) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	pq.pending[sessionID] = q
+}
+
+func (pq *PendingQuestionManager) Get(sessionID string) *PendingQuestion {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	return pq.pending[sessionID]
+}
+
+func (pq *PendingQuestionManager) Delete(sessionID string) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	delete(pq.pending, sessionID)
+}
+
+// extractAskUserQuestion checks an assistant transcript line for an
+// AskUserQuestion tool_use block and returns the parsed question data.
+// Returns nil if the line does not contain a valid AskUserQuestion.
+func extractAskUserQuestion(line string) *PendingQuestion {
+	var msg struct {
+		Message struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		return nil
+	}
+	var blocks []struct {
+		Type  string          `json:"type"`
+		ID    string          `json:"id"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(msg.Message.Content, &blocks); err != nil {
+		return nil
+	}
+	for _, b := range blocks {
+		if b.Type != "tool_use" || b.Name != "AskUserQuestion" {
+			continue
+		}
+		var input struct {
+			Questions []PendingQuestionItem `json:"questions"`
+		}
+		if err := json.Unmarshal(b.Input, &input); err != nil || len(input.Questions) == 0 {
+			continue
+		}
+		return &PendingQuestion{
+			ToolUseID: b.ID,
+			Questions: input.Questions,
+			CreatedAt: time.Now(),
+		}
+	}
+	return nil
+}
+
+func (s *Server) handlePendingQuestion(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	pending := s.pendingQuestions.Get(sessionID)
+
+	w.Header().Set("Content-Type", "application/json")
+	if pending == nil {
+		json.NewEncoder(w).Encode(map[string]interface{}{"pending": false})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"pending":     true,
+		"tool_use_id": pending.ToolUseID,
+		"questions":   pending.Questions,
+		"created_at":  pending.CreatedAt,
+	})
+}
+
+// handleDismissQuestion clears a pending question without sending a response
+// to the PTY. Used by the UI's "skip" action when a question is stuck.
+func (s *Server) handleDismissQuestion(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			http.Error(w, "session not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	if sess.Mode != "managed" {
+		http.Error(w, "not a managed session", http.StatusBadRequest)
+		return
+	}
+
+	s.pendingQuestions.Delete(sessionID)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/server/api/pending_question_test.go
+++ b/server/api/pending_question_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestExtractAskUserQuestion_ValidQuestion(t *testing.T) {
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_123","name":"AskUserQuestion","input":{"questions":[{"question":"Which approach?","header":"Approach","options":[{"label":"Option A","description":"First option"},{"label":"Option B","description":"Second option"}],"multiSelect":false}]}}]}}`
+	pq := extractAskUserQuestion(line)
+	if pq == nil {
+		t.Fatal("expected non-nil PendingQuestion")
+	}
+	if pq.ToolUseID != "toolu_123" {
+		t.Errorf("ToolUseID = %q, want %q", pq.ToolUseID, "toolu_123")
+	}
+	if len(pq.Questions) != 1 {
+		t.Fatalf("len(Questions) = %d, want 1", len(pq.Questions))
+	}
+	if pq.Questions[0].Question != "Which approach?" {
+		t.Errorf("Question = %q, want %q", pq.Questions[0].Question, "Which approach?")
+	}
+	if len(pq.Questions[0].Options) != 2 {
+		t.Errorf("len(Options) = %d, want 2", len(pq.Questions[0].Options))
+	}
+}
+
+func TestExtractAskUserQuestion_NoQuestions(t *testing.T) {
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_456","name":"AskUserQuestion","input":{"questions":[]}}]}}`
+	pq := extractAskUserQuestion(line)
+	if pq != nil {
+		t.Error("expected nil for empty questions array")
+	}
+}
+
+func TestExtractAskUserQuestion_MissingInput(t *testing.T) {
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_789","name":"AskUserQuestion","input":{}}]}}`
+	pq := extractAskUserQuestion(line)
+	if pq != nil {
+		t.Error("expected nil for missing questions field")
+	}
+}
+
+func TestExtractAskUserQuestion_NotAskUserQuestion(t *testing.T) {
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_abc","name":"Read","input":{"file_path":"/tmp/test.txt"}}]}}`
+	pq := extractAskUserQuestion(line)
+	if pq != nil {
+		t.Error("expected nil for non-AskUserQuestion tool")
+	}
+}
+
+func TestExtractAskUserQuestion_MalformedJSON(t *testing.T) {
+	pq := extractAskUserQuestion(`not json`)
+	if pq != nil {
+		t.Error("expected nil for malformed JSON")
+	}
+}
+
+func TestExtractAskUserQuestion_TextOnlyAssistant(t *testing.T) {
+	line := `{"type":"assistant","message":{"content":[{"type":"text","text":"Hello!"}]}}`
+	pq := extractAskUserQuestion(line)
+	if pq != nil {
+		t.Error("expected nil for text-only assistant message")
+	}
+}
+
+func TestPendingQuestionManager(t *testing.T) {
+	mgr := NewPendingQuestionManager()
+
+	if mgr.Get("sess1") != nil {
+		t.Error("expected nil for unknown session")
+	}
+
+	pq := &PendingQuestion{ToolUseID: "toolu_1", Questions: []PendingQuestionItem{{Question: "test?"}}}
+	mgr.Set("sess1", pq)
+
+	got := mgr.Get("sess1")
+	if got == nil || got.ToolUseID != "toolu_1" {
+		t.Error("expected stored question")
+	}
+
+	mgr.Delete("sess1")
+	if mgr.Get("sess1") != nil {
+		t.Error("expected nil after delete")
+	}
+}
+
+func TestHandlePendingQuestion_NoPending(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0, 0)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions/"+sess.ID+"/pending-question", nil)
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["pending"] != false {
+		t.Errorf("pending=%v, want false", result["pending"])
+	}
+}
+
+func TestHandleDismissQuestion(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.CreateManagedSession("/tmp/test", `["Read"]`, 50, 5.0, 0)
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/question-dismiss", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHandleDismissQuestion_NotManaged(t *testing.T) {
+	ts, store := setupTestServer(t)
+	defer ts.Close()
+	defer store.Close()
+
+	sess, _ := store.UpsertSession("computer1", "/tmp/proj", "")
+
+	req, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/question-dismiss", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer test-api-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 400 {
+		t.Errorf("status=%d, want 400 for non-managed session", resp.StatusCode)
+	}
+}

--- a/server/api/question_respond.go
+++ b/server/api/question_respond.go
@@ -40,6 +40,8 @@ func (s *Server) handleQuestionRespond(w http.ResponseWriter, r *http.Request) {
 
 	isOther := req.OptionIndex < 0 || req.OptionIndex >= req.OptionCount
 
+	s.pendingQuestions.Delete(sessionID)
+
 	if isOther {
 		// Navigate past all options to "Other", select it, type text, confirm
 		if err := s.sendQuestionKeys(sessionID, req.OptionCount, true, req.Text); err != nil {

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -25,6 +25,7 @@ type Server struct {
 	workflowEngine    *managed.WorkflowEngine
 	envPath           string
 	permissions       *PermissionManager
+	pendingQuestions  *PendingQuestionManager
 	shutdownFunc      func() // called to trigger server restart
 	restartInProgress atomic.Bool
 	serverID          string // unique ID per server instance, used by clients to detect restart
@@ -40,7 +41,7 @@ type Server struct {
 }
 
 func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath string, shutdownFunc func(), serverID string, taskTrigger TaskTrigger) http.Handler {
-	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), shutdownFunc: shutdownFunc, serverID: serverID, taskTrigger: taskTrigger}
+	s := &Server{store: store, manager: mgr, envPath: envPath, permissions: NewPermissionManager(), pendingQuestions: NewPendingQuestionManager(), shutdownFunc: shutdownFunc, serverID: serverID, taskTrigger: taskTrigger}
 
 	// Initialize workflow engine with callbacks wired to the server
 	s.workflowEngine = managed.NewWorkflowEngine(
@@ -114,6 +115,8 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 	apiMux.HandleFunc("POST /api/sessions/{id}/permission-respond", s.handlePermissionRespond)
 	apiMux.HandleFunc("GET /api/sessions/{id}/pending-permission", s.handlePendingPermission)
 	apiMux.HandleFunc("POST /api/sessions/{id}/question-respond", s.handleQuestionRespond)
+	apiMux.HandleFunc("GET /api/sessions/{id}/pending-question", s.handlePendingQuestion)
+	apiMux.HandleFunc("POST /api/sessions/{id}/question-dismiss", s.handleDismissQuestion)
 	apiMux.HandleFunc("GET /api/sessions/{id}/commands", s.handleListCommands)
 	apiMux.HandleFunc("GET /api/sessions/{id}/commands/content", s.handleCommandContent)
 

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2041,6 +2041,30 @@ document.addEventListener('alpine:init', () => {
         }
       }).catch(() => {});
 
+      // Check for pending question on reconnect
+      fetch(`/api/sessions/${sessionId}/pending-question`, {
+        headers: { 'Authorization': `Bearer ${this.apiKey}` }
+      }).then(r => r.json()).then(data => {
+        if (data.pending && data.questions && data.questions.length > 0) {
+          const alreadyShown = this.chatMessages.some(m => m.role === 'question' && !m.answered);
+          if (!alreadyShown) {
+            this.pendingQuestion = {
+              toolUseId: data.tool_use_id,
+              questions: data.questions,
+              timestamp: data.created_at
+            };
+            this.pendingQuestionOtherText = '';
+            this.chatMessages.push({
+              id: 'question-' + Date.now(),
+              role: 'question',
+              questions: data.questions,
+              timestamp: data.created_at
+            });
+            this.$nextTick(() => this.scrollToBottom(true));
+          }
+        }
+      }).catch(() => {});
+
       this.sessionSSE.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
@@ -2192,6 +2216,7 @@ document.addEventListener('alpine:init', () => {
           if (data.type === 'done') {
             this.pendingPermission = null;
             this.pendingQuestion = null;
+            this.chatMessages = this.chatMessages.filter(m => m.role !== 'question_stuck' && m.role !== 'question_error');
             this.finalizeAgentInvocations();
             // Keep the SSE connection open: in interactive mode the Claude
             // process outlives the turn and can produce more output (e.g.
@@ -2208,20 +2233,33 @@ document.addEventListener('alpine:init', () => {
                 this.addActivityPill(label, 'active');
                 this.trackAgentInvocation(block, label);
 
-                if (block.name === 'AskUserQuestion' && block.input && block.input.questions) {
-                  this.pendingQuestion = {
-                    toolUseId: block.id,
-                    questions: block.input.questions,
-                    timestamp: new Date().toISOString()
-                  };
-                  this.pendingQuestionOtherText = '';
-                  this.chatMessages.push({
-                    id: 'question-' + Date.now(),
-                    role: 'question',
-                    questions: block.input.questions,
-                    timestamp: new Date().toISOString()
-                  });
-                  this.$nextTick(() => this.scrollToBottom(true));
+                if (block.name === 'AskUserQuestion') {
+                  const questions = block.input && Array.isArray(block.input.questions) && block.input.questions.length > 0
+                    ? block.input.questions
+                    : null;
+                  if (questions) {
+                    this.pendingQuestion = {
+                      toolUseId: block.id,
+                      questions: questions,
+                      timestamp: new Date().toISOString()
+                    };
+                    this.pendingQuestionOtherText = '';
+                    this.chatMessages.push({
+                      id: 'question-' + Date.now(),
+                      role: 'question',
+                      questions: questions,
+                      timestamp: new Date().toISOString()
+                    });
+                    this.$nextTick(() => this.scrollToBottom(true));
+                  } else {
+                    this.chatMessages.push({
+                      id: 'question-error-' + Date.now(),
+                      role: 'question_error',
+                      timestamp: new Date().toISOString()
+                    });
+                    this.$nextTick(() => this.scrollToBottom(true));
+                    this.scheduleQuestionRetry(block.id);
+                  }
                 }
               }
             }
@@ -2433,6 +2471,98 @@ document.addEventListener('alpine:init', () => {
         msg.answered = false;
         msg.selectedOption = null;
         msg.answerText = '';
+      }
+    },
+
+    scheduleQuestionRetry(toolUseId) {
+      let attempts = 0;
+      const maxAttempts = 3;
+      const retryInterval = 2000;
+      const doRetry = () => {
+        if (attempts >= maxAttempts || !this.selectedSessionId) {
+          const errMsg = this.chatMessages.find(m => m.role === 'question_error');
+          if (errMsg) errMsg.retryExhausted = true;
+          return;
+        }
+        attempts++;
+        fetch(`/api/sessions/${this.selectedSessionId}/pending-question`, {
+          headers: { 'Authorization': `Bearer ${this.apiKey}` }
+        }).then(r => r.json()).then(data => {
+          if (data.pending && data.questions && data.questions.length > 0) {
+            const errIdx = this.chatMessages.findIndex(m => m.role === 'question_error');
+            if (errIdx >= 0) this.chatMessages.splice(errIdx, 1);
+            this.pendingQuestion = {
+              toolUseId: data.tool_use_id,
+              questions: data.questions,
+              timestamp: data.created_at
+            };
+            this.pendingQuestionOtherText = '';
+            this.chatMessages.push({
+              id: 'question-' + Date.now(),
+              role: 'question',
+              questions: data.questions,
+              timestamp: data.created_at
+            });
+            this.$nextTick(() => this.scrollToBottom(true));
+          } else {
+            setTimeout(doRetry, retryInterval);
+          }
+        }).catch(() => setTimeout(doRetry, retryInterval));
+      };
+      setTimeout(doRetry, retryInterval);
+    },
+
+    async retryQuestion() {
+      if (!this.selectedSessionId) return;
+      const errIdx = this.chatMessages.findIndex(m => m.role === 'question_error');
+      if (errIdx >= 0) this.chatMessages.splice(errIdx, 1);
+      try {
+        const r = await fetch(`/api/sessions/${this.selectedSessionId}/pending-question`, {
+          headers: { 'Authorization': `Bearer ${this.apiKey}` }
+        });
+        const data = await r.json();
+        if (data.pending && data.questions && data.questions.length > 0) {
+          this.pendingQuestion = {
+            toolUseId: data.tool_use_id,
+            questions: data.questions,
+            timestamp: data.created_at
+          };
+          this.pendingQuestionOtherText = '';
+          this.chatMessages.push({
+            id: 'question-' + Date.now(),
+            role: 'question',
+            questions: data.questions,
+            timestamp: data.created_at
+          });
+          this.$nextTick(() => this.scrollToBottom(true));
+        } else {
+          this.toast('No pending question found');
+        }
+      } catch (e) {
+        this.toast('Failed to fetch question: ' + e.message);
+      }
+    },
+
+    async dismissQuestion() {
+      if (!this.selectedSessionId) return;
+      try {
+        await fetch(`/api/sessions/${this.selectedSessionId}/question-dismiss`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json'
+          }
+        });
+      } catch (e) {
+        console.error('Failed to dismiss question:', e);
+      }
+      this.pendingQuestion = null;
+      const errIdx = this.chatMessages.findIndex(m => m.role === 'question_error');
+      if (errIdx >= 0) this.chatMessages.splice(errIdx, 1);
+      const qIdx = this.chatMessages.findIndex(m => m.role === 'question' && !m.answered);
+      if (qIdx >= 0) {
+        this.chatMessages[qIdx].answered = true;
+        this.chatMessages[qIdx].answerText = 'Dismissed';
       }
     },
 
@@ -3209,6 +3339,23 @@ Please review this PR and provide feedback.`;
             stalePill.content = stalePill.originalLabel;
         }
         this.stalenessTimer = setTimeout(() => {
+            if (this.pendingQuestion) {
+                const hasUnanswered = this.chatMessages.some(m => m.role === 'question' && !m.answered);
+                if (!hasUnanswered) {
+                    this.retryQuestion();
+                } else {
+                    const stuckExists = this.chatMessages.some(m => m.role === 'question_stuck');
+                    if (!stuckExists) {
+                        this.chatMessages.push({
+                            id: 'question-stuck-' + Date.now(),
+                            role: 'question_stuck',
+                            timestamp: new Date().toISOString()
+                        });
+                        this.$nextTick(() => this.scrollToBottom(true));
+                    }
+                }
+                return;
+            }
             const activePill = this.chatMessages.find(m => m.role === 'activity' && m.pillState === 'active');
             if (activePill) {
                 const elapsed = Math.round((Date.now() - this.lastEventTime) / 1000);

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -421,7 +421,54 @@
                       </template>
                     </div>
                   </template>
-                  <template x-if="!msg.isAutoContinue && msg.role !== 'activity' && msg.role !== 'shell' && msg.role !== 'shell_output' && msg.role !== 'question'">
+                  <template x-if="msg.role === 'question_error'">
+                    <div class="question-card" style="border-color:var(--yellow,#e6a700);">
+                      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+                        <span style="color:var(--yellow,#e6a700);font-size:16px;">&#9888;</span>
+                        <span style="font-weight:600;color:var(--text);">Question failed to load</span>
+                      </div>
+                      <p style="color:var(--text-muted);margin:0 0 12px 0;font-size:13px;">
+                        Claude asked a question but the content didn't arrive completely.
+                      </p>
+                      <div style="display:flex;gap:8px;">
+                        <button class="question-option-btn" style="flex:none;padding:6px 16px;" @click="retryQuestion()">
+                          Retry
+                        </button>
+                        <button class="question-option-btn" style="flex:none;padding:6px 16px;opacity:0.7;" @click="dismissQuestion()">
+                          Skip
+                        </button>
+                        <button class="question-option-btn" style="flex:none;padding:6px 16px;opacity:0.7;" @click="interruptSession()">
+                          Interrupt
+                        </button>
+                      </div>
+                      <div x-show="msg.retryExhausted" x-cloak style="margin-top:8px;font-size:12px;color:var(--text-muted);">
+                        Auto-retry exhausted. Use Retry to try again or Interrupt to cancel the turn.
+                      </div>
+                    </div>
+                  </template>
+                  <template x-if="msg.role === 'question_stuck'">
+                    <div class="question-card" style="border-color:var(--yellow,#e6a700);">
+                      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+                        <span style="color:var(--yellow,#e6a700);font-size:16px;">&#9888;</span>
+                        <span style="font-weight:600;color:var(--text);">Session appears stuck</span>
+                      </div>
+                      <p style="color:var(--text-muted);margin:0 0 12px 0;font-size:13px;">
+                        Claude is waiting for a response to a question above. If you can't see the question or can't interact with it, use the actions below.
+                      </p>
+                      <div style="display:flex;gap:8px;">
+                        <button class="question-option-btn" style="flex:none;padding:6px 16px;" @click="retryQuestion()">
+                          Reload Question
+                        </button>
+                        <button class="question-option-btn" style="flex:none;padding:6px 16px;opacity:0.7;" @click="dismissQuestion()">
+                          Skip
+                        </button>
+                        <button class="question-option-btn" style="flex:none;padding:6px 16px;opacity:0.7;" @click="interruptSession()">
+                          Interrupt
+                        </button>
+                      </div>
+                    </div>
+                  </template>
+                  <template x-if="!msg.isAutoContinue && msg.role !== 'activity' && msg.role !== 'shell' && msg.role !== 'shell_output' && msg.role !== 'question' && msg.role !== 'question_error' && msg.role !== 'question_stuck'">
                     <div class="chat-bubble"
                          :class="bubbleClass(msg, idx)"
                          x-html="bubbleHTML(msg)">


### PR DESCRIPTION
## Summary

Fixes #205 — AskUserQuestion tool calls in managed sessions intermittently rendered with missing content, leaving sessions stuck.

**Root cause:** AskUserQuestion data was broadcast via SSE once with no server-side persistence. If the SSE connection hiccuped (reconnect, tab background, network blip), the question data was lost forever. Claude waited for a response that could never arrive.

**Fix:** Mirror the existing `PendingPermission` pattern:
- **Server-side persistence** — `PendingQuestionManager` stores question state, detected from transcript `tool_use` blocks via `extractAskUserQuestion()`
- **Recovery endpoint** — `GET /api/sessions/{id}/pending-question` lets the frontend recover missed questions on SSE reconnect
- **Dismiss endpoint** — `POST /api/sessions/{id}/question-dismiss` for skip/cancel actions
- **Lifecycle cleanup** — pending question cleared on respond, dismiss, and turn-end
- **Defensive rendering** — incomplete/malformed AskUserQuestion shows error card with Retry/Skip/Interrupt instead of blank
- **Stuck detection** — 60s staleness timer shows question-specific recovery UI when `pendingQuestion` exists

## Files changed

| File | Change |
|------|--------|
| `server/api/pending_question.go` | New: PendingQuestionManager, extractAskUserQuestion, handlers |
| `server/api/pending_question_test.go` | New: 10 tests for extraction, manager, and HTTP endpoints |
| `server/api/router.go` | Add pendingQuestions field + 2 new routes |
| `server/api/managed_interactive.go` | Detect AskUserQuestion in onTranscriptLine, cleanup on turn-end |
| `server/api/managed_sessions.go` | Cleanup pending question on print-mode turn-end |
| `server/api/question_respond.go` | Clear pending question on response |
| `server/web/static/app.js` | Reconnect recovery, defensive rendering, stuck detection, retry/dismiss |
| `server/web/static/index.html` | question_error and question_stuck card templates |

## Test plan

- [x] All existing Go tests pass (no regressions)
- [x] 10 new tests for extraction logic, manager CRUD, and HTTP endpoints
- [ ] Manual: trigger AskUserQuestion in managed session — verify full card renders
- [ ] Manual: kill/restart SSE during pending question — verify card recovers on reconnect
- [ ] Manual: verify permission prompts still render correctly (regression guard)
- [ ] Manual: verify stuck indicator appears after 60s if question card is missing