### PR TITLE
fix: migrate legacy database into default instance directory

### DIFF
--- a/server/instance/migrate.go
+++ b/server/instance/migrate.go
@@ -1,0 +1,94 @@
+package instance
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// MigrateLegacy copies the pre-multi-instance database and API key from
+// ~/.claude-controller/ into the default instance directory. It runs only for
+// the default instance, only when the instance has no database yet, and never
+// modifies the legacy files.
+func MigrateLegacy(instanceName string) (bool, error) {
+	if instanceName != "default" {
+		return false, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false, err
+	}
+	legacyDir := filepath.Join(home, ".claude-controller")
+
+	instDir, err := ConfigDir(instanceName)
+	if err != nil {
+		return false, err
+	}
+
+	return migrateLegacyDirs(legacyDir, instDir)
+}
+
+func migrateLegacyDirs(legacyDir, instDir string) (bool, error) {
+	legacyDB := filepath.Join(legacyDir, "data.db")
+	if _, err := os.Stat(legacyDB); err != nil {
+		return false, nil
+	}
+	if _, err := os.Stat(filepath.Join(instDir, "claude.db")); err == nil {
+		return false, nil
+	}
+
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		return false, err
+	}
+
+	if err := copyFile(legacyDB, filepath.Join(instDir, "claude.db")); err != nil {
+		return false, err
+	}
+	// WAL/SHM sidecars carry writes not yet checkpointed into the main DB.
+	for _, suffix := range []string{"-wal", "-shm"} {
+		src := legacyDB + suffix
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		if err := copyFile(src, filepath.Join(instDir, "claude.db"+suffix)); err != nil {
+			return false, err
+		}
+	}
+
+	legacyKey := filepath.Join(legacyDir, "api.key")
+	instKey := filepath.Join(instDir, "api.key")
+	if _, err := os.Stat(legacyKey); err == nil {
+		if _, err := os.Stat(instKey); os.IsNotExist(err) {
+			if err := copyFile(legacyKey, instKey); err != nil {
+				return false, err
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/server/instance/migrate_test.go
+++ b/server/instance/migrate_test.go
@@ -1,0 +1,150 @@
+package instance
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestMigrateLegacyCopiesDBAndKey(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+
+	writeFile(t, filepath.Join(base, "data.db"), "legacy-db")
+	writeFile(t, filepath.Join(base, "data.db-wal"), "legacy-wal")
+	writeFile(t, filepath.Join(base, "data.db-shm"), "legacy-shm")
+	writeFile(t, filepath.Join(base, "api.key"), "legacy-key")
+
+	migrated, err := migrateLegacyDirs(base, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyDirs: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration to happen")
+	}
+
+	if got := readFile(t, filepath.Join(instDir, "claude.db")); got != "legacy-db" {
+		t.Errorf("claude.db = %q, want %q", got, "legacy-db")
+	}
+	if got := readFile(t, filepath.Join(instDir, "claude.db-wal")); got != "legacy-wal" {
+		t.Errorf("claude.db-wal = %q, want %q", got, "legacy-wal")
+	}
+	if got := readFile(t, filepath.Join(instDir, "claude.db-shm")); got != "legacy-shm" {
+		t.Errorf("claude.db-shm = %q, want %q", got, "legacy-shm")
+	}
+	if got := readFile(t, filepath.Join(instDir, "api.key")); got != "legacy-key" {
+		t.Errorf("api.key = %q, want %q", got, "legacy-key")
+	}
+
+	// Legacy files must remain untouched.
+	if got := readFile(t, filepath.Join(base, "data.db")); got != "legacy-db" {
+		t.Errorf("legacy data.db modified: %q", got)
+	}
+}
+
+func TestMigrateLegacyNoopWhenInstanceDBExists(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(base, "data.db"), "legacy-db")
+	writeFile(t, filepath.Join(instDir, "claude.db"), "existing-db")
+
+	migrated, err := migrateLegacyDirs(base, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyDirs: %v", err)
+	}
+	if migrated {
+		t.Fatal("expected no migration when instance DB exists")
+	}
+	if got := readFile(t, filepath.Join(instDir, "claude.db")); got != "existing-db" {
+		t.Errorf("claude.db overwritten: %q", got)
+	}
+}
+
+func TestMigrateLegacyNoopWhenNoLegacyDB(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+
+	migrated, err := migrateLegacyDirs(base, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyDirs: %v", err)
+	}
+	if migrated {
+		t.Fatal("expected no migration when legacy DB missing")
+	}
+	if _, err := os.Stat(filepath.Join(instDir, "claude.db")); !os.IsNotExist(err) {
+		t.Error("claude.db should not have been created")
+	}
+}
+
+func TestMigrateLegacyDoesNotOverwriteExistingKey(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(base, "data.db"), "legacy-db")
+	writeFile(t, filepath.Join(base, "api.key"), "legacy-key")
+	writeFile(t, filepath.Join(instDir, "api.key"), "instance-key")
+
+	migrated, err := migrateLegacyDirs(base, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyDirs: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected DB migration to happen")
+	}
+	if got := readFile(t, filepath.Join(instDir, "api.key")); got != "instance-key" {
+		t.Errorf("api.key overwritten: %q", got)
+	}
+}
+
+func TestMigrateLegacySkipsMissingSidecarsAndKey(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+
+	writeFile(t, filepath.Join(base, "data.db"), "legacy-db")
+
+	migrated, err := migrateLegacyDirs(base, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyDirs: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration to happen")
+	}
+	for _, f := range []string{"claude.db-wal", "claude.db-shm", "api.key"} {
+		if _, err := os.Stat(filepath.Join(instDir, f)); !os.IsNotExist(err) {
+			t.Errorf("%s should not exist", f)
+		}
+	}
+}
+
+func TestMigrateLegacyOnlyDefaultInstance(t *testing.T) {
+	migrated, err := MigrateLegacy("work")
+	if err != nil {
+		t.Fatalf("MigrateLegacy(non-default): %v", err)
+	}
+	if migrated {
+		t.Fatal("non-default instance must never migrate")
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -102,6 +102,12 @@ func main() {
 		}
 		dir := filepath.Dir(*dbPath)
 		os.MkdirAll(dir, 0755)
+		migrated, err := instance.MigrateLegacy(*instanceName)
+		if err != nil {
+			log.Printf("Warning: failed to migrate legacy database: %v", err)
+		} else if migrated {
+			log.Printf("Migrated legacy database and API key from ~/.claude-controller/ to %s", dir)
+		}
 	}
 
 	store, err := db.Open(*dbPath)


### PR DESCRIPTION
## Summary
- #221 moved the default DB path from `~/.claude-controller/data.db` to `~/.claude-controller/default/claude.db` with no data migration, so upgrading made all session history and scheduled tasks appear wiped (the server silently created a fresh empty DB). A fresh `api.key` was also generated, breaking existing device pairings.
- On startup of the `default` instance (only when the DB path is not overridden via `--db`), copy the legacy `data.db` + WAL/SHM sidecars and `api.key` into the instance directory when no instance DB exists yet. Legacy files are left untouched; existing instance files are never overwritten. Logs a message when migration runs.

## Test plan
- [x] `go test ./...` — all packages pass; 6 new tests in `server/instance/migrate_test.go` cover copy, no-overwrite, no-legacy, key-preservation, missing-sidecar, and non-default-instance cases
- [x] E2E: ran the built binary with a fake `$HOME` containing a legacy `data.db` + `api.key` — migration log emitted, files copied into `default/`, legacy files intact