### PR TITLE
feat/autoship 241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-05
 
+- [9a3d286](https://github.com/lankeami/claude-control/commit/9a3d286987eb6bde6140bbb65c9e73855afe12bb) fix: mobile menu header shows session title instead of app name (#241)
+  The mobile side-menu overlay header was hardcoded to "Claude Controller". It now binds the selected session's display name via the existing sessionName() helper, falling back to the app name when no session is selected.
 - [b0ab189](https://github.com/lankeami/claude-control/commit/b0ab189ee1e08af55a3d3388ca4c7d1d9499607f) fix: theme-aware session/task row background for dark mode (#239)
   .session-item hardcoded rgba(255,255,255,0.7) (the light-theme watermark scrim from b01d074), which rendered light-gray cards under light text in dark mode. Move the value to an --item-bg variable with a dark override so mobile session and task lists are readable in both themes.
 

--- a/server/web/static/index.html
+++ b/server/web/static/index.html
@@ -1058,7 +1058,7 @@
        :style="mobileMenuOpen ? 'transform:translateX(0)' : 'transform:translateX(-100%)'">
     <!-- Menu Header -->
     <div class="mobile-menu-header">
-      <span style="font-weight:600;">Claude Controller</span>
+      <span style="font-weight:600;" x-text="selectedSession ? sessionName(selectedSession) : 'Claude Controller'"></span>
       <button class="mobile-menu-close" @click="mobileMenuOpen = false; mobileOverlay = null" aria-label="Close menu">
         <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
           <path d="M5.3 5.3a1 1 0 011.4 0L10 8.6l3.3-3.3a1 1 0 111.4 1.4L11.4 10l3.3 3.3a1 1 0 01-1.4 1.4L10 11.4l-3.3 3.3a1 1 0 01-1.4-1.4L8.6 10 5.3 6.7a1 1 0 010-1.4z"/>

--- a/server/web/static/mobile-menu-title.test.mjs
+++ b/server/web/static/mobile-menu-title.test.mjs
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dir = dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(join(dir, 'index.html'), 'utf8');
+
+// Mobile menu header lives between the "Menu Header" and "Tab Content" comments.
+const header = html.slice(html.indexOf('<!-- Menu Header -->'), html.indexOf('<!-- Tab Content -->'));
+
+test('mobile menu header binds the selected session title with app-name fallback', () => {
+  assert.match(header, /x-text="selectedSession \? sessionName\(selectedSession\) : 'Claude Controller'"/);
+});
+
+test('mobile menu header has no hardcoded app-name text node', () => {
+  assert.doesNotMatch(header, />\s*Claude Controller\s*</);
+});


### PR DESCRIPTION
- **fix: mobile menu header shows session title instead of app name (#241)**
- **Update changelog for 9a3d286**
