### PR TITLE
fix: autoship runner crashes under set -euo pipefail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-05
 
+- fix: autoship runner crashes under `set -euo pipefail` (#243)
+  Two shell bugs: (1) `write_autoship_save_point` glob on empty `.claude/save-points/` exits 2 under pipefail — added `|| true` guard matching `purge_autoship_save_point`. (2) `record_checkpoint` trips `set -u` on missing 4th arg and emits trailing-comma JSON on empty arg — default with `${4:-}` and conditionally omit the metadata field.
 - [9a3d286](https://github.com/lankeami/claude-control/commit/9a3d286987eb6bde6140bbb65c9e73855afe12bb) fix: mobile menu header shows session title instead of app name (#241)
   The mobile side-menu overlay header was hardcoded to "Claude Controller". It now binds the selected session's display name via the existing sessionName() helper, falling back to the app name when no session is selected.
 - [b0ab189](https://github.com/lankeami/claude-control/commit/b0ab189ee1e08af55a3d3388ca4c7d1d9499607f) fix: theme-aware session/task row background for dark mode (#239)


### PR DESCRIPTION
## Summary

Fixes #243. Two shell bugs in the autoship runner bash libs crash the pipeline mid-run under set -euo pipefail:

- **write_autoship_save_point** (runner.sh:114): glob on empty .claude/save-points/ dir causes grep exit 2, shell dies under pipefail. Added || true guard matching purge_autoship_save_point.
- **record_checkpoint** (checkpoint.sh:23): local metadata="$4" trips set -u when called with 3 args; passing empty string emits trailing-comma JSON breaking jq consumers. Fixed with ${4:-} and conditional metadata field emission.

Changes live in ~/.claud-bb/skills/autoship/lib/ (outside this repo). This PR carries the changelog entry.

## Test plan

- [x] bash ~/.claud-bb/skills/autoship/tests/test-save-point-empty-dir.sh -- green
- [x] bash ~/.claud-bb/skills/autoship/tests/test-checkpoint-metadata.sh -- green
- [x] All 8 existing autoship tests -- green, zero regressions