### PR TITLE
fix: stop server-driven session interruptions (inflated turn/cost counting)

### DIFF
--- a/server/api/managed_interactive.go
+++ b/server/api/managed_interactive.go
@@ -80,6 +80,11 @@ type interactiveTurnState struct {
 	interruptedFor string // "" | "max_turns" | "budget"
 	promptEchoed   bool   // the typed prompt appeared in the transcript
 	questionCh     chan struct{}
+	// seenMsgIDs tracks assistant message IDs already counted this turn.
+	// Native transcripts split one API response into multiple JSONL entries
+	// (one per content block) that share a message ID and repeat the same
+	// usage stats — counting each entry doubles turn counts and token sums.
+	seenMsgIDs map[string]bool
 }
 
 func (t *interactiveTurnState) reset() {
@@ -90,6 +95,7 @@ func (t *interactiveTurnState) reset() {
 	t.outputTokens = 0
 	t.interruptedFor = ""
 	t.promptEchoed = false
+	t.seenMsgIDs = make(map[string]bool)
 	// Drain any stale question signal
 	select {
 	case <-t.questionCh:
@@ -123,6 +129,7 @@ type interactiveTranscriptEntry struct {
 	Type        string `json:"type"`
 	IsSidechain bool   `json:"isSidechain"`
 	Message     struct {
+		ID      string          `json:"id"`
 		Content json.RawMessage `json:"content"`
 		Usage   struct {
 			InputTokens  int `json:"input_tokens"`
@@ -353,9 +360,19 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 				}
 			}
 			cur.mu.Lock()
-			cur.assistantCount++
-			cur.inputTokens += entry.Message.Usage.InputTokens
-			cur.outputTokens += entry.Message.Usage.OutputTokens
+			if cur.seenMsgIDs == nil {
+				cur.seenMsgIDs = make(map[string]bool)
+			}
+			// Count each API response once, not once per content-block entry.
+			firstEntry := entry.Message.ID == "" || !cur.seenMsgIDs[entry.Message.ID]
+			if firstEntry {
+				if entry.Message.ID != "" {
+					cur.seenMsgIDs[entry.Message.ID] = true
+				}
+				cur.assistantCount++
+				cur.inputTokens += entry.Message.Usage.InputTokens
+				cur.outputTokens += entry.Message.Usage.OutputTokens
+			}
 			count := cur.assistantCount
 			alreadyInterrupted := cur.interruptedFor != ""
 			if maxTurns > 0 && count >= maxTurns && !alreadyInterrupted {
@@ -555,16 +572,18 @@ func (s *Server) runInteractiveTurns(sess *db.Session, prompt string, turn *inte
 			return
 		}
 
-		// Budget enforcement from accumulated transcript usage.
+		// Budget is informational for interactive sessions — they bill the
+		// subscription and the accumulated cost is an estimate. Warn once,
+		// never pause the session or block auto-continue.
 		if sess.MaxBudgetUSD > 0 {
 			if total, err := s.store.SessionCostTotal(sessionID); err == nil && total > sess.MaxBudgetUSD {
-				log.Printf("session %s: budget exceeded ($%.4f > $%.2f)", sessionID, total, sess.MaxBudgetUSD)
-				budgetEvt, _ := json.Marshal(map[string]any{"type": "budget_exceeded", "total": total, "budget": sess.MaxBudgetUSD})
-				broadcaster.Send(string(budgetEvt))
-				_, _ = s.store.CreateMessage(sessionID, "system",
-					fmt.Sprintf("Budget limit reached ($%.2f of $%.2f). Session paused.", total, sess.MaxBudgetUSD), 0)
-				s.finishInteractiveTurn(sessionID, broadcaster)
-				return
+				if _, warned := s.budgetWarned.LoadOrStore(sessionID, true); !warned {
+					log.Printf("session %s: cost estimate exceeded budget ($%.4f > $%.2f), warning only", sessionID, total, sess.MaxBudgetUSD)
+					budgetEvt, _ := json.Marshal(map[string]any{"type": "budget_exceeded", "total": total, "budget": sess.MaxBudgetUSD})
+					broadcaster.Send(string(budgetEvt))
+					_, _ = s.store.CreateMessage(sessionID, "system",
+						fmt.Sprintf("Cost estimate ($%.2f) has exceeded this session's budget ($%.2f). Interactive sessions bill your subscription, so this is informational only.", total, sess.MaxBudgetUSD), 0)
+				}
 			}
 		}
 

--- a/server/api/managed_interactive_test.go
+++ b/server/api/managed_interactive_test.go
@@ -41,6 +41,13 @@ func assistantTranscriptLine(text string, in, out int) string {
 	return fmt.Sprintf(`{"type":"assistant","timestamp":"2026-06-12T00:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":%q}],"usage":{"input_tokens":%d,"output_tokens":%d}}}`, text, in, out)
 }
 
+// assistantTranscriptLineWithID mimics real transcripts, where one API
+// response is split into multiple JSONL entries (one per content block) that
+// all share the same message ID and repeat the same usage stats.
+func assistantTranscriptLineWithID(msgID, text string, in, out int) string {
+	return fmt.Sprintf(`{"type":"assistant","timestamp":"2026-06-12T00:00:00Z","message":{"id":%q,"role":"assistant","content":[{"type":"text","text":%q}],"usage":{"input_tokens":%d,"output_tokens":%d}}}`, msgID, text, in, out)
+}
+
 func TestInteractiveTurnTouchesActivityWhileWaiting(t *testing.T) {
 	ts, store, mock := setupInteractiveTestServer(t)
 	sess, err := store.CreateManagedSession("/tmp/int-touch", `["Bash"]`, 50, 5.0, 0)
@@ -214,7 +221,104 @@ drain:
 	}
 }
 
-func TestInteractiveBudgetExceededStopsSession(t *testing.T) {
+// TestInteractiveTurnCountDedupesByMessageID: real transcripts split one API
+// response into multiple entries sharing a message ID. Only unique message
+// IDs may count toward max_turns — duplicate entries must not trigger the
+// ESC interrupt early.
+func TestInteractiveTurnCountDedupesByMessageID(t *testing.T) {
+	old := escStopFallback
+	escStopFallback = 200 * time.Millisecond
+	defer func() { escStopFallback = old }()
+
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-dedupe", `["Bash"]`, 2, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := sendMessage(ts, sess.ID, "long task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	waitForTranscriptFn(t, mock, sess.ID)
+	// Three entries, all the same API response — must count as ONE turn.
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLineWithID("msg_1", "text block", 10, 10))
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLineWithID("msg_1", "tool block", 10, 10))
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLineWithID("msg_1", "another block", 10, 10))
+
+	time.Sleep(300 * time.Millisecond)
+	if n := mock.InterruptInteractiveCount(); n != 0 {
+		t.Fatalf("InterruptInteractive calls = %d after duplicate entries, want 0", n)
+	}
+
+	// A second unique message ID reaches max_turns=2 — now interrupt.
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLineWithID("msg_2", "step 2", 10, 10))
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && mock.InterruptInteractiveCount() == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n := mock.InterruptInteractiveCount(); n != 1 {
+		t.Fatalf("InterruptInteractive calls = %d, want 1", n)
+	}
+	mock.SignalStop(sess.ID)
+}
+
+// TestInteractiveUsageCountedOncePerMessage: duplicate entries repeat the
+// same usage stats; tokens must be summed once per message ID.
+func TestInteractiveUsageCountedOncePerMessage(t *testing.T) {
+	ts, store, mock := setupInteractiveTestServer(t)
+	sess, err := store.CreateManagedSession("/tmp/int-usage", `["Bash"]`, 50, 5.0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := mock.GetBroadcaster(sess.ID)
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	resp, err := sendMessage(ts, sess.ID, "count my tokens")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	waitForTranscriptFn(t, mock, sess.ID)
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLineWithID("msg_1", "text", 100, 50))
+	mock.EmitTranscriptLine(sess.ID, assistantTranscriptLineWithID("msg_1", "tool", 100, 50))
+	time.Sleep(100 * time.Millisecond)
+	mock.SignalStop(sess.ID)
+
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case msg := <-ch:
+			var obj struct {
+				Type  string `json:"type"`
+				Usage struct {
+					InputTokens  int `json:"input_tokens"`
+					OutputTokens int `json:"output_tokens"`
+				} `json:"usage"`
+			}
+			json.Unmarshal([]byte(msg), &obj)
+			if obj.Type == "result" {
+				if obj.Usage.InputTokens != 100 || obj.Usage.OutputTokens != 50 {
+					t.Fatalf("usage = %d/%d, want 100/50 (duplicate entries double-counted)",
+						obj.Usage.InputTokens, obj.Usage.OutputTokens)
+				}
+				return
+			}
+		case <-timeout:
+			t.Fatal("never saw result event")
+		}
+	}
+}
+
+// TestInteractiveBudgetExceededWarnsOnceWithoutPausing: interactive sessions
+// bill the subscription — the cost figure is an estimate. Crossing the cap
+// must warn exactly once and never block the session or auto-continue.
+func TestInteractiveBudgetExceededWarnsOnceWithoutPausing(t *testing.T) {
 	ts, store, mock := setupInteractiveTestServer(t)
 	sess, err := store.CreateManagedSession("/tmp/int-budget", `["Bash"]`, 50, 0.01, 0)
 	if err != nil {
@@ -227,28 +331,55 @@ func TestInteractiveBudgetExceededStopsSession(t *testing.T) {
 	ch := b.Subscribe()
 	defer b.Unsubscribe(ch)
 
-	resp, err := sendMessage(ts, sess.ID, "one more thing")
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-
-	waitForTranscriptFn(t, mock, sess.ID)
-	mock.SignalStop(sess.ID)
-
-	var sawBudget bool
-	timeout := time.After(3 * time.Second)
-	for !sawBudget {
-		select {
-		case msg := <-ch:
-			if strings.Contains(msg, `"budget_exceeded"`) {
-				sawBudget = true
+	runTurn := func(text string, promptCount int) {
+		t.Helper()
+		resp, err := sendMessage(ts, sess.ID, text)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		waitForTranscriptFn(t, mock, sess.ID)
+		// Wait for the prompt to be typed so the orchestrator is past its
+		// stale-stop drain before we signal.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) && len(mock.SentPromptsCopy()) < promptCount {
+			time.Sleep(10 * time.Millisecond)
+		}
+		mock.SignalStop(sess.ID)
+		timeout := time.After(3 * time.Second)
+		for {
+			select {
+			case msg := <-ch:
+				if strings.Contains(msg, `"done"`) {
+					return
+				}
+			case <-timeout:
+				t.Fatal("turn never finished")
 			}
-		case <-timeout:
-			t.Fatal("no budget_exceeded event")
 		}
 	}
+
+	runTurn("first turn over budget", 1)
 	pollActivityState(t, store, sess.ID, "waiting", 2*time.Second)
+	runTurn("second turn over budget", 2)
+	pollActivityState(t, store, sess.ID, "waiting", 2*time.Second)
+
+	msgs, _ := store.ListMessages(sess.ID)
+	var warnings, paused int
+	for _, m := range msgs {
+		if m.Role == "system" && strings.Contains(m.Content, "udget") {
+			warnings++
+			if strings.Contains(m.Content, "paused") {
+				paused++
+			}
+		}
+	}
+	if warnings != 1 {
+		t.Errorf("budget warnings = %d, want exactly 1", warnings)
+	}
+	if paused != 0 {
+		t.Errorf("found %d 'paused' budget messages — budget must not pause sessions", paused)
+	}
 }
 
 func userEchoTranscriptLine(text string) string {

--- a/server/api/router.go
+++ b/server/api/router.go
@@ -41,6 +41,9 @@ type Server struct {
 	// process spawn and outlives individual turns, so it must look up the
 	// live turn state here instead of capturing it.
 	interactiveTurns sync.Map
+	// budgetWarned tracks sessions already warned about exceeding their cost
+	// estimate, so the warning fires once per session per server lifetime.
+	budgetWarned sync.Map
 }
 
 func NewRouter(store *db.Store, apiKey string, mgr SessionManager, envPath string, shutdownFunc func(), serverID string, taskTrigger TaskTrigger, instanceName string) http.Handler {

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -2224,7 +2224,7 @@ document.addEventListener('alpine:init', () => {
             this.chatMessages.push({
               id: 'budget-' + Date.now(),
               role: 'system',
-              content: `Budget limit reached ($${(data.total || 0).toFixed(2)} of $${(data.budget || 0).toFixed(2)}). Session paused.`
+              content: `Cost estimate ($${(data.total || 0).toFixed(2)}) has exceeded this session's budget ($${(data.budget || 0).toFixed(2)}). Informational only — the session keeps running.`
             });
             this.$nextTick(() => this.scrollToBottom(true));
             return;


### PR DESCRIPTION
## Summary

Root-cause fix for the "sessions get interrupted when running multiple sessions" issue — the third report today. Previous fixes (#205, #209, #213) targeted AskUserQuestion; the actual culprit is the server's own turn/budget enforcement fed by corrupted counting.

**Evidence (from the live controller DB + a real transcript):**
- 98 of 173 assistant transcript entries were duplicates — native transcripts write one JSONL entry *per content block*, all sharing one message ID and repeating the same usage stats
- The transcript callback counted every entry, so `max_turns=50` fired at ~25 real API calls → ESC interrupt mid-turn → auto-continue churn → session stops when continues exhaust
- Token sums (and thus cost) were ~2x inflated; session `da2b1b19` recorded a synthetic "$23.52 of $5.00" and got "Budget limit reached. Session paused." after **every** turn, with auto-continue permanently blocked
- The correlation with multiple sessions: more long-lived sessions crossing the lifetime cap + heavier autonomous turns hitting the halved effective turn limit

**Changes:**
- Dedupe turn counting and usage summation by message ID (`interactiveTurnState.seenMsgIDs`)
- Budget cap for interactive (subscription-billed) sessions is informational only: warn once per session, never pause or block auto-continue
- Web UI copy updated to match

## Test plan
- [x] New failing-first tests: `TestInteractiveTurnCountDedupesByMessageID`, `TestInteractiveUsageCountedOncePerMessage`, `TestInteractiveBudgetExceededWarnsOnceWithoutPausing`
- [x] Full `go test ./...` passes
- [ ] Deploy and confirm previously-bricked sessions (e.g. `da2b1b19`) no longer pause after each turn
