### PR TITLE
fix: prevent 429 rate-limit cascade causing UI disconnections via ngrok

### DIFF
--- a/server/api/events.go
+++ b/server/api/events.go
@@ -58,6 +58,21 @@ func (s *Server) sendSSEState(w http.ResponseWriter, flusher http.Flusher) {
 		"sessions": sessions,
 		"prompts":  prompts,
 	}
+
+	// Include cost summary so the frontend doesn't need to poll /api/cost-summary
+	now := time.Now()
+	fiveHrStart, fiveHrEnd := db.FiveHourWindow(now)
+	sevenDayStart, sevenDayEnd := db.SevenDayWindow(now)
+	fiveHrLimit, sevenDayLimit := s.usageLimits()
+	if fiveHr, err := s.aggregateCosts(fiveHrStart, fiveHrEnd, fiveHrLimit); err == nil {
+		if sevenDay, err := s.aggregateCosts(sevenDayStart, sevenDayEnd, sevenDayLimit); err == nil {
+			payload["cost_summary"] = map[string]interface{}{
+				"five_hour": fiveHr,
+				"seven_day": sevenDay,
+			}
+		}
+	}
+
 	data, _ := json.Marshal(payload)
 
 	fmt.Fprintf(w, "event: update\ndata: %s\n\n", data)

--- a/server/api/events.go
+++ b/server/api/events.go
@@ -9,6 +9,13 @@ import (
 	"github.com/jaychinthrajah/claude-controller/server/db"
 )
 
+const costCacheTTL = 15 * time.Second
+
+type costSummaryCache struct {
+	data      map[string]interface{}
+	timestamp time.Time
+}
+
 func (s *Server) handleSSEEvents(w http.ResponseWriter, r *http.Request, apiKey string) {
 	// Auth via query param (EventSource can't send headers)
 	token := r.URL.Query().Get("token")
@@ -43,6 +50,40 @@ func (s *Server) handleSSEEvents(w http.ResponseWriter, r *http.Request, apiKey 
 	}
 }
 
