### PR TITLE
feat: improve skill list with sorting, scope coloring, and filter pills

### DIFF
--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -114,6 +114,7 @@ document.addEventListener('alpine:init', () => {
     skillsExpanded: false,
     skillsLoading: false,
     skillsError: null,
+    skillsFilter: 'all',
 
     viewerFile: null,
     viewerMode: 'diff',
@@ -2706,12 +2707,20 @@ document.addEventListener('alpine:init', () => {
           this.skillsError = 'Failed to load skills';
           return;
         }
-        this.skills = await resp.json() || [];
+        const raw = await resp.json() || [];
+        raw.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+        this.skills = raw;
       } catch (e) {
         this.skillsError = e.message || 'Failed to load skills';
       } finally {
         this.skillsLoading = false;
       }
+    },
+
+    get filteredSkills() {
+      if (this.skillsFilter === 'global') return this.skills.filter(s => s.dir !== 'project');
+      if (this.skillsFilter === 'project') return this.skills.filter(s => s.dir === 'project');
+      return this.skills;
     },
 
     sendSkill(skillName) {

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -887,14 +887,19 @@
             <button class="file-tree-refresh" x-show="skillsExpanded" @click.stop="fetchSkills(selectedSessionId)" title="Refresh skills">↻</button>
           </div>
           <div x-show="skillsExpanded" x-collapse style="padding:0 12px 8px 12px">
+            <div class="issue-state-toggles" style="margin-bottom:6px" x-show="!skillsLoading && !skillsError && skills.length > 0">
+              <button class="issue-state-toggle" :class="{ 'active-skills-all': skillsFilter === 'all' }" @click="skillsFilter = 'all'">All</button>
+              <button class="issue-state-toggle" :class="{ 'active-skills-global': skillsFilter === 'global' }" @click="skillsFilter = 'global'">Global</button>
+              <button class="issue-state-toggle" :class="{ 'active-skills-project': skillsFilter === 'project' }" @click="skillsFilter = 'project'">Project</button>
+            </div>
             <div x-show="skillsLoading" class="issues-loading">Loading...</div>
             <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
             <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
             <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
-              <template x-for="skill in skills" :key="skill.name">
+              <template x-for="skill in filteredSkills" :key="skill.name">
                 <div class="issue-row" @click="sendSkill(skill.name)" :title="skill.description || skill.name">
                   <div class="issue-row-content">
-                    <div class="issue-row-title" x-text="skill.name"></div>
+                    <div class="issue-row-title" x-text="skill.name" :style="skill.dir === 'project' ? 'color: #3b82f6' : ''"></div>
                   </div>
                 </div>
               </template>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -912,6 +912,19 @@ body {
   border-color: #8957e5;
 }
 
+.issue-state-toggle.active-skills-all,
+.issue-state-toggle.active-skills-global {
+  background: var(--text-muted);
+  color: #fff;
+  border-color: var(--text-muted);
+}
+
+.issue-state-toggle.active-skills-project {
+  background: #3b82f6;
+  color: #fff;
+  border-color: #3b82f6;
+}
+
 .issues-search {
   width: 100%;
   padding: 5px 8px;


### PR DESCRIPTION
## Summary

Closes #207

- **Sort skills alphabetically** — Skills are sorted A-Z (case-insensitive) after fetching from the API
- **Color-code project-specific skills** — Skills with `dir === "project"` render in blue (`#3b82f6`); global/user/bb skills keep the default text color
- **Add filter pill bar** — Horizontal `All` / `Global` / `Project` radio-button pills above the skill list filter by scope, with `All` selected by default

## Changes

- `app.js`: Added `skillsFilter` state, alphabetical sort on fetch, `filteredSkills` getter
- `index.html`: Added pill bar HTML, wired `x-for` to `filteredSkills`, added `:style` binding for blue project skill text
- `style.css`: Added active-state styles for the three filter pills

## Test plan

- [ ] Open skill list — verify skills appear in A-Z order
- [ ] Confirm project-scoped skills show in blue text, global skills in default color
- [ ] Click each pill (All, Global, Project) — verify correct filtering
- [ ] Verify only one pill is active at a time, with distinct highlighted style
- [ ] Click a skill to send it — verify existing functionality unchanged