### PR TITLE
Restrict file viewer access to session CWD and temp dirs

### DIFF
--- a/server/api/files.go
+++ b/server/api/files.go
@@ -39,6 +39,28 @@ func isMediaFile(path string) bool {
 	return mediaExtensions[ext]
 }
 
+// pathWithinAllowedRoots reports whether resolved (a symlink-resolved absolute
+// path) lies within the session CWD or a temp directory. Roots are also
+// symlink-resolved before comparing (on macOS /tmp -> /private/tmp), so
+// symlinks can't be used to escape the boundary.
+func pathWithinAllowedRoots(resolved, cwd string) bool {
+	roots := []string{os.TempDir(), "/tmp"}
+	if cwd != "" {
+		roots = append(roots, cwd)
+	}
+	for _, root := range roots {
+		resolvedRoot, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			resolvedRoot = root
+		}
+		rel, err := filepath.Rel(resolvedRoot, resolved)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) handleGetFileRaw(w http.ResponseWriter, r *http.Request) {
 	filePath := r.URL.Query().Get("path")
 	sessionID := r.URL.Query().Get("session_id")
@@ -48,7 +70,8 @@ func (s *Server) handleGetFileRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.store.GetSessionByID(sessionID); err != nil {
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
 	}
@@ -57,6 +80,11 @@ func (s *Server) handleGetFileRaw(w http.ResponseWriter, r *http.Request) {
 	resolved, err := filepath.EvalSymlinks(filePath)
 	if err != nil {
 		http.Error(w, "file not found", http.StatusNotFound)
+		return
+	}
+
+	if !pathWithinAllowedRoots(resolved, sess.CWD) {
+		http.Error(w, "file is outside session working directory and temp dirs", http.StatusForbidden)
 		return
 	}
 
@@ -212,7 +240,8 @@ func (s *Server) handleGetFileContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := s.store.GetSessionByID(sessionID); err != nil {
+	sess, err := s.store.GetSessionByID(sessionID)
+	if err != nil {
 		http.Error(w, `{"error":"session not found"}`, http.StatusNotFound)
 		return
 	}
@@ -229,6 +258,11 @@ func (s *Server) handleGetFileContent(w http.ResponseWriter, r *http.Request) {
 			Truncated: false,
 			Binary:    false,
 		})
+		return
+	}
+
+	if !pathWithinAllowedRoots(resolved, sess.CWD) {
+		http.Error(w, `{"error":"file is outside session working directory and temp dirs"}`, http.StatusForbidden)
 		return
 	}
 

--- a/server/api/files_test.go
+++ b/server/api/files_test.go
@@ -70,7 +70,8 @@ func TestHandleGetFileRaw(t *testing.T) {
 		}
 	})
 
-	t.Run("serves file outside session CWD", func(t *testing.T) {
+	t.Run("serves file in system temp dir outside session CWD", func(t *testing.T) {
+		// t.TempDir() lives under os.TempDir(), which is an allowed root
 		outsideDir := t.TempDir()
 		outsidePath := filepath.Join(outsideDir, "outside.txt")
 		os.WriteFile(outsidePath, []byte("outside content"), 0644)
@@ -84,6 +85,34 @@ func TestHandleGetFileRaw(t *testing.T) {
 		}
 		if w.Body.String() != "outside content" {
 			t.Fatalf("expected 'outside content', got %q", w.Body.String())
+		}
+	})
+
+	t.Run("serves file in /tmp", func(t *testing.T) {
+		f, err := os.CreateTemp("/tmp", "cc-raw-*.txt")
+		if err != nil {
+			t.Skipf("cannot create file in /tmp: %v", err)
+		}
+		defer os.Remove(f.Name())
+		f.WriteString("tmp content")
+		f.Close()
+
+		req := httptest.NewRequest("GET", "/api/files/raw?path="+f.Name()+"&session_id="+sessID+"&key=test-key", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("file outside CWD and temp dirs returns 403", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/files/raw?path=/etc/passwd&session_id="+sessID+"&key=test-key", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d", w.Code)
 		}
 	})
 
@@ -189,7 +218,7 @@ func TestHandleGetFileContent(t *testing.T) {
 		}
 	})
 
-	t.Run("returns content for file outside session CWD", func(t *testing.T) {
+	t.Run("returns content for file in system temp dir", func(t *testing.T) {
 		outsideDir := t.TempDir()
 		p := filepath.Join(outsideDir, "outside.txt")
 		os.WriteFile(p, []byte("outside content"), 0644)
@@ -204,6 +233,35 @@ func TestHandleGetFileContent(t *testing.T) {
 		}
 		if !resp.Exists || resp.Content != "outside content" {
 			t.Fatalf("expected content 'outside content', got exists=%v content=%q", resp.Exists, resp.Content)
+		}
+	})
+
+	t.Run("returns content for file in /tmp", func(t *testing.T) {
+		f, err := os.CreateTemp("/tmp", "cc-content-*.txt")
+		if err != nil {
+			t.Skipf("cannot create file in /tmp: %v", err)
+		}
+		defer os.Remove(f.Name())
+		f.WriteString("tmp content")
+		f.Close()
+
+		w := get(f.Name())
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp fileContentResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if !resp.Exists || resp.Content != "tmp content" {
+			t.Fatalf("expected content 'tmp content', got exists=%v content=%q", resp.Exists, resp.Content)
+		}
+	})
+
+	t.Run("file outside CWD and temp dirs returns 403", func(t *testing.T) {
+		w := get("/etc/passwd")
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
 		}
 	})
 


### PR DESCRIPTION
Follow-up to #228, addressing the security-review finding (HIGH: arbitrary file read).

## Summary
- #228 removed the CWD boundary entirely, so any API-key holder could read any file on disk (`/etc/passwd` was servable — the new test demonstrated it)
- Restore a boundary for `/api/files/raw` and `/api/files/content`: allowed roots are **session CWD**, **os.TempDir()**, and **/tmp**
- Both roots and target paths are symlink-resolved before comparison (macOS `/tmp` -> `/private/tmp`), so symlinks cannot escape the boundary
- The primary use case that motivated #228 — viewing files Claude writes to `/tmp` (HTML previews etc.) — keeps working

## Test plan
- [x] `go test ./...` green
- [x] New tests: `/tmp` file served (raw + content), system temp dir served, `/etc/passwd` returns 403 on both endpoints, in-CWD and auth behavior unchanged