+// cachedCostSummary returns the cost summary, recomputing at most once per costCacheTTL.
+func (s *Server) cachedCostSummary() map[string]interface{} {
+	s.costCacheMu.RLock()
+	if s.costCache != nil && time.Since(s.costCache.timestamp) < costCacheTTL {
+		data := s.costCache.data
+		s.costCacheMu.RUnlock()
+		return data
+	}
+	s.costCacheMu.RUnlock()
+
+	now := time.Now()
+	fiveHrStart, fiveHrEnd := db.FiveHourWindow(now)
+	sevenDayStart, sevenDayEnd := db.SevenDayWindow(now)
+	fiveHrLimit, sevenDayLimit := s.usageLimits()
+	fiveHr, err := s.aggregateCosts(fiveHrStart, fiveHrEnd, fiveHrLimit)
+	if err != nil {
+		return nil
+	}
+	sevenDay, err := s.aggregateCosts(sevenDayStart, sevenDayEnd, sevenDayLimit)
+	if err != nil {
+		return nil
+	}
+	result := map[string]interface{}{
+		"five_hour": fiveHr,
+		"seven_day": sevenDay,
+	}
+
+	s.costCacheMu.Lock()
+	s.costCache = &costSummaryCache{data: result, timestamp: now}
+	s.costCacheMu.Unlock()
+
+	return result
+}
+
 func (s *Server) sendSSEState(w http.ResponseWriter, flusher http.Flusher) {
 	sessions, _ := s.store.ListSessions(false)
 	prompts, _ := s.store.ListPrompts("", "")
@@ -59,18 +100,8 @@ func (s *Server) sendSSEState(w http.ResponseWriter, flusher http.Flusher) {
 		"prompts":  prompts,
 	}
 
-	// Include cost summary so the frontend doesn't need to poll /api/cost-summary
-	now := time.Now()
-	fiveHrStart, fiveHrEnd := db.FiveHourWindow(now)
-	sevenDayStart, sevenDayEnd := db.SevenDayWindow(now)
-	fiveHrLimit, sevenDayLimit := s.usageLimits()
-	if fiveHr, err := s.aggregateCosts(fiveHrStart, fiveHrEnd, fiveHrLimit); err == nil {
-		if sevenDay, err := s.aggregateCosts(sevenDayStart, sevenDayEnd, sevenDayLimit); err == nil {
-			payload["cost_summary"] = map[string]interface{}{
-				"five_hour": fiveHr,
-				"seven_day": sevenDay,
-			}
-		}
+	if cs := s.cachedCostSummary(); cs != nil {
+		payload["cost_summary"] = cs
 	}
 
 	data, _ := json.Marshal(payload)

--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -326,6 +326,17 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 				log.Printf("session %s: AskUserQuestion detected in transcript, storing pending question (tool_use_id=%s)", sessionID, pq.ToolUseID)
 				s.pendingQuestions.Set(sessionID, pq)
 				questionDetected = true
+				// Broadcast a structured question event so the frontend
+				// picks it up via SSE without polling.
+				if qData, err := json.Marshal(map[string]interface{}{
+					"type":        "pending_question",
+					"pending":     true,
+					"tool_use_id": pq.ToolUseID,
+					"questions":   pq.Questions,
+					"created_at":  pq.CreatedAt,
+				}); err == nil {
+					broadcaster.Send(string(qData))
+				}
 			}
 			extractSessionFiles(line, sessionID, s.store)
 

--- a/server/api/managed_sessions.go
+++ b/server/api/managed_sessions.go
@@ -638,6 +638,20 @@ func (s *Server) handleSessionStream(w http.ResponseWriter, r *http.Request, api
 	// can broadcast events before the SSE subscriber is ready.
 	flusher.Flush()
 
+	// Send current pending question state so late-connecting clients catch up.
+	if pq := s.pendingQuestions.Get(sessionID); pq != nil {
+		if qData, err := json.Marshal(map[string]interface{}{
+			"type":        "pending_question",
+			"pending":     true,
+			"tool_use_id": pq.ToolUseID,
+			"questions":   pq.Questions,
+			"created_at":  pq.CreatedAt,
+		}); err == nil {
+			fmt.Fprintf(w, "data: %s\n\n", qData)
+			flusher.Flush()
+		}
+	}
+
 	// Per-connection heartbeat: the interactive backend can go silent for
 	// minutes mid-turn (long thinking, long tool runs), and the web UI treats
 	// >30s of SSE silence as a dead connection.

--- a/server/api/middleware.go
+++ b/server/api/middleware.go
@@ -3,17 +3,33 @@ package api
 import (
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
 )
 
+// clientIP extracts the real client IP from the request. When TRUST_PROXY=true
+// (required when running behind ngrok or another reverse proxy), it reads the
+// first address from X-Forwarded-For. Otherwise it falls back to RemoteAddr.
+func clientIP(r *http.Request) string {
+	if strings.EqualFold(os.Getenv("TRUST_PROXY"), "true") {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			if ip := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0]); ip != "" {
+				return ip
+			}
+		}
+	}
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	if ip == "" {
+		ip = r.RemoteAddr
+	}
+	return ip
+}
+
 func AuthMiddleware(apiKey string, rl *RateLimiter, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-		if ip == "" {
-			ip = r.RemoteAddr
-		}
+		ip := clientIP(r)
 
 		// Check if IP is locked out from too many failed auth attempts
 		if rl.IsLockedOut(ip) {
@@ -78,10 +94,7 @@ func (rl *RateLimiter) IsLockedOut(ip string) bool {
 
 func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-		if ip == "" {
-			ip = r.RemoteAddr
-		}
+		ip := clientIP(r)
 
 		rl.mu.Lock()
 		now := time.Now()

--- a/server/api/middleware.go
+++ b/server/api/middleware.go
@@ -15,8 +15,14 @@ import (
 func clientIP(r *http.Request) string {
 	if strings.EqualFold(os.Getenv("TRUST_PROXY"), "true") {
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			if ip := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0]); ip != "" {
-				return ip
+			raw := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
+			// Strip brackets and port from IPv6 addresses (e.g. "[::1]:1234")
+			host := raw
+			if h, _, err := net.SplitHostPort(raw); err == nil {
+				host = h
+			}
+			if net.ParseIP(host) != nil {
+				return host
 			}
 		}
 	}

--- a/server/api/middleware_test.go
+++ b/server/api/middleware_test.go
@@ -122,6 +122,28 @@ func TestClientIPFallsBackWhenXFFEmpty(t *testing.T) {
 	}
 }
 
+func TestClientIPRejectsInvalidXFF(t *testing.T) {
+	os.Setenv("TRUST_PROXY", "true")
+	defer os.Unsetenv("TRUST_PROXY")
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	req.Header.Set("X-Forwarded-For", "not-an-ip, 10.0.0.1")
+	if got := clientIP(req); got != "10.0.0.1" {
+		t.Errorf("expected RemoteAddr fallback for invalid XFF, got %s", got)
+	}
+}
+
+func TestClientIPHandlesIPv6XFF(t *testing.T) {
+	os.Setenv("TRUST_PROXY", "true")
+	defer os.Unsetenv("TRUST_PROXY")
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	req.Header.Set("X-Forwarded-For", "2001:db8::1")
+	if got := clientIP(req); got != "2001:db8::1" {
+		t.Errorf("expected IPv6 address, got %s", got)
+	}
+}
+
 func TestRateLimiterSeparateBucketsPerIP(t *testing.T) {
 	rl := NewRateLimiter(2, 100)
 	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/api/middleware_test.go
+++ b/server/api/middleware_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -87,5 +88,61 @@ func TestRateLimiterBlocksOverLimit(t *testing.T) {
 		if i == 2 && rec.Code != http.StatusTooManyRequests {
 			t.Errorf("request %d: expected 429, got %d", i, rec.Code)
 		}
+	}
+}
+
+func TestClientIPUsesRemoteAddrByDefault(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	req.Header.Set("X-Forwarded-For", "203.0.113.50")
+	os.Unsetenv("TRUST_PROXY")
+	if got := clientIP(req); got != "10.0.0.1" {
+		t.Errorf("expected RemoteAddr IP 10.0.0.1, got %s", got)
+	}
+}
+
+func TestClientIPUsesXForwardedForWhenTrusted(t *testing.T) {
+	os.Setenv("TRUST_PROXY", "true")
+	defer os.Unsetenv("TRUST_PROXY")
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	req.Header.Set("X-Forwarded-For", "203.0.113.50, 10.0.0.1")
+	if got := clientIP(req); got != "203.0.113.50" {
+		t.Errorf("expected first XFF IP 203.0.113.50, got %s", got)
+	}
+}
+
+func TestClientIPFallsBackWhenXFFEmpty(t *testing.T) {
+	os.Setenv("TRUST_PROXY", "true")
+	defer os.Unsetenv("TRUST_PROXY")
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:5555"
+	if got := clientIP(req); got != "10.0.0.1" {
+		t.Errorf("expected RemoteAddr fallback 10.0.0.1, got %s", got)
+	}
+}
+
+func TestRateLimiterSeparateBucketsPerIP(t *testing.T) {
+	rl := NewRateLimiter(2, 100)
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		req.RemoteAddr = "1.1.1.1:1234"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if i < 2 && rec.Code != http.StatusOK {
+			t.Errorf("ip1 request %d: expected 200, got %d", i, rec.Code)
+		}
+	}
+	// Different IP should have its own bucket
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.RemoteAddr = "2.2.2.2:1234"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("ip2 request: expected 200, got %d", rec.Code)
 	}
 }

