### PR TITLE
fix: mobile skills tab parity with desktop (#236)

### DIFF
--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1258,7 +1258,7 @@
               <div x-show="githubIssuesLoading" class="issues-loading">Loading...</div>
               <div x-show="!githubIssuesLoading && githubIssuesError" class="issues-error" x-text="githubIssuesError"></div>
               <div x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length === 0" class="issues-empty">No issues found</div>
-              <div class="issue-list" x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length > 0">
+              <div class="issue-list full" x-show="!githubIssuesLoading && !githubIssuesError && githubIssues.length > 0">
                 <template x-for="issue in githubIssues" :key="issue.number">
                   <div class="issue-row" @click="fetchIssueDetail(selectedSessionId, issue.number)">
                     <div class="issue-dot" :class="issue.state"></div>
@@ -1315,17 +1315,22 @@
           <div>
             <div style="display:flex;align-items:center;gap:6px;margin-bottom:8px;">
               <span style="font-weight:600;font-size:14px;">Skills</span>
-              <span class="file-count-badge" x-show="skills.length > 0" x-text="skills.length"></span>
+              <span class="file-count-badge" x-show="filteredSkills.length > 0" x-text="filteredSkills.length"></span>
               <button class="file-tree-refresh" @click="fetchSkills(selectedSessionId)" title="Refresh">&#8635;</button>
+            </div>
+            <div class="issue-state-toggles" style="margin-bottom:6px" x-show="!skillsLoading && !skillsError && skills.length > 0">
+              <button class="issue-state-toggle" :class="{ 'active-skills-all': skillsFilter === 'all' }" @click="skillsFilter = 'all'">All</button>
+              <button class="issue-state-toggle" :class="{ 'active-skills-global': skillsFilter === 'global' }" @click="skillsFilter = 'global'">Global</button>
+              <button class="issue-state-toggle" :class="{ 'active-skills-project': skillsFilter === 'project' }" @click="skillsFilter = 'project'">Project</button>
             </div>
             <div x-show="skillsLoading" class="issues-loading">Loading...</div>
             <div x-show="!skillsLoading && skillsError" class="issues-error" x-text="skillsError"></div>
             <div x-show="!skillsLoading && !skillsError && skills.length === 0" class="issues-empty">No skills found</div>
-            <div class="issue-list" x-show="!skillsLoading && !skillsError && skills.length > 0">
-              <template x-for="skill in skills" :key="skill.name">
+            <div class="issue-list full" x-show="!skillsLoading && !skillsError && skills.length > 0">
+              <template x-for="skill in filteredSkills" :key="skill.name">
                 <div class="issue-row" @click="mobileMenuOpen=false; sendSkill(skill.name)" :title="skill.description || skill.name">
                   <div class="issue-row-content">
-                    <div class="issue-row-title" x-text="skill.name"></div>
+                    <div class="issue-row-title" x-text="skill.name" :style="skill.dir === 'project' ? 'color: #3b82f6' : ''"></div>
                   </div>
                 </div>
               </template>

--- a/server/web/static/mobile-skills.test.mjs
+++ b/server/web/static/mobile-skills.test.mjs
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dir = dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(join(dir, 'index.html'), 'utf8');
+const css = readFileSync(join(dir, 'style.css'), 'utf8');
+
+// Mobile skills tab lives between the "Skills Tab" and "Tasks Tab" comments.
+const mobileSkills = html.slice(html.indexOf('<!-- Skills Tab -->'), html.indexOf('<!-- Tasks Tab -->'));
+
+test('mobile skills tab has All/Global/Project filter pills', () => {
+  assert.match(mobileSkills, /skillsFilter = 'all'/);
+  assert.match(mobileSkills, /skillsFilter = 'global'/);
+  assert.match(mobileSkills, /skillsFilter = 'project'/);
+});
+
+test('mobile skills tab renders the filtered list, not the raw list', () => {
+  assert.match(mobileSkills, /x-for="skill in filteredSkills"/);
+});
+
+test('mobile skills tab tints project skills like desktop', () => {
+  assert.match(mobileSkills, /skill\.dir === 'project'/);
+});
+
+test('mobile skills and issues lists are not height-clipped', () => {
+  assert.match(css, /\.issue-list\.full\s*\{[^}]*max-height:\s*none/);
+  assert.match(mobileSkills, /class="issue-list full"/);
+  const mobileIssues = html.slice(html.indexOf('<!-- GitHub Issues (mobile) -->'), html.indexOf('<!-- Jira Placeholder (mobile) -->'));
+  assert.match(mobileIssues, /class="issue-list full"/);
+});

--- a/server/web/static/style.css
+++ b/server/web/static/style.css
@@ -947,6 +947,12 @@ body {
   overflow-y: auto;
 }
 
+/* Full-height variant for mobile tabs where the tab container scrolls */
+.issue-list.full {
+  max-height: none;
+  overflow-y: visible;
+}
+
 .issue-row {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
Closes #236

## Changes
- Mobile Skills tab now has the same All/Global/Project filter pills as the desktop sidebar, reusing the existing `skillsFilter` state and `filteredSkills` getter.
- Mobile skills list renders `filteredSkills` and tints project skills blue, matching desktop.
- New `.issue-list.full` modifier removes the 30vh `max-height` inside mobile tabs — the list was being clipped to ~9 rows with no visible scrollbar on iOS. Applied to both the mobile Skills and Issues lists (same root cause).
- Count badge reflects the filtered list.

## Testing
- `node --test server/web/static/mobile-skills.test.mjs` — 4 static parity assertions (red before, green after).
- `go test ./...` — all pass.
- Playwright visual verification at 390×844: full 29-skill list scrolls, pills filter correctly (Project → 1 skill, blue tint), desktop sidebar unchanged.