### PR TITLE
Fix file viewer: audio/video preview, any-path access, full-height layout

### DIFF
--- a/server/api/files.go
+++ b/server/api/files.go
@@ -48,8 +48,7 @@ func (s *Server) handleGetFileRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess, err := s.store.GetSessionByID(sessionID)
-	if err != nil {
+	if _, err := s.store.GetSessionByID(sessionID); err != nil {
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
 	}
@@ -59,19 +58,6 @@ func (s *Server) handleGetFileRaw(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, "file not found", http.StatusNotFound)
 		return
-	}
-
-	// CWD boundary check
-	if sess.CWD != "" {
-		resolvedCWD, err := filepath.EvalSymlinks(sess.CWD)
-		if err != nil {
-			resolvedCWD = sess.CWD
-		}
-		rel, err := filepath.Rel(resolvedCWD, resolved)
-		if err != nil || len(rel) >= 2 && rel[:2] == ".." {
-			http.Error(w, "file is outside session working directory", http.StatusForbidden)
-			return
-		}
 	}
 
 	// Verify file exists
@@ -226,8 +212,7 @@ func (s *Server) handleGetFileContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess, err := s.store.GetSessionByID(sessionID)
-	if err != nil {
+	if _, err := s.store.GetSessionByID(sessionID); err != nil {
 		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
 		return
 	}
@@ -245,19 +230,6 @@ func (s *Server) handleGetFileContent(w http.ResponseWriter, r *http.Request) {
 			Binary:    false,
 		})
 		return
-	}
-
-	// Validate resolved path is within session CWD or /tmp/
-	if sess.CWD != "" && !strings.HasPrefix(resolved, os.TempDir()+string(filepath.Separator)) {
-		resolvedCWD, err := filepath.EvalSymlinks(sess.CWD)
-		if err != nil {
-			resolvedCWD = sess.CWD
-		}
-		rel, err := filepath.Rel(resolvedCWD, resolved)
-		if err != nil || len(rel) >= 2 && rel[:2] == ".." {
-			http.Error(w, `{"error":"file is outside session working directory"}`, http.StatusForbidden)
-			return
-		}
 	}
 
 	// Read the file

--- a/server/api/files_test.go
+++ b/server/api/files_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -69,13 +70,54 @@ func TestHandleGetFileRaw(t *testing.T) {
 		}
 	})
 