--- a/server/api/pending_question.go
+++ b/server/api/pending_question.go
@@ -151,6 +151,7 @@ func (s *Server) handleDismissQuestion(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.pendingQuestions.Delete(sessionID)
+	s.manager.GetBroadcaster(sessionID).Send(`{"type":"question_cleared"}`)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})

--- a/server/api/question_respond.go
+++ b/server/api/question_respond.go
@@ -41,6 +41,7 @@ func (s *Server) handleQuestionRespond(w http.ResponseWriter, r *http.Request) {
 	isOther := req.OptionIndex < 0 || req.OptionIndex >= req.OptionCount
 
 	s.pendingQuestions.Delete(sessionID)
+	s.manager.GetBroadcaster(sessionID).Send(`{"type":"question_cleared"}`)
 
 	if isOther {
 		// Navigate past all options to "Other", select it, type text, confirm

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -33,6 +33,8 @@ type Server struct {
 	skipKeychain      bool   // skip macOS keychain lookup in tests
 	usageCache        *UsageCache
 	usageCacheMu      sync.RWMutex
+	costCache         *costSummaryCache
+	costCacheMu       sync.RWMutex
 	// interactiveTurns maps sessionID -> *interactiveTurnState for the turn
 	// currently in flight. The transcript callback is registered once at
 	// process spawn and outlives individual turns, so it must look up the

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -180,7 +180,7 @@ func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath strin
 	apiMux.HandleFunc("GET /api/workflow-runs", s.handleListWorkflowRuns)
 	apiMux.HandleFunc("GET /api/workflow-runs/{id}", s.handleGetWorkflowRun)
 
-	rl := NewRateLimiter(60, 10)
+	rl := NewRateLimiter(180, 10)
 	authedAPI := rl.Middleware(AuthMiddleware(apiKey, rl, apiMux))
 
 	// Root mux — routes to appropriate handler

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -27,7 +27,6 @@ document.addEventListener('alpine:init', () => {
     eventSource: null,
     sseFailCount: 0,
     pollInterval: null,
-    usagePollInterval: null,
 
     // Unified input (replaces old instructionText)
     inputText: '',
@@ -48,7 +47,6 @@ document.addEventListener('alpine:init', () => {
     sessionSSE: null,
     sseReconnectAttempts: 0,
     sseReconnectTimer: null,
-    questionPollTimer: null,
 
     // Directory browser state
     browsePath: '',
@@ -310,9 +308,9 @@ document.addEventListener('alpine:init', () => {
         await this.loadWorkflows();
         await this.checkSettingsFirstRun();
         this.loadShortcuts();
-        // Usage rate limit polling
+        // Cost data is now pushed via SSE — no polling needed.
+        // Initial fetch for immediate display before first SSE tick.
         this.fetchCostSummary();
-        this.usagePollInterval = setInterval(() => this.fetchCostSummary(), 60_000);
       }
       this.$watch('mobileMenuOpen', (open) => {
         document.body.style.overflow = open ? 'hidden' : '';
@@ -356,10 +354,6 @@ document.addEventListener('alpine:init', () => {
 
     disconnect() {
       this.stopSSE();
-      if (this.usagePollInterval) {
-        clearInterval(this.usagePollInterval);
-        this.usagePollInterval = null;
-      }
       this.usageData = null;
       this.usageError = false;
       this.authenticated = false;
@@ -409,6 +403,11 @@ document.addEventListener('alpine:init', () => {
               }
             }
           }
+          // Update cost data from SSE payload (eliminates cost polling)
+          if (data.cost_summary) {
+            this.usageData = data.cost_summary;
+            this.usageError = false;
+          }
           this.connected = true;
           this.sseFailCount = 0;
           this.checkActivityStateNotifications(data.sessions || []);
@@ -434,7 +433,13 @@ document.addEventListener('alpine:init', () => {
         this.sseFailCount++;
         if (this.sseFailCount >= 3) {
           this.stopSSE();
-          this.startPolling();
+          // Delay before falling back to polling to avoid hammering
+          // a rate-limited server immediately after SSE failure.
+          setTimeout(() => {
+            if (!this.eventSource && this.authenticated) {
+              this.startPolling();
+            }
+          }, 2000);
         }
       };
     },
@@ -448,8 +453,10 @@ document.addEventListener('alpine:init', () => {
     },
 
     // Polling fallback
+    pollBackoffMs: 5000,
     startPolling() {
       this.stopPolling();
+      this.pollBackoffMs = 5000;
       this.pollInterval = setInterval(() => this.pollState(), 5000);
       this.pollState();
     },
@@ -459,6 +466,7 @@ document.addEventListener('alpine:init', () => {
         clearInterval(this.pollInterval);
         this.pollInterval = null;
       }
+      this.pollBackoffMs = 5000;
     },
 
     async pollState() {
@@ -471,6 +479,21 @@ document.addEventListener('alpine:init', () => {
         if (sessResp.status === 401 || promptResp.status === 401) {
           this.disconnect();
           return;
+        }
+        // On 429, back off: double the interval up to 60s
+        if (sessResp.status === 429 || promptResp.status === 429) {
+          this.pollBackoffMs = Math.min(this.pollBackoffMs * 2, 60000);
+          if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = setInterval(() => this.pollState(), this.pollBackoffMs);
+          }
+          return;
+        }
+        // Success — reset backoff to normal
+        if (this.pollBackoffMs > 5000 && this.pollInterval) {
+          this.pollBackoffMs = 5000;
+          clearInterval(this.pollInterval);
+          this.pollInterval = setInterval(() => this.pollState(), 5000);
         }
         const sessions = await sessResp.json();
         this.sessions = sessions;
@@ -2043,29 +2066,8 @@ document.addEventListener('alpine:init', () => {
         }
       }).catch(() => {});
 
-      // Check for pending question on reconnect
-      fetch(`/api/sessions/${sessionId}/pending-question`, {
-        headers: { 'Authorization': `Bearer ${this.apiKey}` }
-      }).then(r => r.json()).then(data => {
-        if (data.pending && data.questions && data.questions.length > 0) {
-          const alreadyShown = this.chatMessages.some(m => m.role === 'question' && !m.answered);
-          if (!alreadyShown) {
-            this.pendingQuestion = {
-              toolUseId: data.tool_use_id,
-              questions: data.questions,
-              timestamp: data.created_at
-            };
-            this.pendingQuestionOtherText = '';
-            this.chatMessages.push({
-              id: 'question-' + Date.now(),
-              role: 'question',
-              questions: data.questions,
-              timestamp: data.created_at
-            });
-            this.$nextTick(() => this.scrollToBottom(true));
-          }
-        }
-      }).catch(() => {});
+      // Pending question state is now sent by the server as an SSE event
+      // on connect — no fetch needed.
 
       this.sessionSSE.onmessage = (event) => {
         try {
@@ -2077,6 +2079,35 @@ document.addEventListener('alpine:init', () => {
           // Heartbeat: just reset the timer and return
           if (data.type === 'heartbeat') {
             this.resetHeartbeatTimer();
+            return;
+          }
+
+          // Pending question pushed via SSE (replaces polling)
+          if (data.type === 'pending_question' && data.pending && data.questions && data.questions.length > 0) {
+            if (!this.pendingQuestion) {
+              const alreadyShown = this.chatMessages.some(m => m.role === 'question' && !m.answered);
+              if (!alreadyShown) {
+                this.pendingQuestion = {
+                  toolUseId: data.tool_use_id,
+                  questions: data.questions,
+                  timestamp: data.created_at
+                };
+                this.pendingQuestionOtherText = '';
+                this.chatMessages.push({
+                  id: 'question-' + Date.now(),
+                  role: 'question',
+                  questions: data.questions,
+                  timestamp: data.created_at
+                });
+                this.$nextTick(() => this.scrollToBottom(true));
+              }
+            }
+            return;
+          }
+
+          // Question cleared (answered or dismissed elsewhere)
+          if (data.type === 'question_cleared') {
+            this.pendingQuestion = null;
             return;
           }
 
@@ -2352,49 +2383,6 @@ document.addEventListener('alpine:init', () => {
       this.sessionSSE.onerror = () => {
         this.attemptSSEReconnect(sessionId);
       };
-
-      this.startQuestionPoll(sessionId);
-    },
-
-    startQuestionPoll(sessionId) {
-      this.stopQuestionPoll();
-      this.questionPollTimer = setInterval(async () => {
-        if (sessionId !== this.selectedSessionId) {
-          this.stopQuestionPoll();
-          return;
-        }
-        if (this.pendingQuestion) return;
-        const hasUnanswered = this.chatMessages.some(m => m.role === 'question' && !m.answered);
-        if (hasUnanswered) return;
-        try {
-          const r = await fetch(`/api/sessions/${sessionId}/pending-question`, {
-            headers: { 'Authorization': `Bearer ${this.apiKey}` }
-          });
-          const data = await r.json();
-          if (data.pending && data.questions && data.questions.length > 0) {
-            this.pendingQuestion = {
-              toolUseId: data.tool_use_id,
-              questions: data.questions,
-              timestamp: data.created_at
-            };
-            this.pendingQuestionOtherText = '';
-            this.chatMessages.push({
-              id: 'question-' + Date.now(),
-              role: 'question',
-              questions: data.questions,
-              timestamp: data.created_at
-            });
-            this.$nextTick(() => this.scrollToBottom(true));
-          }
-        } catch (e) { /* ignore poll failures */ }
-      }, 3000);
-    },
-
-    stopQuestionPoll() {
-      if (this.questionPollTimer) {
-        clearInterval(this.questionPollTimer);
-        this.questionPollTimer = null;
-      }
     },
 
     attemptSSEReconnect(sessionId) {
@@ -2415,18 +2403,21 @@ document.addEventListener('alpine:init', () => {
         return;
       }
 
-      // Exponential backoff: 1s, 2s, 4s, 8s... capped at 15s
-      const delay = Math.min(1000 * Math.pow(2, this.sseReconnectAttempts), 15000);
+      // Exponential backoff: 1s, 2s, 4s, 8s... capped at 30s
+      const delay = Math.min(1000 * Math.pow(2, this.sseReconnectAttempts), 30000);
       this.sseReconnectAttempts++;
 
       this.sseReconnectTimer = setTimeout(async () => {
         if (sessionId !== this.selectedSessionId) return;
-        // Reachability probe — never give up silently on a bad response;
-        // retry with backoff until the attempt cap handles it.
         try {
           const resp = await fetch(`/api/sessions/${sessionId}`, {
             headers: { 'Authorization': `Bearer ${this.apiKey}` }
           });
+          // On 429, wait longer before retrying — don't cascade
+          if (resp.status === 429) {
+            this.attemptSSEReconnect(sessionId);
+            return;
+          }
           if (!resp.ok) throw new Error(`session fetch ${resp.status}`);
         } catch (e) {
           this.attemptSSEReconnect(sessionId);
@@ -2446,7 +2437,6 @@ document.addEventListener('alpine:init', () => {
         this.sseReconnectTimer = null;
       }
       this.sseReconnectAttempts = 0;
-      this.stopQuestionPoll();
       if (this.sessionSSE) {
         this.sessionSSE.close();
         this.sessionSSE = null;

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2108,6 +2108,8 @@ document.addEventListener('alpine:init', () => {
           // Question cleared (answered or dismissed elsewhere)
           if (data.type === 'question_cleared') {
             this.pendingQuestion = null;
+            const qMsg = this.chatMessages.find(m => m.role === 'question' && !m.answered);
+            if (qMsg) qMsg.answered = true;
             return;
           }
 


### PR DESCRIPTION
## Summary

Fixes #214 — The web UI periodically disconnects when accessed via ngrok because all traffic shares a single proxy IP for rate limiting, and polling loops exhaust the 60 req/min budget.

**Changes:**

- **Rate limiter uses X-Forwarded-For** (`middleware.go`): New `clientIP()` function extracts real client IP from `X-Forwarded-For` when `TRUST_PROXY=true` env var is set (required for ngrok). Distinct clients get separate rate-limit buckets.
- **Rate limit increased** from 60 to 180 req/min (3 req/sec headroom)
- **Question polling eliminated** (~20 req/min saved): Pending question state is now pushed via the per-session SSE stream as `pending_question` and `question_cleared` events. Late-connecting clients receive current state on SSE connect.
- **Cost polling eliminated** (~1 req/min saved): Cost summary data is included in the global SSE `update` event payload.
- **429 backoff in polling fallback**: `pollState()` doubles its interval on 429 responses (up to 60s cap), resets on success.
- **SSE reconnect cascade fixed**: Reachability probe handles 429 explicitly (waits with backoff instead of cascading). Global SSE fallback delayed 2s to prevent hammering. Reconnect backoff cap increased from 15s to 30s.

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] New middleware tests verify `clientIP()` with/without `TRUST_PROXY`, XFF parsing, and per-IP bucket isolation
- [ ] Manual: Open web UI via ngrok, use normally for 5+ min — no 429s in network tab
- [ ] Manual: Verify "Reconnecting..." banner does not appear during normal use
- [ ] Manual: Confirm no `GET /api/sessions/{id}/pending-question` polling in network tab
- [ ] Manual: Confirm no `GET /api/cost-summary` polling in network tab (cost updates arrive via SSE)
- [ ] Manual: Set `TRUST_PROXY=true`, access via ngrok from two browsers — verify separate rate-limit buckets
- [ ] Manual: Temporarily lower rate limit to 10, trigger 429s — verify polling intervals increase in network tab