### PR TITLE
fix: unblock managed session hang on AskUserQuestion

### DIFF
--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -61,6 +61,15 @@ func buildInteractiveArgs(sess *db.Session, settingsPath, trustPrompt string) []
 	return args
 }
 
+// turnEndReason distinguishes why waitForTurnEnd unblocked.
+type turnEndReason int
+
+const (
+	turnEndStop     turnEndReason = iota // Stop hook fired (normal turn completion)
+	turnEndDied                          // Process exited
+	turnEndQuestion                      // AskUserQuestion detected in transcript
+)
+
 // interactiveTurnState tracks per-turn counters shared between the transcript
 // callback (tailer goroutine) and the orchestrator goroutine.
 type interactiveTurnState struct {
@@ -70,6 +79,7 @@ type interactiveTurnState struct {
 	outputTokens   int
 	interruptedFor string // "" | "max_turns" | "budget"
 	promptEchoed   bool   // the typed prompt appeared in the transcript
+	questionCh     chan struct{}
 }
 
 func (t *interactiveTurnState) reset() {
@@ -80,6 +90,11 @@ func (t *interactiveTurnState) reset() {
 	t.outputTokens = 0
 	t.interruptedFor = ""
 	t.promptEchoed = false
+	// Drain any stale question signal
+	select {
+	case <-t.questionCh:
+	default:
+	}
 }
 
 func (t *interactiveTurnState) markPromptEchoed() {
@@ -215,7 +230,7 @@ func (s *Server) sendMessageInteractive(sess *db.Session, message string, imageP
 	// Register this message's turn state so the long-lived transcript
 	// callback (registered at spawn, possibly by an earlier message's
 	// goroutine) feeds counters into the current turn.
-	turn := &interactiveTurnState{}
+	turn := &interactiveTurnState{questionCh: make(chan struct{}, 1)}
 	s.interactiveTurns.Store(sessionID, turn)
 
 	prompt := message
@@ -306,9 +321,11 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 			for _, toolName := range extractToolNames(line) {
 				_, _ = s.store.CreateMessage(sessionID, "activity", toolName, 0)
 			}
+			questionDetected := false
 			if pq := extractAskUserQuestion(line); pq != nil {
 				log.Printf("session %s: AskUserQuestion detected in transcript, storing pending question (tool_use_id=%s)", sessionID, pq.ToolUseID)
 				s.pendingQuestions.Set(sessionID, pq)
+				questionDetected = true
 			}
 			extractSessionFiles(line, sessionID, s.store)
 
@@ -317,6 +334,13 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 				return
 			}
 			cur := v.(*interactiveTurnState)
+
+			if questionDetected {
+				select {
+				case cur.questionCh <- struct{}{}:
+				default:
+				}
+			}
 			cur.mu.Lock()
 			cur.assistantCount++
 			cur.inputTokens += entry.Message.Usage.InputTokens
@@ -436,9 +460,45 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 			s.confirmPromptSubmission(sessionID, turn, proc.Done, turnOver, broadcaster)
 		})
 
-		procDied := !s.waitForTurnEnd(sessionID, stopCh, proc.Done, turn)
+		reason := s.waitForTurnEnd(sessionID, stopCh, proc.Done, turn)
+
+		// AskUserQuestion detected — transition to waiting, then resume when
+		// the user responds (or abort if Stop/death occurs while waiting).
+		for reason == turnEndQuestion {
+			log.Printf("session %s: AskUserQuestion unblocked turn loop, transitioning to waiting", sessionID)
+			_ = s.store.UpdateActivityState(sessionID, "waiting")
+			questionEvt, _ := json.Marshal(map[string]string{"type": "question_ready"})
+			broadcaster.Send(string(questionEvt))
+
+			respondedCh := s.pendingQuestions.WaitForClear(sessionID)
+
+			// If the question was already answered (race), skip the wait.
+			if s.pendingQuestions.Get(sessionID) == nil {
+				log.Printf("session %s: pending question already cleared, resuming turn", sessionID)
+				_ = s.store.UpdateActivityState(sessionID, "working")
+				reason = s.waitForTurnEnd(sessionID, stopCh, proc.Done, turn)
+				continue
+			}
+
+			select {
+			case <-respondedCh:
+				log.Printf("session %s: question answered, resuming turn", sessionID)
+				_ = s.store.UpdateActivityState(sessionID, "working")
+				reason = s.waitForTurnEnd(sessionID, stopCh, proc.Done, turn)
+			case <-stopCh:
+				log.Printf("session %s: stop during question wait, ending turn", sessionID)
+				s.pendingQuestions.Delete(sessionID)
+				reason = turnEndStop
+			case <-proc.Done:
+				log.Printf("session %s: process died during question wait", sessionID)
+				s.pendingQuestions.Delete(sessionID)
+				reason = turnEndDied
+			}
+		}
+
 		close(turnOver)
 
+		procDied := reason == turnEndDied
 		count, in, out, interrupted := turn.snapshot()
 
 		if !sess.Initialized {
@@ -590,19 +650,22 @@ func (s *Server) confirmPromptSubmission(sessionID string, turn *interactiveTurn
 	broadcaster.Send(string(evt))
 }
 
-// waitForTurnEnd blocks until the Stop hook fires, the process dies, or — if
-// the turn was interrupted via ESC — a fallback timer expires (the Stop hook
-// may not fire on interrupts). Returns false if the process died.
-func (s *Server) waitForTurnEnd(sessionID string, stopCh <-chan struct{}, done <-chan struct{}, turn *interactiveTurnState) bool {
+// waitForTurnEnd blocks until the Stop hook fires, the process dies, an
+// AskUserQuestion is detected in the transcript, or — if the turn was
+// interrupted via ESC — a fallback timer expires (the Stop hook may not fire
+// on interrupts).
+func (s *Server) waitForTurnEnd(sessionID string, stopCh <-chan struct{}, done <-chan struct{}, turn *interactiveTurnState) turnEndReason {
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 	var interruptedAt time.Time
 	for {
 		select {
 		case <-stopCh:
-			return true
+			return turnEndStop
 		case <-done:
-			return false
+			return turnEndDied
+		case <-turn.questionCh:
+			return turnEndQuestion
 		case <-ticker.C:
 			s.manager.TouchInteractive(sessionID)
 			_, _, _, interrupted := turn.snapshot()
@@ -611,7 +674,7 @@ func (s *Server) waitForTurnEnd(sessionID string, stopCh <-chan struct{}, done <
 			}
 			if !interruptedAt.IsZero() && time.Since(interruptedAt) > escStopFallback {
 				log.Printf("session %s: no Stop hook after interrupt, assuming turn ended", sessionID)
-				return true
+				return turnEndStop
 			}
 		}
 	}

--- a/server/api/managed_interactive_test.go
+++ b/server/api/managed_interactive_test.go
@@ -462,6 +462,157 @@ func TestIsCliNoiseMessage(t *testing.T) {
 	}
 }
 
+func askUserQuestionTranscriptLine(toolID, question string, options []string) string {
+	opts := make([]map[string]string, len(options))
+	for i, o := range options {
+		opts[i] = map[string]string{"label": o, "description": "Option " + o}
+	}
+	input := map[string]any{
+		"questions": []map[string]any{{
+			"question":    question,
+			"header":      "Choice",
+			"options":     opts,
+			"multiSelect": false,
+		}},
+	}
+	inputJSON, _ := json.Marshal(input)
+	return fmt.Sprintf(`{"type":"assistant","timestamp":"2026-06-12T00:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","id":%q,"name":"AskUserQuestion","input":%s}],"usage":{"input_tokens":100,"output_tokens":50}}}`, toolID, string(inputJSON))
+}
+
+func TestInteractiveAskUserQuestionUnblocksWaitForTurnEnd(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-question", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := sendMessage(ts, sess.ID, "do something")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	waitForTranscriptFn(t, mock, sess.ID)
+
+	// Emit an AskUserQuestion in the transcript
+	mock.EmitTranscriptLine(sess.ID, askUserQuestionTranscriptLine("toolu_test1", "Which approach?", []string{"A", "B"}))
+
+	// The activity state should transition to "waiting" without user intervention.
+	pollActivityState(t, store, sess.ID, "waiting", 3*time.Second)
+
+	// A question_ready SSE event should be broadcast.
+	var sawQuestionReady bool
+	timeout := time.After(2 * time.Second)
+drainQuestionReady:
+	for {
+		select {
+		case msg := <-ch:
+			var obj map[string]any
+			json.Unmarshal([]byte(msg), &obj)
+			if obj["type"] == "question_ready" {
+				sawQuestionReady = true
+				break drainQuestionReady
+			}
+		case <-timeout:
+			break drainQuestionReady
+		}
+	}
+	if !sawQuestionReady {
+		t.Error("no question_ready SSE event broadcast")
+	}
+
+	// Simulate the user responding via the question-respond endpoint.
+	respReq, _ := http.NewRequest("POST", ts.URL+"/api/sessions/"+sess.ID+"/question-respond",
+		strings.NewReader(`{"option_index":0,"option_count":2}`))
+	respReq.Header.Set("Authorization", "Bearer test-api-key")
+	respReq.Header.Set("Content-Type", "application/json")
+	respResp, err := http.DefaultClient.Do(respReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	respResp.Body.Close()
+	if respResp.StatusCode != http.StatusOK {
+		t.Fatalf("question-respond status = %d", respResp.StatusCode)
+	}
+
+	// After responding, activity state should go back to "working".
+	pollActivityState(t, store, sess.ID, "working", 3*time.Second)
+
+	// Now signal Stop to end the turn normally.
+	mock.SignalStop(sess.ID)
+
+	// Should transition to "waiting" after the turn completes.
+	pollActivityState(t, store, sess.ID, "waiting", 3*time.Second)
+
+	// Verify a done event was broadcast.
+	var sawDone bool
+	timeout = time.After(2 * time.Second)
+	for !sawDone {
+		select {
+		case msg := <-ch:
+			var obj map[string]any
+			json.Unmarshal([]byte(msg), &obj)
+			if obj["type"] == "done" {
+				sawDone = true
+			}
+		case <-timeout:
+			t.Fatal("no done event after stop")
+		}
+	}
+}
+
+func TestInteractiveStopDuringAskUserQuestion(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-question-stop", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := sendMessage(ts, sess.ID, "do something")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	waitForTranscriptFn(t, mock, sess.ID)
+
+	// Emit an AskUserQuestion
+	mock.EmitTranscriptLine(sess.ID, askUserQuestionTranscriptLine("toolu_stop1", "Which?", []string{"X", "Y"}))
+
+	// Wait for the question to be detected
+	pollActivityState(t, store, sess.ID, "waiting", 3*time.Second)
+
+	// Instead of responding, signal Stop (simulates user clicking Stop)
+	mock.SignalStop(sess.ID)
+
+	// Should transition to "waiting" (turn ended) and pending question cleared
+	pollActivityState(t, store, sess.ID, "waiting", 3*time.Second)
+
+	// Verify done event
+	var sawDone bool
+	timeout := time.After(3 * time.Second)
+	for !sawDone {
+		select {
+		case msg := <-ch:
+			var obj map[string]any
+			json.Unmarshal([]byte(msg), &obj)
+			if obj["type"] == "done" {
+				sawDone = true
+			}
+		case <-timeout:
+			t.Fatal("no done event after stop during question")
+		}
+	}
+}
+
 func TestInteractiveNoResponseRequestedSuppressed(t *testing.T) {
 	ts, store, mock := setupInteractiveTestServer(t)
 	sess, err := store.CreateManagedSession("/tmp/int-noise", `["Bash"]`, 50, 5.0, 0)

--- a/server/api/pending_question.go
+++ b/server/api/pending_question.go
@@ -28,11 +28,13 @@ type PendingQuestion struct {
 type PendingQuestionManager struct {
 	mu      sync.Mutex
 	pending map[string]*PendingQuestion
+	waiters map[string]chan struct{}
 }
 
 func NewPendingQuestionManager() *PendingQuestionManager {
 	return &PendingQuestionManager{
 		pending: make(map[string]*PendingQuestion),
+		waiters: make(map[string]chan struct{}),
 	}
 }
 
@@ -48,10 +50,28 @@ func (pq *PendingQuestionManager) Get(sessionID string) *PendingQuestion {
 	return pq.pending[sessionID]
 }
 
+// WaitForClear returns a channel that receives a value when the pending
+// question for sessionID is deleted (via Delete). Used by the turn loop
+// to detect when the user responds to an AskUserQuestion.
+func (pq *PendingQuestionManager) WaitForClear(sessionID string) <-chan struct{} {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+	ch := make(chan struct{}, 1)
+	pq.waiters[sessionID] = ch
+	return ch
+}
+
 func (pq *PendingQuestionManager) Delete(sessionID string) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 	delete(pq.pending, sessionID)
+	if ch, ok := pq.waiters[sessionID]; ok {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+		delete(pq.waiters, sessionID)
+	}
 }
 
 // extractAskUserQuestion checks an assistant transcript line for an

--- a/server/api/pending_question_test.go
+++ b/server/api/pending_question_test.go
@@ -87,6 +87,46 @@ func TestPendingQuestionManager(t *testing.T) {
 	}
 }
 
+func TestPendingQuestionWaitForClear(t *testing.T) {
+	mgr := NewPendingQuestionManager()
+	pq := &PendingQuestion{ToolUseID: "toolu_w1", Questions: []PendingQuestionItem{{Question: "test?"}}}
+	mgr.Set("sess1", pq)
+
+	ch := mgr.WaitForClear("sess1")
+
+	// Channel should not be ready yet
+	select {
+	case <-ch:
+		t.Fatal("WaitForClear fired before Delete")
+	default:
+	}
+
+	// Delete should signal the channel
+	mgr.Delete("sess1")
+
+	select {
+	case <-ch:
+		// expected
+	default:
+		t.Fatal("WaitForClear did not fire after Delete")
+	}
+}
+
+func TestPendingQuestionWaitForClearWithoutSet(t *testing.T) {
+	mgr := NewPendingQuestionManager()
+	ch := mgr.WaitForClear("sess2")
+
+	// Delete on a non-existent session should still signal the waiter
+	mgr.Delete("sess2")
+
+	select {
+	case <-ch:
+		// expected
+	default:
+		t.Fatal("WaitForClear did not fire for Delete on empty session")
+	}
+}
+
 func TestHandlePendingQuestion_NoPending(t *testing.T) {
 	ts, store := setupTestServer(t)
 	defer ts.Close()


### PR DESCRIPTION
## Summary

Fixes #212. Managed sessions hung indefinitely when Claude Code invoked `AskUserQuestion` because `waitForTurnEnd()` only listened for Stop hook signals — which never fire while Claude is waiting for PTY input.

- Add `questionCh` signal channel to `interactiveTurnState`, signaled by the transcript callback when an `AskUserQuestion` tool_use block is detected
- Change `waitForTurnEnd()` from `bool` return to a `turnEndReason` tri-state (`turnEndStop`, `turnEndDied`, `turnEndQuestion`)
- When `turnEndQuestion` fires: transition `activity_state` to `"waiting"`, broadcast `question_ready` SSE event, then wait for the user to respond (or Stop/death). After response, set `activity_state` back to `"working"` and re-enter `waitForTurnEnd()` for the remainder of the turn
- Add `WaitForClear()` to `PendingQuestionManager` so the turn loop can block until `handleQuestionRespond` deletes the pending question
- Handle race where question is already answered before the wait starts
- Handle Stop during question wait: clears pending question and ends the turn cleanly

## Test plan

- [x] `TestInteractiveAskUserQuestionUnblocksWaitForTurnEnd` — verifies question detection transitions to waiting, user can respond, session resumes working, then ends normally on Stop
- [x] `TestInteractiveStopDuringAskUserQuestion` — verifies Stop during question wait ends the turn cleanly
- [x] `TestPendingQuestionWaitForClear` — verifies the waiter notification mechanism
- [x] `TestPendingQuestionWaitForClearWithoutSet` — verifies Delete signals waiter even without a prior Set
- [x] All existing interactive tests pass (no regressions in normal turn lifecycle)
- [x] Full test suite passes (`go test ./...`)