### PR TITLE
feat: add author and last-updated time to PR list items

### DIFF
--- a/server/api/github.go
+++ b/server/api/github.go
@@ -73,6 +73,7 @@ type ghAPIIssue struct {
 	Title       string           `json:"title"`
 	State       string           `json:"state"`
 	CreatedAt   string           `json:"created_at"`
+	UpdatedAt   string           `json:"updated_at"`
 	User        ghAPIUser        `json:"user"`
 	Labels      []ghAPILabel     `json:"labels"`
 	Body        string           `json:"body"`
@@ -348,6 +349,7 @@ type pullResponse struct {
 	Title     string       `json:"title"`
 	State     string       `json:"state"`
 	CreatedAt string       `json:"created_at"`
+	UpdatedAt string       `json:"updated_at"`
 	Author    string       `json:"author"`
 	Labels    []issueLabel `json:"labels"`
 	Body      string       `json:"body"`
@@ -369,6 +371,7 @@ func reshapeAPIPull(g ghAPIIssue) pullResponse {
 		Title:     g.Title,
 		State:     g.State,
 		CreatedAt: g.CreatedAt,
+		UpdatedAt: g.UpdatedAt,
 		Author:    g.User.Login,
 		Labels:    labels,
 		Body:      g.Body,

--- a/server/api/github_test.go
+++ b/server/api/github_test.go
@@ -191,6 +191,29 @@ func TestGetGithubIssue_ManagedNoCWDReturns400(t *testing.T) {
 	}
 }
 
+func TestReshapeAPIPullUpdatedAt(t *testing.T) {
+	input := ghAPIIssue{
+		Number:    42,
+		Title:     "Test PR",
+		State:     "open",
+		CreatedAt: "2026-07-01T10:00:00Z",
+		UpdatedAt: "2026-07-29T14:30:00Z",
+		User:      ghAPIUser{Login: "lankeami"},
+	}
+
+	result := reshapeAPIPull(input)
+
+	if result.UpdatedAt == "" {
+		t.Fatal("pullResponse.UpdatedAt is empty; want the updated_at from the GitHub API response")
+	}
+	if result.UpdatedAt != "2026-07-29T14:30:00Z" {
+		t.Fatalf("pullResponse.UpdatedAt = %q; want %q", result.UpdatedAt, "2026-07-29T14:30:00Z")
+	}
+	if result.Author != "lankeami" {
+		t.Fatalf("pullResponse.Author = %q; want %q", result.Author, "lankeami")
+	}
+}
+
 func TestListGithubIssues_DefaultParamsAccepted(t *testing.T) {
 	ts, store := setupTestServer(t)
 	defer ts.Close()

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1011,7 +1011,7 @@
                   <div class="issue-dot" :class="pull.state"></div>
                   <div class="issue-row-content">
                     <div class="issue-row-title" x-text="pull.title"></div>
-                    <div class="issue-row-meta" x-text="'#' + pull.number + ' · ' + issueTimeAgo(pull.updated_at)"></div>
+                    <div class="issue-row-meta" x-text="'#' + pull.number + ' · ' + pull.author + ' · ' + issueTimeAgo(pull.updated_at)"></div>
                   </div>
                 </div>
               </template>


### PR DESCRIPTION
Closes #234

## Changes

- Added `UpdatedAt string` field to `ghAPIIssue` (deserializes `updated_at` from the GitHub API JSON)
- Added `UpdatedAt string` field to `pullResponse` (serializes as `updated_at` to the client)
- Updated `reshapeAPIPull` to map `UpdatedAt` from the raw API shape
- Updated PR list item meta line in `index.html` to show author login alongside number and relative updated time

## Before / After

**Before:** `#26 ·` (time blank — `updated_at` was never mapped so `issueTimeAgo` received `undefined`)
**After:** `#26 · lankeami · 4 hours ago`

## Test

Added `TestReshapeAPIPullUpdatedAt` in `server/api/github_test.go` — asserts that `reshapeAPIPull` correctly populates `UpdatedAt` and `Author` from the raw `ghAPIIssue` shape. Confirmed red before implementation, green after.