### PR TITLE
fix: migrate legacy settings .env into default instance directory

### DIFF
--- a/server/instance/migrate.go
+++ b/server/instance/migrate.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // MigrateLegacy copies the pre-multi-instance database and API key from
@@ -26,7 +27,41 @@ func MigrateLegacy(instanceName string) (bool, error) {
 		return false, err
 	}
 
-	return migrateLegacyDirs(legacyDir, instDir)
+	dbMigrated, err := migrateLegacyDirs(legacyDir, instDir)
+	if err != nil {
+		return dbMigrated, err
+	}
+
+	// Pre-multi-instance, settings were saved to .env in the server's
+	// working directory.
+	envMigrated, err := migrateLegacyEnv(".env", instDir)
+	return dbMigrated || envMigrated, err
+}
+
+// controllerEnvMarker is a section header formatEnvFile always writes, used to
+// distinguish a controller settings file from an unrelated project's .env.
+const controllerEnvMarker = "# Managed session config"
+
+func migrateLegacyEnv(legacyEnv, instDir string) (bool, error) {
+	if _, err := os.Stat(filepath.Join(instDir, ".env")); err == nil {
+		return false, nil
+	}
+
+	data, err := os.ReadFile(legacyEnv)
+	if err != nil {
+		return false, nil
+	}
+	if !strings.Contains(string(data), controllerEnvMarker) {
+		return false, nil
+	}
+
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		return false, err
+	}
+	if err := copyFile(legacyEnv, filepath.Join(instDir, ".env")); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func migrateLegacyDirs(legacyDir, instDir string) (bool, error) {

--- a/server/instance/migrate.go
+++ b/server/instance/migrate.go
@@ -43,10 +43,6 @@ func MigrateLegacy(instanceName string) (bool, error) {
 const controllerEnvMarker = "# Managed session config"
 
 func migrateLegacyEnv(legacyEnv, instDir string) (bool, error) {
-	if _, err := os.Stat(filepath.Join(instDir, ".env")); err == nil {
-		return false, nil
-	}
-
 	data, err := os.ReadFile(legacyEnv)
 	if err != nil {
 		return false, nil
@@ -55,13 +51,29 @@ func migrateLegacyEnv(legacyEnv, instDir string) (bool, error) {
 		return false, nil
 	}
 
-	if err := os.MkdirAll(instDir, 0755); err != nil {
-		return false, err
+	migrated := false
+	// shortcuts.json is written by the settings API next to the .env file.
+	files := map[string]string{
+		legacyEnv: ".env",
+		filepath.Join(filepath.Dir(legacyEnv), "shortcuts.json"): "shortcuts.json",
 	}
-	if err := copyFile(legacyEnv, filepath.Join(instDir, ".env")); err != nil {
-		return false, err
+	for src, name := range files {
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		dst := filepath.Join(instDir, name)
+		if _, err := os.Stat(dst); err == nil {
+			continue
+		}
+		if err := os.MkdirAll(instDir, 0755); err != nil {
+			return migrated, err
+		}
+		if err := copyFile(src, dst); err != nil {
+			return migrated, err
+		}
+		migrated = true
 	}
-	return true, nil
+	return migrated, nil
 }
 
 func migrateLegacyDirs(legacyDir, instDir string) (bool, error) {

--- a/server/instance/migrate_test.go
+++ b/server/instance/migrate_test.go
@@ -139,6 +139,85 @@ func TestMigrateLegacySkipsMissingSidecarsAndKey(t *testing.T) {
 	}
 }
 
+const controllerEnv = "# Server\nPORT=8080\n\n# Managed session config\nCLAUDE_BIN=claude\n"
+
+func TestMigrateLegacyEnvCopiesControllerEnv(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	legacyEnv := filepath.Join(base, ".env")
+
+	writeFile(t, legacyEnv, controllerEnv)
+
+	migrated, err := migrateLegacyEnv(legacyEnv, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected env migration to happen")
+	}
+	if got := readFile(t, filepath.Join(instDir, ".env")); got != controllerEnv {
+		t.Errorf(".env = %q, want %q", got, controllerEnv)
+	}
+	if got := readFile(t, legacyEnv); got != controllerEnv {
+		t.Errorf("legacy .env modified: %q", got)
+	}
+}
+
+func TestMigrateLegacyEnvSkipsForeignEnv(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	legacyEnv := filepath.Join(base, ".env")
+
+	writeFile(t, legacyEnv, "DATABASE_URL=postgres://foo\nSECRET=bar\n")
+
+	migrated, err := migrateLegacyEnv(legacyEnv, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if migrated {
+		t.Fatal("must not migrate a non-controller .env")
+	}
+	if _, err := os.Stat(filepath.Join(instDir, ".env")); !os.IsNotExist(err) {
+		t.Error("instance .env should not have been created")
+	}
+}
+
+func TestMigrateLegacyEnvNoopWhenInstanceEnvExists(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	legacyEnv := filepath.Join(base, ".env")
+
+	writeFile(t, legacyEnv, controllerEnv)
+	writeFile(t, filepath.Join(instDir, ".env"), "PORT=9090\n")
+
+	migrated, err := migrateLegacyEnv(legacyEnv, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if migrated {
+		t.Fatal("must not overwrite existing instance .env")
+	}
+	if got := readFile(t, filepath.Join(instDir, ".env")); got != "PORT=9090\n" {
+		t.Errorf("instance .env overwritten: %q", got)
+	}
+}
+
+func TestMigrateLegacyEnvNoopWhenLegacyMissing(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+
+	migrated, err := migrateLegacyEnv(filepath.Join(base, ".env"), instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if migrated {
+		t.Fatal("expected no migration when legacy .env missing")
+	}
+}
+
 func TestMigrateLegacyOnlyDefaultInstance(t *testing.T) {
 	migrated, err := MigrateLegacy("work")
 	if err != nil {

--- a/server/instance/migrate_test.go
+++ b/server/instance/migrate_test.go
@@ -205,6 +205,93 @@ func TestMigrateLegacyEnvNoopWhenInstanceEnvExists(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyEnvCopiesShortcuts(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	legacyEnv := filepath.Join(base, ".env")
+
+	writeFile(t, legacyEnv, controllerEnv)
+	writeFile(t, filepath.Join(base, "shortcuts.json"), `[{"key":"👍","value":"yes"}]`)
+
+	migrated, err := migrateLegacyEnv(legacyEnv, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration to happen")
+	}
+	if got := readFile(t, filepath.Join(instDir, "shortcuts.json")); got != `[{"key":"👍","value":"yes"}]` {
+		t.Errorf("shortcuts.json = %q", got)
+	}
+}
+
+func TestMigrateLegacyEnvCopiesShortcutsWhenInstanceEnvExists(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	legacyEnv := filepath.Join(base, ".env")
+
+	writeFile(t, legacyEnv, controllerEnv)
+	writeFile(t, filepath.Join(base, "shortcuts.json"), `[{"key":"👍","value":"yes"}]`)
+	writeFile(t, filepath.Join(instDir, ".env"), "PORT=9090\n")
+
+	migrated, err := migrateLegacyEnv(legacyEnv, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected shortcuts migration to happen")
+	}
+	if got := readFile(t, filepath.Join(instDir, ".env")); got != "PORT=9090\n" {
+		t.Errorf("instance .env overwritten: %q", got)
+	}
+	if got := readFile(t, filepath.Join(instDir, "shortcuts.json")); got != `[{"key":"👍","value":"yes"}]` {
+		t.Errorf("shortcuts.json = %q", got)
+	}
+}
+
+func TestMigrateLegacyEnvDoesNotOverwriteInstanceShortcuts(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	legacyEnv := filepath.Join(base, ".env")
+
+	writeFile(t, legacyEnv, controllerEnv)
+	writeFile(t, filepath.Join(base, "shortcuts.json"), `[{"key":"old"}]`)
+	writeFile(t, filepath.Join(instDir, "shortcuts.json"), `[{"key":"new"}]`)
+
+	if _, err := migrateLegacyEnv(legacyEnv, instDir); err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if got := readFile(t, filepath.Join(instDir, "shortcuts.json")); got != `[{"key":"new"}]` {
+		t.Errorf("instance shortcuts.json overwritten: %q", got)
+	}
+}
+
+func TestMigrateLegacyEnvNoShortcutsWhenForeignEnv(t *testing.T) {
+	base := t.TempDir()
+	instDir := filepath.Join(base, "default")
+	legacyEnv := filepath.Join(base, ".env")
+
+	writeFile(t, legacyEnv, "DATABASE_URL=postgres://foo\n")
+	writeFile(t, filepath.Join(base, "shortcuts.json"), `[{"key":"old"}]`)
+
+	migrated, err := migrateLegacyEnv(legacyEnv, instDir)
+	if err != nil {
+		t.Fatalf("migrateLegacyEnv: %v", err)
+	}
+	if migrated {
+		t.Fatal("must not migrate anything next to a foreign .env")
+	}
+	if _, err := os.Stat(filepath.Join(instDir, "shortcuts.json")); !os.IsNotExist(err) {
+		t.Error("shortcuts.json should not have been created")
+	}
+}
+
 func TestMigrateLegacyEnvNoopWhenLegacyMissing(t *testing.T) {
 	base := t.TempDir()
 	instDir := filepath.Join(base, "default")

--- a/server/main.go
+++ b/server/main.go
@@ -106,7 +106,7 @@ func main() {
 		if err != nil {
 			log.Printf("Warning: failed to migrate legacy database: %v", err)
 		} else if migrated {
-			log.Printf("Migrated legacy database and API key from ~/.claude-controller/ to %s", dir)
+			log.Printf("Migrated legacy configuration (database, API key, settings) to %s", dir)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Follow-up to #223. Settings saved from the web UI used to be written to `.env` in the server's working directory (and shortcuts to a sibling `shortcuts.json`); after #221 the server reads them from `~/.claude-controller/default/` instead, so upgrading showed the first-run welcome modal with blank settings and no shortcuts.
- On startup of the `default` instance, migrate the working-directory `.env` and `shortcuts.json` into the instance directory when the instance copies don't exist yet. Migration is gated on the `# Managed session config` section header that `formatEnvFile` always writes, so an unrelated project's `.env` in the working directory is never copied. Legacy files untouched; existing instance files never overwritten.

## Test plan
- [x] `go test ./...` — all packages pass; 8 new tests cover env copy, shortcuts copy (with and without an existing instance .env), foreign-.env rejection, no-overwrite, and missing-legacy cases
- [x] E2E: ran the built binary with fake $HOME + controller-style `.env` and `shortcuts.json` in cwd — DB, api.key, `.env`, and `shortcuts.json` all migrated into `default/`