-	t.Run("file outside CWD returns 403", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "/api/files/raw?path=/etc/passwd&session_id="+sessID+"&key=test-key", nil)
+	t.Run("serves file outside session CWD", func(t *testing.T) {
+		outsideDir := t.TempDir()
+		outsidePath := filepath.Join(outsideDir, "outside.txt")
+		os.WriteFile(outsidePath, []byte("outside content"), 0644)
+
+		req := httptest.NewRequest("GET", "/api/files/raw?path="+outsidePath+"&session_id="+sessID+"&key=test-key", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 
-		if w.Code != http.StatusForbidden {
-			t.Fatalf("expected 403, got %d", w.Code)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		if w.Body.String() != "outside content" {
+			t.Fatalf("expected 'outside content', got %q", w.Body.String())
+		}
+	})
+
+	t.Run("serves audio with correct content-type", func(t *testing.T) {
+		mp3Path := filepath.Join(dir, "test.mp3")
+		os.WriteFile(mp3Path, []byte{0xFF, 0xFB, 0x90, 0x00}, 0644)
+
+		req := httptest.NewRequest("GET", "/api/files/raw?path="+mp3Path+"&session_id="+sessID+"&key=test-key", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		ct := w.Header().Get("Content-Type")
+		if ct != "audio/mpeg" {
+			t.Fatalf("expected Content-Type audio/mpeg, got %s", ct)
+		}
+	})
+
+	t.Run("serves video with correct content-type", func(t *testing.T) {
+		mp4Path := filepath.Join(dir, "test.mp4")
+		os.WriteFile(mp4Path, []byte{0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70}, 0644)
+
+		req := httptest.NewRequest("GET", "/api/files/raw?path="+mp4Path+"&session_id="+sessID+"&key=test-key", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		ct := w.Header().Get("Content-Type")
+		if ct != "video/mp4" {
+			t.Fatalf("expected Content-Type video/mp4, got %s", ct)
 		}
 	})
 
@@ -100,6 +142,82 @@ func TestHandleGetFileRaw(t *testing.T) {
 		}
 		if w.Body.String() != "hello world" {
 			t.Fatalf("expected 'hello world', got %q", w.Body.String())
+		}
+	})
+}
+
+func TestHandleGetFileContent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	store, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	envPath := filepath.Join(dir, ".env")
+	router := NewRouter(store, "test-key", nil, envPath, nil, "test-server-id", nil, "default")
+
+	sess, err := store.CreateManagedSession(dir, "", 0, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateManagedSession: %v", err)
+	}
+	sessID := sess.ID
+
+	get := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", "/api/files/content?path="+path+"&session_id="+sessID, nil)
+		req.Header.Set("Authorization", "Bearer test-key")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	t.Run("returns content for file inside CWD", func(t *testing.T) {
+		p := filepath.Join(dir, "inside.txt")
+		os.WriteFile(p, []byte("inside content"), 0644)
+
+		w := get(p)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp fileContentResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !resp.Exists || resp.Content != "inside content" {
+			t.Fatalf("expected content 'inside content', got exists=%v content=%q", resp.Exists, resp.Content)
+		}
+	})
+
+	t.Run("returns content for file outside session CWD", func(t *testing.T) {
+		outsideDir := t.TempDir()
+		p := filepath.Join(outsideDir, "outside.txt")
+		os.WriteFile(p, []byte("outside content"), 0644)
+
+		w := get(p)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp fileContentResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !resp.Exists || resp.Content != "outside content" {
+			t.Fatalf("expected content 'outside content', got exists=%v content=%q", resp.Exists, resp.Content)
+		}
+	})
+
+	t.Run("nonexistent file reports exists=false", func(t *testing.T) {
+		w := get(filepath.Join(dir, "nope.txt"))
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp fileContentResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.Exists {
+			t.Fatalf("expected exists=false")
 		}
 	})
 }

