### PR TITLE
fix: add polling fallback for AskUserQuestion detection in managed sessions

### DIFF
--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -307,6 +307,7 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 				_, _ = s.store.CreateMessage(sessionID, "activity", toolName, 0)
 			}
 			if pq := extractAskUserQuestion(line); pq != nil {
+				log.Printf("session %s: AskUserQuestion detected in transcript, storing pending question (tool_use_id=%s)", sessionID, pq.ToolUseID)
 				s.pendingQuestions.Set(sessionID, pq)
 			}
 			extractSessionFiles(line, sessionID, s.store)

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -48,6 +48,7 @@ document.addEventListener('alpine:init', () => {
     sessionSSE: null,
     sseReconnectAttempts: 0,
     sseReconnectTimer: null,
+    questionPollTimer: null,
 
     // Directory browser state
     browsePath: '',
@@ -1798,8 +1799,8 @@ document.addEventListener('alpine:init', () => {
         this.addActivityPill('Thinking...', 'active');
         this.resetStalenessTimer();
 
-        // Start SSE stream for this session
-        this.startSessionSSE(this.selectedSessionId);
+        // Ensure SSE is connected (reuse existing connection if open)
+        await this.ensureSSEConnected(this.selectedSessionId);
       } catch (e) {
         this.toast('Error: ' + e.message);
       }
@@ -2351,6 +2352,49 @@ document.addEventListener('alpine:init', () => {
       this.sessionSSE.onerror = () => {
         this.attemptSSEReconnect(sessionId);
       };
+
+      this.startQuestionPoll(sessionId);
+    },
+
+    startQuestionPoll(sessionId) {
+      this.stopQuestionPoll();
+      this.questionPollTimer = setInterval(async () => {
+        if (sessionId !== this.selectedSessionId) {
+          this.stopQuestionPoll();
+          return;
+        }
+        if (this.pendingQuestion) return;
+        const hasUnanswered = this.chatMessages.some(m => m.role === 'question' && !m.answered);
+        if (hasUnanswered) return;
+        try {
+          const r = await fetch(`/api/sessions/${sessionId}/pending-question`, {
+            headers: { 'Authorization': `Bearer ${this.apiKey}` }
+          });
+          const data = await r.json();
+          if (data.pending && data.questions && data.questions.length > 0) {
+            this.pendingQuestion = {
+              toolUseId: data.tool_use_id,
+              questions: data.questions,
+              timestamp: data.created_at
+            };
+            this.pendingQuestionOtherText = '';
+            this.chatMessages.push({
+              id: 'question-' + Date.now(),
+              role: 'question',
+              questions: data.questions,
+              timestamp: data.created_at
+            });
+            this.$nextTick(() => this.scrollToBottom(true));
+          }
+        } catch (e) { /* ignore poll failures */ }
+      }, 3000);
+    },
+
+    stopQuestionPoll() {
+      if (this.questionPollTimer) {
+        clearInterval(this.questionPollTimer);
+        this.questionPollTimer = null;
+      }
     },
 
     attemptSSEReconnect(sessionId) {
@@ -2402,6 +2446,7 @@ document.addEventListener('alpine:init', () => {
         this.sseReconnectTimer = null;
       }
       this.sseReconnectAttempts = 0;
+      this.stopQuestionPoll();
       if (this.sessionSSE) {
         this.sessionSSE.close();
         this.sessionSSE = null;


### PR DESCRIPTION
## Summary
- Reuse existing SSE connection on message send (`ensureSSEConnected` instead of `startSessionSSE`) to prevent a brief subscriber gap where broadcast messages are lost
- Add 3-second polling fallback that checks `/pending-question` when no question card is visible, catching cases where the transcript entry is buffered by Claude Code and not immediately visible to the tailer
- Add server-side diagnostic logging when AskUserQuestion is detected in the transcript

## Test plan
- [ ] Send a message that triggers AskUserQuestion in a managed session
- [ ] Verify the question card appears within a few seconds without needing to hit Stop
- [ ] Verify answering the question still works correctly
- [ ] Check server logs for the new AskUserQuestion diagnostic message