### PR TITLE
fix: settings hot-reload wipes managed mode, causing duplicate messages

### DIFF
--- a/server/api/settings.go
+++ b/server/api/settings.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	"github.com/jaychinthrajah/claude-controller/server/managed"
 )
 
 type Shortcut struct {
@@ -158,7 +156,9 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Hot-reload manager config
+	// Hot-reload manager config. Only the claude-invocation fields are
+	// settings-controlled — start from the current config so startup-derived
+	// fields (Mode, BinaryPath, ServerPort, KeyFilePath) survive the reload.
 	if s.manager != nil {
 		claudeBin := payload.ClaudeBin
 		if claudeBin == "" {
@@ -168,11 +168,11 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 		if payload.ClaudeEnv != "" {
 			claudeEnv = strings.Split(payload.ClaudeEnv, ",")
 		}
-		s.manager.UpdateConfig(managed.Config{
-			ClaudeBin:  claudeBin,
-			ClaudeArgs: strings.Fields(payload.ClaudeArgs),
-			ClaudeEnv:  claudeEnv,
-		})
+		cfg := s.manager.Config()
+		cfg.ClaudeBin = claudeBin
+		cfg.ClaudeArgs = strings.Fields(payload.ClaudeArgs)
+		cfg.ClaudeEnv = claudeEnv
+		s.manager.UpdateConfig(cfg)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/api/settings_test.go
+++ b/server/api/settings_test.go
@@ -144,6 +144,59 @@ func TestPutSettings_MaskedAuthtoken(t *testing.T) {
 	}
 }
 
+func TestPutSettings_PreservesManagerConfigFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := db.Open(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	mgr := managed.NewManager(managed.Config{
+		ClaudeBin:   "claude",
+		Mode:        "interactive",
+		BinaryPath:  "/usr/local/bin/claude-controller",
+		ServerPort:  9999,
+		KeyFilePath: "/tmp/api.key",
+	})
+	envPath := filepath.Join(tmpDir, ".env")
+	router := NewRouter(store, "test-key", mgr, envPath, nil, "test-server-id", nil, "default")
+	ts := httptest.NewServer(router)
+	t.Cleanup(ts.Close)
+
+	settings := map[string]string{
+		"claude_bin":  "/usr/bin/claude",
+		"claude_args": "--flag1",
+		"claude_env":  "K1=V1",
+	}
+	req := authReq("PUT", ts.URL+"/api/settings", settings)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	cfg := mgr.Config()
+	if cfg.ClaudeBin != "/usr/bin/claude" {
+		t.Errorf("ClaudeBin = %q, want /usr/bin/claude", cfg.ClaudeBin)
+	}
+	if cfg.Mode != "interactive" {
+		t.Errorf("Mode = %q, want interactive (hot-reload must not wipe the managed backend mode)", cfg.Mode)
+	}
+	if cfg.BinaryPath != "/usr/local/bin/claude-controller" {
+		t.Errorf("BinaryPath = %q, want /usr/local/bin/claude-controller", cfg.BinaryPath)
+	}
+	if cfg.ServerPort != 9999 {
+		t.Errorf("ServerPort = %d, want 9999", cfg.ServerPort)
+	}
+	if cfg.KeyFilePath != "/tmp/api.key" {
+		t.Errorf("KeyFilePath = %q, want /tmp/api.key", cfg.KeyFilePath)
+	}
+}
+
 func TestPutSettings_RestartRequired(t *testing.T) {
 	ts, _, _, envPath := newTestServerWithManager(t)
 	os.WriteFile(envPath, []byte("PORT=8080\n"), 0600)


### PR DESCRIPTION
## Summary
- Saving settings in the web UI called `manager.UpdateConfig` with a fresh `managed.Config` containing only `ClaudeBin`/`ClaudeArgs`/`ClaudeEnv`, silently wiping `Mode`, `BinaryPath`, `ServerPort`, and `KeyFilePath`.
- With `Mode` emptied, `handleSendMessage` took the **print** branch on an interactive-mode server. The new `claude -p --resume <id>` process appended to the same transcript JSONL that a still-alive interactive process's tailer was watching, so both pipelines persisted and broadcast every assistant/activity event — messages appeared **twice** in the web UI/iOS app until the idle interactive process was reaped.
- Side effects of the wipe: sessions silently switched to API billing (print mode) and lost the MCP permission-prompt bridge (`BinaryPath`/`ServerPort` empty).
- Fix: hot-reload now mutates a copy of the current config, so startup-derived fields survive settings saves.

## Test plan
- [x] New `TestPutSettings_PreservesManagerConfigFields` — fails on main (Mode/BinaryPath/ServerPort/KeyFilePath wiped), passes with fix
- [x] `go test ./...` green
- [ ] Manual: restart server in interactive mode, save settings, confirm next message still uses the interactive PTY backend (no `-p` child process, no duplicate messages)