--- a/server/web/static/app.js
+++ b/server/web/static/app.js
@@ -3223,7 +3223,9 @@ Please review this PR and provide feedback.`;
         this.renderedContentCache[cacheKey] = {
           html: this.viewerFullHtml,
           fileType: this.viewerFileType,
-          binary: true,
+          // Not "binary" in the viewer sense: media renders via the raw endpoint.
+          // A true value here made cache hits show "Binary file — cannot display".
+          binary: false,
           truncated: false,
         };
         return;

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1355,114 +1355,6 @@
       </div>
     </div>
 
-    <!-- Mobile File Viewer Overlay -->
-    <div class="mobile-detail-overlay" x-show="mobileOverlay === 'file'" x-cloak
-         :style="mobileOverlay === 'file' ? 'transform:translateX(0)' : 'transform:translateX(100%)'">
-      <div class="mobile-detail-header">
-        <button @click="mobileOverlay = null; closeFileViewer()" class="mobile-back-btn" aria-label="Back">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-            <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
-          </svg>
-        </button>
-        <span class="mobile-detail-title" x-text="viewerFile ? viewerFile.split('/').pop() : ''"></span>
-        <span class="file-type-badge" x-text="viewerFileType" x-show="viewerFileType"></span>
-        <div style="margin-left:auto;display:flex;gap:4px;">
-          <button class="btn btn-sm" :class="{ active: viewerMode === 'diff' }" @click="switchToDiffView()">Diff</button>
-          <button class="btn btn-sm" :class="{ active: viewerMode === 'full' }" @click="switchToFullView()">Full</button>
-        </div>
-      </div>
-      <div class="mobile-detail-body">
-        <div x-show="viewerMode === 'diff'" class="diff-view">
-          <div x-show="viewerLoading" class="viewer-loading">Loading diff...</div>
-          <div x-show="!viewerLoading && !viewerDiffHtml" class="diff-empty">No changes detected.</div>
-          <div x-show="!viewerLoading && viewerDiffHtml" x-html="viewerDiffHtml"></div>
-        </div>
-        <div x-show="viewerMode === 'full'" class="full-view">
-          <div x-show="viewerLoading" class="viewer-loading">Loading...</div>
-          <div x-show="viewerBinary" class="viewer-binary">Binary file — cannot display.</div>
-          <div x-show="!viewerLoading && !viewerBinary" class="full-file-content" x-html="viewerFullHtml"></div>
-          <div x-show="viewerTruncated" class="viewer-truncated">File truncated (exceeds 1MB).</div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Mobile Issue Viewer Overlay -->
-    <div class="mobile-detail-overlay" x-show="mobileOverlay === 'issue'" x-cloak
-         :style="mobileOverlay === 'issue' ? 'transform:translateX(0)' : 'transform:translateX(100%)'">
-      <div class="mobile-detail-header">
-        <button @click="mobileOverlay = null; closeIssueViewer()" class="mobile-back-btn" aria-label="Back">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-            <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
-          </svg>
-        </button>
-        <span class="mobile-detail-title" x-text="selectedIssue ? 'Issue #' + selectedIssue.number : ''"></span>
-        <span class="file-type-badge" x-show="selectedIssue"
-              x-text="selectedIssue?.state"
-              :style="selectedIssue?.state === 'OPEN' ? 'background:#238636;color:#fff' : 'background:#8957e5;color:#fff'"></span>
-        <div style="margin-left:auto;display:flex;gap:4px;">
-          <a class="btn btn-sm" x-show="selectedIssue" :href="'https://github.com/' + githubRepo + '/issues/' + selectedIssue?.number" target="_blank" rel="noopener">&#8599; GitHub</a>
-          <button class="btn btn-sm" x-show="selectedIssue" @click="generateIssuePrompt(selectedIssue); mobileMenuOpen=false; mobileOverlay=null;">Prompt</button>
-        </div>
-      </div>
-      <div class="mobile-detail-body" style="padding:16px;">
-        <div x-show="selectedIssueLoading" class="viewer-loading">Loading issue...</div>
-        <div x-show="!selectedIssueLoading && selectedIssue">
-          <h3 style="margin:0 0 8px;font-size:16px;" x-text="selectedIssue?.title"></h3>
-          <div style="font-size:11px;color:var(--text-muted);margin-bottom:12px">
-            opened by <span x-text="selectedIssue?.author"></span> &middot;
-            <span x-text="issueTimeAgo(selectedIssue?.created_at || selectedIssue?.updated_at)"></span>
-          </div>
-          <div class="issue-labels" x-show="selectedIssue?.labels?.length > 0" style="margin-bottom:12px">
-            <template x-for="label in (selectedIssue?.labels || [])" :key="label.name">
-              <span class="issue-label" :style="issueLabelStyle(label)" x-text="label.name"></span>
-            </template>
-          </div>
-          <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
-               x-html="renderMarkdown(selectedIssue?.body || '*No description*')"></div>
-
-          <!-- Linked PRs (mobile) -->
-          <template x-if="selectedIssue && linkedPRsForIssue(selectedIssue.number).length > 0">
-            <div class="issue-linked-prs">
-              <div class="issue-section-header">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
-                Linked Pull Requests
-              </div>
-              <template x-for="pr in linkedPRsForIssue(selectedIssue.number)" :key="pr.number">
-                <div class="linked-pr-item">
-                  <a class="linked-pr-link" :href="'https://github.com/' + githubRepo + '/pull/' + pr.number" target="_blank" rel="noopener">
-                    <span class="linked-pr-number" x-text="'#' + pr.number"></span>
-                    <span class="linked-pr-title" x-text="pr.title"></span>
-                  </a>
-                  <span class="linked-pr-state" :style="prStateBadgeStyle(pr)" x-text="prStateLabel(pr)"></span>
-                </div>
-              </template>
-            </div>
-          </template>
-
-          <!-- Comments thread (mobile) -->
-          <div class="issue-comments-section" x-show="selectedIssue?.comments > 0 || issueCommentsLoading">
-            <div class="issue-section-header" style="cursor:pointer" @click="issueCommentsExpanded = !issueCommentsExpanded">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 01.75.75v2.19l2.72-2.72a.749.749 0 01.53-.22h4.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25H2.75z"/></svg>
-              <span x-text="'Comments (' + (selectedIssue?.comments || 0) + ')'"></span>
-              <span class="issues-toggle" x-text="issueCommentsExpanded ? '▼' : '▶'" style="margin-left:auto;font-size:9px"></span>
-            </div>
-            <div x-show="issueCommentsExpanded" x-collapse>
-              <div x-show="issueCommentsLoading" class="issues-loading" style="padding:8px 0">Loading comments...</div>
-              <template x-for="comment in issueComments" :key="comment.id">
-                <div class="issue-comment">
-                  <div class="issue-comment-header">
-                    <span class="issue-comment-author" x-text="comment.author"></span>
-                    <span class="issue-comment-time" x-text="issueTimeAgo(comment.created_at)"></span>
-                  </div>
-                  <div class="issue-comment-body issue-body"
-                       x-html="renderMarkdown(comment.body)"></div>
-                </div>
-              </template>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
 
     <!-- Bottom Tab Bar -->
     <div class="mobile-tab-bar" role="tablist">
@@ -1512,6 +1404,117 @@
         </svg>
         <span>Settings</span>
       </button>
+    </div>
+  </div>
+
+  <!-- Mobile detail overlays (file / issue) — siblings of the menu overlay so they
+       fill the viewport regardless of menu state -->
+  <!-- Mobile File Viewer Overlay -->
+  <div class="mobile-detail-overlay" x-show="mobileOverlay === 'file'" x-cloak
+       :style="mobileOverlay === 'file' ? 'transform:translateX(0)' : 'transform:translateX(100%)'">
+    <div class="mobile-detail-header">
+      <button @click="mobileOverlay = null; closeFileViewer()" class="mobile-back-btn" aria-label="Back">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
+        </svg>
+      </button>
+      <span class="mobile-detail-title" x-text="viewerFile ? viewerFile.split('/').pop() : ''"></span>
+      <span class="file-type-badge" x-text="viewerFileType" x-show="viewerFileType"></span>
+      <div style="margin-left:auto;display:flex;gap:4px;">
+        <button class="btn btn-sm" :class="{ active: viewerMode === 'diff' }" @click="switchToDiffView()">Diff</button>
+        <button class="btn btn-sm" :class="{ active: viewerMode === 'full' }" @click="switchToFullView()">Full</button>
+      </div>
+    </div>
+    <div class="mobile-detail-body">
+      <div x-show="viewerMode === 'diff'" class="diff-view">
+        <div x-show="viewerLoading" class="viewer-loading">Loading diff...</div>
+        <div x-show="!viewerLoading && !viewerDiffHtml" class="diff-empty">No changes detected.</div>
+        <div x-show="!viewerLoading && viewerDiffHtml" x-html="viewerDiffHtml"></div>
+      </div>
+      <div x-show="viewerMode === 'full'" class="full-view">
+        <div x-show="viewerLoading" class="viewer-loading">Loading...</div>
+        <div x-show="viewerBinary" class="viewer-binary">Binary file — cannot display.</div>
+        <div x-show="!viewerLoading && !viewerBinary" class="full-file-content" x-html="viewerFullHtml"></div>
+        <div x-show="viewerTruncated" class="viewer-truncated">File truncated (exceeds 1MB).</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mobile Issue Viewer Overlay -->
+  <div class="mobile-detail-overlay" x-show="mobileOverlay === 'issue'" x-cloak
+       :style="mobileOverlay === 'issue' ? 'transform:translateX(0)' : 'transform:translateX(100%)'">
+    <div class="mobile-detail-header">
+      <button @click="mobileOverlay = null; closeIssueViewer()" class="mobile-back-btn" aria-label="Back">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M12.7 5.3a1 1 0 010 1.4L9.4 10l3.3 3.3a1 1 0 01-1.4 1.4l-4-4a1 1 0 010-1.4l4-4a1 1 0 011.4 0z"/>
+        </svg>
+      </button>
+      <span class="mobile-detail-title" x-text="selectedIssue ? 'Issue #' + selectedIssue.number : ''"></span>
+      <span class="file-type-badge" x-show="selectedIssue"
+            x-text="selectedIssue?.state"
+            :style="selectedIssue?.state === 'OPEN' ? 'background:#238636;color:#fff' : 'background:#8957e5;color:#fff'"></span>
+      <div style="margin-left:auto;display:flex;gap:4px;">
+        <a class="btn btn-sm" x-show="selectedIssue" :href="'https://github.com/' + githubRepo + '/issues/' + selectedIssue?.number" target="_blank" rel="noopener">&#8599; GitHub</a>
+        <button class="btn btn-sm" x-show="selectedIssue" @click="generateIssuePrompt(selectedIssue); mobileMenuOpen=false; mobileOverlay=null;">Prompt</button>
+      </div>
+    </div>
+    <div class="mobile-detail-body" style="padding:16px;">
+      <div x-show="selectedIssueLoading" class="viewer-loading">Loading issue...</div>
+      <div x-show="!selectedIssueLoading && selectedIssue">
+        <h3 style="margin:0 0 8px;font-size:16px;" x-text="selectedIssue?.title"></h3>
+        <div style="font-size:11px;color:var(--text-muted);margin-bottom:12px">
+          opened by <span x-text="selectedIssue?.author"></span> &middot;
+          <span x-text="issueTimeAgo(selectedIssue?.created_at || selectedIssue?.updated_at)"></span>
+        </div>
+        <div class="issue-labels" x-show="selectedIssue?.labels?.length > 0" style="margin-bottom:12px">
+          <template x-for="label in (selectedIssue?.labels || [])" :key="label.name">
+            <span class="issue-label" :style="issueLabelStyle(label)" x-text="label.name"></span>
+          </template>
+        </div>
+        <div class="issue-body" style="max-height:none;background:transparent;border:none;padding:0"
+             x-html="renderMarkdown(selectedIssue?.body || '*No description*')"></div>
+
+        <!-- Linked PRs (mobile) -->
+        <template x-if="selectedIssue && linkedPRsForIssue(selectedIssue.number).length > 0">
+          <div class="issue-linked-prs">
+            <div class="issue-section-header">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+              Linked Pull Requests
+            </div>
+            <template x-for="pr in linkedPRsForIssue(selectedIssue.number)" :key="pr.number">
+              <div class="linked-pr-item">
+                <a class="linked-pr-link" :href="'https://github.com/' + githubRepo + '/pull/' + pr.number" target="_blank" rel="noopener">
+                  <span class="linked-pr-number" x-text="'#' + pr.number"></span>
+                  <span class="linked-pr-title" x-text="pr.title"></span>
+                </a>
+                <span class="linked-pr-state" :style="prStateBadgeStyle(pr)" x-text="prStateLabel(pr)"></span>
+              </div>
+            </template>
+          </div>
+        </template>
+
+        <!-- Comments thread (mobile) -->
+        <div class="issue-comments-section" x-show="selectedIssue?.comments > 0 || issueCommentsLoading">
+          <div class="issue-section-header" style="cursor:pointer" @click="issueCommentsExpanded = !issueCommentsExpanded">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="opacity:0.7"><path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0113.25 12H9.06l-2.573 2.573A1.458 1.458 0 014 13.543V12H2.75A1.75 1.75 0 011 10.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 01.75.75v2.19l2.72-2.72a.749.749 0 01.53-.22h4.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25H2.75z"/></svg>
+            <span x-text="'Comments (' + (selectedIssue?.comments || 0) + ')'"></span>
+            <span class="issues-toggle" x-text="issueCommentsExpanded ? '▼' : '▶'" style="margin-left:auto;font-size:9px"></span>
+          </div>
+          <div x-show="issueCommentsExpanded" x-collapse>
+            <div x-show="issueCommentsLoading" class="issues-loading" style="padding:8px 0">Loading comments...</div>
+            <template x-for="comment in issueComments" :key="comment.id">
+              <div class="issue-comment">
+                <div class="issue-comment-header">
+                  <span class="issue-comment-author" x-text="comment.author"></span>
+                  <span class="issue-comment-time" x-text="issueTimeAgo(comment.created_at)"></span>
+                </div>
+                <div class="issue-comment-body issue-body"
+                     x-html="renderMarkdown(comment.body)"></div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -1351,6 +1351,14 @@ body {
 .git-diff-content .diff-hunk { color: var(--accent); font-weight: 600; margin-top: 8px; }
 .git-diff-content .diff-meta { color: var(--text-muted); }
 .full-file-content { margin: 0; white-space: pre-wrap; word-break: break-word; }
+/* Full-height chain: lets HTML/media previews fill the panel while text content
+   still grows and scrolls in .file-viewer-body / .mobile-detail-body */
+.full-view { display: flex; flex-direction: column; min-height: 100%; }
+.full-view .full-file-content { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+.full-file-content > .html-preview,
+.full-file-content > .image-preview,
+.full-file-content > .video-preview,
+.full-file-content > .audio-preview { flex: 1; min-height: 0; }
 .viewer-loading, .viewer-binary, .viewer-truncated { color: var(--text-muted); padding: 8px 0; }
 .viewer-truncated { border-top: 1px solid var(--border); margin-top: 12px; padding-top: 12px; font-size: 11px; }
 
@@ -1810,11 +1818,13 @@ body {
   .mobile-detail-overlay {
     display: flex;
     flex-direction: column;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
+    height: 100vh; /* fallback */
+    height: 100dvh;
     background: var(--bg);
     z-index: 1001;
     transition: transform 250ms ease-out;
@@ -2199,7 +2209,9 @@ body {
 
 .image-preview img {
   max-width: 100%;
-  max-height: 80vh;
+  flex: 1;
+  min-height: 0;
+  object-fit: scale-down; /* fill the panel but never upscale */
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
@@ -2221,7 +2233,9 @@ body {
 
 .video-preview video {
   max-width: 100%;
-  max-height: 80vh;
+  flex: 1;
+  min-height: 0;
+  object-fit: contain;
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
Closes #227

## Summary
- Remove session-CWD boundary checks from `/api/files/raw` and `/api/files/content` so files anywhere on disk can be viewed (API-key auth, symlink resolution, and 401-without-key behavior unchanged)
- Fix media render cache storing `binary: true`, which made **reopening** any audio/video/image file show "Binary file — cannot display" instead of the player
- Move mobile detail overlays out of `.mobile-menu-overlay` — its `display:none` + inline transform containing block collapsed them to 0×0 whenever a file was opened outside the menu; overlays are now `position: fixed` at `100dvh`
- Add a full-height flex chain (`.full-view` → `.full-file-content` → preview) so HTML preview iframes and media fill the viewer panel instead of collapsing to 300px / capping at `80vh`

## Test plan
- [x] Go: `go test ./...` passes; new tests for out-of-CWD raw/content access + audio/video content types
- [x] Browser (Playwright, desktop 1440×900): video + audio from `/tmp` play; HTML iframe fills panel (748px vs 300px before); out-of-CWD markdown renders; Go code view regression-free
- [x] Browser (Playwright, mobile 390×844): file overlay fills full viewport (844px), video plays, overlay covers menu when opened from menu (z-index verified), issue overlay still full-height
- [x] Reopen-from-cache path verified (previously showed "Binary file — cannot display")
- [x] Range requests return 206 for media streaming