### PR TITLE
feat: show open PR link before branch name in git status bar

### DIFF
--- a/server/api/filetree.go
+++ b/server/api/filetree.go
@@ -229,16 +229,18 @@ func gitListFiles(cwd string) ([]string, error) {
 }
 
 type gitSummaryInfo struct {
-	Branch    string `json:"branch"`
-	RepoName  string `json:"repo_name,omitempty"`
-	RepoURL   string `json:"repo_url,omitempty"`
-	Modified  int    `json:"modified"`
-	Added     int    `json:"added"`
-	Deleted   int    `json:"deleted"`
-	Untracked int    `json:"untracked"`
-	Staged    int    `json:"staged"`
-	Ahead     int    `json:"ahead"`
-	Behind    int    `json:"behind"`
+	Branch      string `json:"branch"`
+	RepoName    string `json:"repo_name,omitempty"`
+	RepoURL     string `json:"repo_url,omitempty"`
+	Modified    int    `json:"modified"`
+	Added       int    `json:"added"`
+	Deleted     int    `json:"deleted"`
+	Untracked   int    `json:"untracked"`
+	Staged      int    `json:"staged"`
+	Ahead       int    `json:"ahead"`
+	Behind      int    `json:"behind"`
+	OpenPRNumber int   `json:"open_pr_number,omitempty"`
+	OpenPRURL   string `json:"open_pr_url,omitempty"`
 }
 
 func gitSummary(cwd string) gitSummaryInfo {
@@ -249,6 +251,22 @@ func gitSummary(cwd string) gitSummaryInfo {
 	cmd.Dir = cwd
 	if out, err := cmd.Output(); err == nil {
 		info.Branch = strings.TrimSpace(string(out))
+	}
+
+	// Look up open PR for the current branch (fail silently if gh unavailable or no PR)
+	if info.Branch != "" && info.Branch != "HEAD" {
+		cmdPR := exec.Command("gh", "pr", "view", "--json", "number,url")
+		cmdPR.Dir = cwd
+		if out, err := cmdPR.Output(); err == nil {
+			var pr struct {
+				Number int    `json:"number"`
+				URL    string `json:"url"`
+			}
+			if err := json.Unmarshal(out, &pr); err == nil && pr.Number > 0 {
+				info.OpenPRNumber = pr.Number
+				info.OpenPRURL = pr.URL
+			}
+		}
 	}
 
 	// Get remote URL and derive repo name + browsable URL

--- a/server/api/filetree_test.go
+++ b/server/api/filetree_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func setupFakeGH(t *testing.T, script string) (restore func()) {
+	t.Helper()
+	dir := t.TempDir()
+	fakeGH := filepath.Join(dir, "gh")
+	if err := os.WriteFile(fakeGH, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	orig := os.Getenv("PATH")
+	os.Setenv("PATH", dir+":"+orig)
+	return func() { os.Setenv("PATH", orig) }
+}
+
+func initTestRepo(t *testing.T, branch string) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmds := [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "config", "user.email", "test@test.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
+		{"git", "-C", dir, "checkout", "-b", branch},
+	}
+	for _, args := range cmds {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Logf("cmd %v: %s", args, out)
+		}
+	}
+	return dir
+}
+
+func TestGitSummaryOpenPR(t *testing.T) {
+	restore := setupFakeGH(t, "#!/bin/sh\necho '{\"number\":42,\"url\":\"https://github.com/owner/repo/pull/42\"}'\n")
+	defer restore()
+
+	repoDir := initTestRepo(t, "feat/test-pr-branch")
+
+	info := gitSummary(repoDir)
+
+	if info.OpenPRNumber != 42 {
+		t.Errorf("OpenPRNumber: got %d, want 42", info.OpenPRNumber)
+	}
+	if info.OpenPRURL != "https://github.com/owner/repo/pull/42" {
+		t.Errorf("OpenPRURL: got %q, want %q", info.OpenPRURL, "https://github.com/owner/repo/pull/42")
+	}
+}
+
+func TestGitSummaryNoPR(t *testing.T) {
+	restore := setupFakeGH(t, "#!/bin/sh\nexit 1\n")
+	defer restore()
+
+	repoDir := initTestRepo(t, "feat/no-pr-branch")
+
+	info := gitSummary(repoDir)
+
+	if info.OpenPRNumber != 0 {
+		t.Errorf("OpenPRNumber: got %d, want 0", info.OpenPRNumber)
+	}
+	if info.OpenPRURL != "" {
+		t.Errorf("OpenPRURL: got %q, want empty", info.OpenPRURL)
+	}
+}

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -875,6 +875,7 @@
           </div>
           <div class="git-branch-row">
             <span class="git-branch-icon">⎇</span>
+            <a x-show="gitInfo?.open_pr_number" :href="gitInfo?.open_pr_url" target="_blank" rel="noopener" class="git-pr-link" x-text="'(#' + gitInfo?.open_pr_number + ')'"></a>
             <span class="git-branch-name" x-text="gitInfo?.branch || 'detached'"></span>
             <span class="git-ahead" x-show="gitInfo?.ahead > 0" x-text="'↑' + gitInfo?.ahead" title="Commits ahead of remote"></span>
             <span class="git-behind" x-show="gitInfo?.behind > 0" x-text="'↓' + gitInfo?.behind" title="Commits behind remote"></span>
@@ -1196,6 +1197,7 @@
             <div class="git-status-bar" x-show="gitInfo" style="margin-top:8px;border-top:1px solid var(--border);padding-top:8px;">
               <div class="git-branch-row">
                 <span class="git-branch-icon">&#9143;</span>
+                <a x-show="gitInfo?.open_pr_number" :href="gitInfo?.open_pr_url" target="_blank" rel="noopener" class="git-pr-link" x-text="'(#' + gitInfo?.open_pr_number + ')'"></a>
                 <span class="git-branch-name" x-text="gitInfo?.branch || 'detached'"></span>
                 <span class="git-ahead" x-show="gitInfo?.ahead > 0" x-text="'&#8593;' + gitInfo?.ahead"></span>
                 <span class="git-behind" x-show="gitInfo?.behind > 0" x-text="'&#8595;' + gitInfo?.behind"></span>

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -805,6 +805,8 @@ body {
 .git-branch-name { color: var(--accent); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .git-ahead { color: var(--green); font-size: 11px; font-weight: 500; }
 .git-behind { color: var(--yellow); font-size: 11px; font-weight: 500; }
+.git-pr-link { color: var(--text-muted); font-size: 11px; font-weight: 500; text-decoration: none; flex-shrink: 0; }
+.git-pr-link:hover { color: var(--accent); text-decoration: underline; }
 .git-file-counts {
   display: flex; flex-wrap: wrap; gap: 4px 8px; color: var(--text-muted); font-size: 11px;
 }


### PR DESCRIPTION
Closes #230

## Changes

- Extended `gitSummaryInfo` in `server/api/filetree.go` with `open_pr_number` (int) and `open_pr_url` (string) fields
- `gitSummary()` now runs `gh pr view --json number,url` from the session CWD to detect an open PR for the current branch; fails silently when `gh` is absent or no PR exists
- Both git-branch-row displays in `index.html` (desktop sidebar and mobile view) now prepend a clickable `(#N)` link before the branch name when `open_pr_number` is set
- Added `.git-pr-link` CSS class in `style.css` matching the existing git status bar palette

## Tests

- `TestGitSummaryOpenPR`: stubs `gh` via PATH override, asserts `OpenPRNumber == 42` and `OpenPRURL` populated
- `TestGitSummaryNoPR`: stubs `gh` to exit 1, asserts fields stay zero/empty
- Full suite: `go test ./...` green