### PR TITLE
Fix /reload-skills hanging due to aggressive prompt timeout

### DIFF
--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -30,7 +30,7 @@ var compactTimeout = 5 * time.Minute
 // promptEchoTimeout is how long we wait for the typed prompt to appear as a
 // user entry in the transcript before re-sending Enter (the paste may land
 // before the TUI is accepting the submit keypress).
-var promptEchoTimeout = 4 * time.Second
+var promptEchoTimeout = 15 * time.Second
 
 // promptEchoRetries is how many extra Enter presses we attempt.
 const promptEchoRetries = 2


### PR DESCRIPTION
Fixes #210 (part of the solution—this is the immediate fix).

## Problem
When running slow commands like `/reload-skills`, the interactive backend's 4-second prompt confirmation timeout was too aggressive. Commands legitimately take >4s for MCP server handshakes and skill registry loading. The server would retry Enter presses while the CLI was still processing, causing:
- Protocol deadlock (server retrying, CLI saying "No response requested")
- False "may be stalled" warnings to the user
- Confused session state

## Solution
Increase `promptEchoTimeout` from 4s to 15s.

This gives slow-but-working commands breathing room. A more robust activity-based detection approach (issue #210) will replace this timeout-based logic in the future.

## Testing
- Manual: Run `/reload-skills` in interactive mode and verify it completes without spurious retries
- Verify server logs show no "prompt not confirmed" messages
- Run existing `confirmPromptSubmission` tests to ensure no regressions